### PR TITLE
panda gm: schedule 0x3D1 spoof from cached openpilot frame

### DIFF
--- a/panda/board/safety/safety_gm.h
+++ b/panda/board/safety/safety_gm.h
@@ -89,9 +89,6 @@ const uint16_t GM_PARAM_REMOTE_START_BOOTS_COMMA = 8192;
 const uint16_t GM_PARAM_PANDA_3D1_SCHED = 16384;
 
 const uint32_t GM_3D1_PERIOD_US = 100000U;
-const uint32_t GM_3D1_TX_OFFSET_US = 0U;
-const uint32_t GM_3D1_LOCK_TOLERANCE_US = 20000U;
-
 void can_send(CANPacket_t *to_push, uint8_t bus_number, bool skip_tx_hook);
 
 enum {
@@ -124,8 +121,6 @@ bool gm_3d1_spoof_valid = false;
 bool gm_3d1_internal_tx = false;
 uint8_t gm_3d1_spoof_data[8] = {0U};
 uint32_t gm_3d1_next_tx_us = 0U;
-uint32_t gm_3d1_expected_stock_us = 0U;
-bool gm_3d1_phase_locked = false;
 
 static void gm_try_send_3d1_spoof(uint32_t now_us) {
   if (!(gm_panda_3d1_sched && gm_3d1_spoof_valid && (gm_3d1_next_tx_us != 0U))) {
@@ -227,7 +222,6 @@ static void gm_rx_hook(const CANPacket_t *to_push) {
 
     // Cruise check for CC only cars
     if ((addr == 0x3D1) && !gm_has_acc) {
-      uint32_t now_us = microsecond_timer_get();
       bool cruise_engaged = (GET_BYTE(to_push, 4) >> 7) != 0U;
       if (gm_cc_long) {
         pcm_cruise_check(cruise_engaged);
@@ -235,26 +229,6 @@ static void gm_rx_hook(const CANPacket_t *to_push) {
         cruise_engaged_prev = cruise_engaged;
       }
 
-      if (gm_panda_3d1_sched) {
-        if (!gm_3d1_phase_locked) {
-          gm_3d1_phase_locked = true;
-          gm_3d1_expected_stock_us = now_us + GM_3D1_PERIOD_US;
-        } else {
-          int32_t phase_err_us = (int32_t)(now_us - gm_3d1_expected_stock_us);
-          if (phase_err_us < 0) {
-            phase_err_us = -phase_err_us;
-          }
-
-          if ((uint32_t)phase_err_us <= GM_3D1_LOCK_TOLERANCE_US) {
-            gm_3d1_expected_stock_us += GM_3D1_PERIOD_US;
-          } else {
-            gm_3d1_expected_stock_us = now_us + GM_3D1_PERIOD_US;
-          }
-        }
-
-        gm_3d1_next_tx_us = now_us + GM_3D1_TX_OFFSET_US;
-        gm_try_send_3d1_spoof(now_us);
-      }
     }
 
     if (addr == 0xBD) {
@@ -368,6 +342,13 @@ static bool gm_tx_hook(const CANPacket_t *to_send) {
       } else {
         (void)memcpy(gm_3d1_spoof_data, to_send->data, 8U);
         gm_3d1_spoof_valid = true;
+
+        uint32_t now_us = microsecond_timer_get();
+        if (gm_3d1_next_tx_us == 0U) {
+          gm_3d1_next_tx_us = now_us;
+        }
+        gm_try_send_3d1_spoof(now_us);
+
         tx = false;
       }
     }
@@ -469,8 +450,6 @@ static safety_config gm_init(uint16_t param) {
   gm_3d1_spoof_valid = false;
   gm_3d1_internal_tx = false;
   gm_3d1_next_tx_us = 0U;
-  gm_3d1_expected_stock_us = 0U;
-  gm_3d1_phase_locked = false;
 
   safety_config ret = BUILD_SAFETY_CFG(gm_rx_checks, GM_ASCM_TX_MSGS);
   if (gm_hw == GM_CAM) {

--- a/selfdrive/car/gm/gmcan.py
+++ b/selfdrive/car/gm/gmcan.py
@@ -188,10 +188,8 @@ def create_acc_dashboard_command(packer, bus, enabled, target_speed_kph, hud_con
 def create_ecm_cruise_control_command(packer, bus, enabled, target_speed_kph):
   dat = bytearray(8)
   dat[0] = 0x01
-  # Match observed stock shape on non-ACC CC paths: byte4 is usually 0x00
-  # (with occasional 0x80 from stock state transitions). Keep this spoofed
-  # path at 0x00 to avoid plausibility mismatch on non-speed bits.
-  dat[4] = 0x00
+  # Mirror stock engage semantics: bit7 carries cruise active state.
+  dat[4] = 0x80 if enabled else 0x00
 
   set_speed_raw = 0
   if enabled:


### PR DESCRIPTION
### Motivation
- Fix GM panda-side `0x3D1` spoofing that could fail to transmit when the panda relied on phase-locking to stock `0x3D1` traffic. 
- Ensure openpilot-sent `0x3D1` frames are honored and replayed at the expected cadence for non-ACC CC-only / pedal-long paths.

### Description
- In `panda/board/safety/safety_gm.h`, remove the unused stock-lock state and constants and stop depending on stock `0x3D1` timing to arm the scheduler. 
- Cache the openpilot `0x3D1` payload in the TX hook, mark spoof valid, initialize `gm_3d1_next_tx_us` if unset, and call `gm_try_send_3d1_spoof(now_us)` to attempt an immediate internal transmit. 
- Keep the periodic retransmit behavior via `gm_try_send_3d1_spoof` using the existing `GM_3D1_PERIOD_US` cadence driven from `rx_hook`. 
- In `selfdrive/car/gm/gmcan.py`, mirror stock semantics by setting byte 4 bit7 for cruise active in `create_ecm_cruise_control_command` (`dat[4] = 0x80` when enabled, `0x00` otherwise). 

### Testing
- Ran `PYENV_VERSION=3.11.14 pytest -q panda/tests/safety/test_gm.py -k Interceptor --maxfail=1` which failed due to the test config expecting xdist (`-n`) support not present in the environment. 
- Ran `PYENV_VERSION=3.11.14 pytest -q panda/tests/safety/test_gm.py -k Interceptor --maxfail=1 -o addopts=''` which failed during collection with `ModuleNotFoundError: No module named 'usb1'` in this environment. 
- No environment-capable automated test validated the on-hardware spoof behavior here, so runtime verification on a device or in an environment with `usb1` and proper pytest config is still recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0dc4ab9c83228501e51e669aaaca)