### PR TITLE
gm: re-allow 0x3D1 transmission for CC-long panda scheduling

### DIFF
--- a/panda/board/safety/safety_gm.h
+++ b/panda/board/safety/safety_gm.h
@@ -57,7 +57,7 @@ const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4}, {0x315, 0, 5}, {0x2CB, 0, 8
 const CanMsg GM_SDGM_TX_MSGS[] = {{0x180, 0, 4}, {0x1E1, 0, 7}, {0xBD, 0, 7}, {0x1F5, 0, 8}, // pt bus
                                   {0x184, 2, 8}};  // camera bus
 
-const CanMsg GM_CC_LONG_TX_MSGS[] = {{0x180, 0, 4}, {0x370, 0, 6}, {0x1E1, 0, 7}, {0xBD, 0, 7}, {0x1F5, 0, 8},  // pt bus
+const CanMsg GM_CC_LONG_TX_MSGS[] = {{0x180, 0, 4}, {0x370, 0, 6}, {0x1E1, 0, 7}, {0x3D1, 0, 8}, {0xBD, 0, 7}, {0x1F5, 0, 8},  // pt bus
                                      {0x184, 2, 8}, {0x1E1, 2, 7}};  // camera bus
 
 // TODO: do checksum and counter checks. Add correct timestep, 0.1s for now.

--- a/panda/tests/safety/test_gm.py
+++ b/panda/tests/safety/test_gm.py
@@ -386,7 +386,7 @@ class TestGmInterceptorSafety(common.GasInterceptorSafetyTest, TestGmCameraSafet
 
 
 class TestGmCcLongitudinalSafety(TestGmCameraSafety):
-  TX_MSGS = [[384, 0], [481, 0], [0x1F5, 0], [388, 2]]
+  TX_MSGS = [[384, 0], [481, 0], [0x3D1, 0], [0x1F5, 0], [388, 2]]
   FWD_BLACKLISTED_ADDRS = {2: [384], 0: [388]}  # block LKAS message and PSCMStatus
   BUTTONS_BUS = 0  # tx only
 


### PR DESCRIPTION
### Motivation
- Panda-side scheduled spoofing of the GM cruise-status frame (0x3D1) never transmitted for CC-long camera configs because the CC-long TX allowlist did not include 0x3D1, causing panda safety to block the frame.
- The change restores the ability for panda to send spoofed cruise-status frames when panda-side scheduling is enabled for CC-only / CC-long paths.

### Description
- Added CAN ID `0x3D1` to `GM_CC_LONG_TX_MSGS` in `panda/board/safety/safety_gm.h` so CC-long safety configs allow transmitting cruise-status frames on bus 0.
- Updated the test expectation in `panda/tests/safety/test_gm.py` (`TestGmCcLongitudinalSafety.TX_MSGS`) to include `0x3D1` on bus 0 so the unit test matches the new allowlist.

### Testing
- Ran `python3 -m compileall panda/tests/safety/test_gm.py`, which succeeded and confirmed the test file is valid Python bytecode.
- Attempted to run the specific test with `pytest` but could not execute the suite because the environment is missing `pytest` and the `python` binary is pinned to a non-installed `pyenv` version, so the full pytest run could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a1456634083229e8e4519a6ff0c69)