### PR TITLE
gm: reduce Bolt 3D1 spoof flicker from transient phase misses

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -40,6 +40,7 @@ ECM_CRUISE_STALE_NS     = 300_000_000  # reset lock if no new stock edge arrives
 ECM_CRUISE_PERIOD_NS    = 100_000_000  # 10Hz spoof cadence aligned to stock cycle
 ECM_CRUISE_ANCHOR_TICKS = 4            # AcceleratorPedal2 (~40Hz) ticks per 3D1 cycle
 ECM_CRUISE_ANCHOR_HITS  = 6            # require repeated agreement before using anchor
+ECM_CRUISE_PHASE_MISS_TOLERANCE = 2    # ignore occasional single-tick phase misses before relocking
 ECM_CRUISE_ANCHOR_GAP_NS = 80_000_000  # min gap for anchor sends (~10Hz target)
 ECM_CRUISE_RETRY_NS     = 12_000_000   # one extra retry shortly after each stock edge
 # Constants for pitch compensation
@@ -114,6 +115,7 @@ class CarController(CarControllerBase):
     self.ecm_anchor_tick_mod = 0
     self.ecm_anchor_phase_mod = -1
     self.ecm_anchor_phase_hits = 0
+    self.ecm_anchor_phase_misses = 0
 
   def calc_pedal_command(self, accel: float, long_active: bool, car_velocity) -> Tuple[float, bool]:
     if not long_active:
@@ -414,16 +416,25 @@ class CarController(CarControllerBase):
           self.last_ecm_cruise_stock_ts_ns = stock_ts_ns
           if self.ecm_anchor_tick_mod == self.ecm_anchor_phase_mod:
             self.ecm_anchor_phase_hits += 1
+            self.ecm_anchor_phase_misses = 0
           else:
-            self.ecm_anchor_phase_mod = self.ecm_anchor_tick_mod
-            self.ecm_anchor_phase_hits = 1
+            self.ecm_anchor_phase_misses += 1
+            if self.ecm_anchor_phase_misses >= ECM_CRUISE_PHASE_MISS_TOLERANCE:
+              self.ecm_anchor_phase_mod = self.ecm_anchor_tick_mod
+              self.ecm_anchor_phase_hits = 1
+              self.ecm_anchor_phase_misses = 0
 
           if not sent_ecm_this_frame:
             can_sends.append(gmcan.create_ecm_cruise_control_command(
               self.packer_pt, CanBus.POWERTRAIN, spoof_enabled, spoof_set_speed_kph))
             self.last_ecm_cruise_spoof_ts_ns = now_nanos
             sent_ecm_this_frame = True
-          self.ecm_cruise_retry_ts_ns = now_nanos + ECM_CRUISE_RETRY_NS
+
+          # Retries help during startup/unlock, but can add jitter when phase lock is stable.
+          if self.ecm_anchor_phase_hits < ECM_CRUISE_ANCHOR_HITS:
+            self.ecm_cruise_retry_ts_ns = now_nanos + ECM_CRUISE_RETRY_NS
+          else:
+            self.ecm_cruise_retry_ts_ns = 0
 
         if self.ecm_cruise_retry_ts_ns > 0 and now_nanos >= self.ecm_cruise_retry_ts_ns and (now_nanos - self.last_ecm_cruise_spoof_ts_ns) >= 5_000_000:
           can_sends.append(gmcan.create_ecm_cruise_control_command(
@@ -434,6 +445,7 @@ class CarController(CarControllerBase):
         if self.last_ecm_cruise_stock_ts_ns > 0 and (now_nanos - self.last_ecm_cruise_stock_ts_ns) > ECM_CRUISE_STALE_NS:
           self.last_ecm_cruise_stock_ts_ns = 0
           self.ecm_anchor_phase_hits = 0
+          self.ecm_anchor_phase_misses = 0
           self.ecm_cruise_retry_ts_ns = 0
 
         if self.last_ecm_cruise_stock_ts_ns == 0 and self.ecm_anchor_phase_hits < ECM_CRUISE_ANCHOR_HITS and self.frame % 10 == 0:


### PR DESCRIPTION
### Motivation
- The Bolt ECM 3D1 spoof can briefly lose phase alignment due to occasional loop jitter or single-tick timestamp irregularities, causing short flicker windows after startup despite generally-good initial sync. 
- The goal is to preserve the strong startup lock behavior while avoiding thrash from one-off misses and unnecessary retry traffic once locked.

### Description
- Add `ECM_CRUISE_PHASE_MISS_TOLERANCE` and track `ecm_anchor_phase_misses` to ignore single transient phase mismatches before switching anchor phase. 
- Only switch `ecm_anchor_phase_mod` after repeated mismatches (`>= ECM_CRUISE_PHASE_MISS_TOLERANCE`) instead of on the first differing edge. 
- Reset `ecm_anchor_phase_misses` when a matching phase is observed or when the lock goes stale. 
- Make the ECM retry scheduling conditional: schedule short retry sends while the anchor is still being acquired, and disable retries once the anchor is considered locked to reduce jitter.

### Testing
- Ran `python3 -m py_compile selfdrive/car/gm/carcontroller.py` and it succeeded. 
- A `python -m py_compile` attempt using the environment `pyenv` default failed due to a missing local Python version (environment issue), not a syntax error. 
- Changes were staged and committed locally with the branch commit message `gm: harden Bolt 3D1 phase lock against jitter`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c1681cc0832297e6af316370d1a9)