### PR TITLE
gm: restore panda-side 0x3D1 spoof seeding for pedal-long CC cars

### DIFF
--- a/selfdrive/car/gm/carcontroller.py
+++ b/selfdrive/car/gm/carcontroller.py
@@ -368,20 +368,20 @@ class CarController(CarControllerBase):
       if now_nanos - self.last_steer_ts_ns >= flush_gap_ns:
         can_sends.extend(paddle_sends)
 
+    spoof_ecm_cruise_cars = {
+      CAR.CHEVROLET_BOLT_CC_2017,
+      CAR.CHEVROLET_BOLT_CC_2019_2021,
+      CAR.CHEVROLET_BOLT_CC_2022_2023,
+      CAR.CHEVROLET_MALIBU_HYBRID_CC,
+    }
+    non_acc_pedal_long = (self.CP.flags & GMFlags.PEDAL_LONG.value) and self.CP.carFingerprint in spoof_ecm_cruise_cars and self.CP.enableGasInterceptor
+    if non_acc_pedal_long and self.frame % 4 == 0:
+      spoof_enabled = bool(CC.enabled)
+      spoof_set_speed_kph = hud_v_cruise * CV.MS_TO_KPH if spoof_enabled else 0.0
+      can_sends.append(gmcan.create_ecm_cruise_control_command(
+        self.packer_pt, CanBus.POWERTRAIN, spoof_enabled, spoof_set_speed_kph))
+
     if self.CP.openpilotLongitudinalControl:
-      spoof_ecm_cruise_cars = {
-        CAR.CHEVROLET_BOLT_CC_2017,
-        CAR.CHEVROLET_BOLT_CC_2019_2021,
-        CAR.CHEVROLET_BOLT_CC_2022_2023,
-        CAR.CHEVROLET_MALIBU_HYBRID_CC,
-      }
-      non_acc_pedal_long = (self.CP.flags & GMFlags.PEDAL_LONG.value) and self.CP.carFingerprint in spoof_ecm_cruise_cars and self.CP.enableGasInterceptor
-      if non_acc_pedal_long:
-        if self.frame % 4 == 0:
-          spoof_enabled = bool(CC.enabled)
-          spoof_set_speed_kph = hud_v_cruise * CV.MS_TO_KPH if spoof_enabled else 0.0
-          can_sends.append(gmcan.create_ecm_cruise_control_command(
-            self.packer_pt, CanBus.POWERTRAIN, spoof_enabled, spoof_set_speed_kph))
 
       # Gas/regen, brakes, and UI commands - all at 25Hz
       if self.frame % 4 == 0:


### PR DESCRIPTION
### Motivation
- Panda never saw any 0x3D1 spoof source for certain non-ACC pedal-long CC cars because the creation of the ECM cruise spoof command was gated by `openpilotLongitudinalControl`, so the panda-side scheduler had nothing to latch and send.

### Description
- Move creation of the GM ECM cruise control spoof command out of the `self.CP.openpilotLongitudinalControl` gate so the spoof payload (enabled speed when engaged, 0 when disengaged) is always appended for supported non-ACC pedal-long cars at 25Hz when applicable, implemented in `selfdrive/car/gm/carcontroller.py`.

### Testing
- `PYENV_VERSION=3.11.14 python -m py_compile selfdrive/car/gm/carcontroller.py` succeeded.
- Running `pytest` on `panda/tests/safety/test_gm.py -k InterceptorSafety` in this environment failed test collection due to a missing `usb1` dependency (environment issue), not due to the code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a135441a08322a80fcd0e079b1408)