### PR TITLE
Restore minimum lead-tracking buffer to fix chill-mode lead stopping

### DIFF
--- a/starpilot/controls/starpilot_planner.py
+++ b/starpilot/controls/starpilot_planner.py
@@ -130,8 +130,12 @@ class StarPilotPlanner:
       self.starpilot_weather.weather_id = 0
 
   def update_lead_status(self, stop_distance=STOP_DISTANCE):
+    # Keep a minimum lead-tracking cushion independent of user stop-distance tuning.
+    # Regressions here can cause ACC/chill to de-prioritize lead control at low speeds.
+    tracking_buffer = max(float(stop_distance), 4.0)
+
     following_lead = self.lead_one.status
-    following_lead &= self.lead_one.dRel < self.model_length + float(stop_distance)
+    following_lead &= self.lead_one.dRel < self.model_length + tracking_buffer
 
     self.tracking_lead_filter.update(following_lead)
     return self.tracking_lead_filter.x >= THRESHOLD


### PR DESCRIPTION
### Motivation
- A recent change removed the minimum lead-tracking cushion and relied solely on `stop_distance`, which can become too small when tuned and let `trackingLead` drop out so chill/ACC no longer prioritizes stopping for lead vehicles.

### Description
- Reintroduce a minimum tracking buffer by using `tracking_buffer = max(float(stop_distance), 4.0)` in `StarPilotPlanner.update_lead_status` (`starpilot/controls/starpilot_planner.py`) and add a short comment explaining why the guard is required.

### Testing
- Compiled the modified file with `python -m py_compile starpilot/controls/starpilot_planner.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9ac1d2388329ad7cffd42862f480)