### PR TITLE
gm safety: kick off panda-side 0x3D1 spoof scheduling immediately

### DIFF
--- a/panda/board/safety/safety_gm.h
+++ b/panda/board/safety/safety_gm.h
@@ -366,8 +366,13 @@ static bool gm_tx_hook(const CANPacket_t *to_send) {
       if (gm_3d1_internal_tx) {
         tx = true;
       } else {
+        uint32_t now_us = microsecond_timer_get();
         (void)memcpy(gm_3d1_spoof_data, to_send->data, 8U);
         gm_3d1_spoof_valid = true;
+        if (gm_3d1_next_tx_us == 0U) {
+          gm_3d1_next_tx_us = now_us + GM_3D1_TX_OFFSET_US;
+        }
+        gm_try_send_3d1_spoof(now_us);
         tx = false;
       }
     }


### PR DESCRIPTION
### Motivation
- Allow the panda to begin transmitting spoofed `0x3D1` cruise/status frames when openpilot sends them, instead of waiting for a stock `0x3D1` phase-lock event which could leave spoofed payloads cached but never emitted.

### Description
- In `panda/board/safety/safety_gm.h` `gm_tx_hook`, capture `now_us = microsecond_timer_get()` when caching a spoofed `0x3D1` payload, initialize `gm_3d1_next_tx_us` if it is `0`, and immediately call `gm_try_send_3d1_spoof(now_us)` so the panda scheduler starts transmitting right away.
- This preserves the existing scheduler logic and periodic transmit (`GM_3D1_PERIOD_US`) while preventing the dead state where `gm_3d1_spoof_valid` is true but `gm_3d1_next_tx_us` was never set.

### Testing
- Attempted to run `python -m pytest panda/tests/safety -k gm -q`, but the environment could not run tests due to pyenv version mismatch and missing `pytest` (no tests executed).
- Attempted `python3 -m pytest panda/tests/safety/test_gm.py -q`, but `pytest` is not installed in this environment (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a119864448322b93ad2a0dd1eea5e)