### PR TITLE
Handle missing custom cruise intervals safely

### DIFF
--- a/selfdrive/car/cruise.py
+++ b/selfdrive/car/cruise.py
@@ -44,7 +44,11 @@ class VCruiseHelper:
 
   def _get_short_press_delta(self, is_metric, starpilot_toggles: SimpleNamespace) -> float:
     base_delta = 1. if is_metric else IMPERIAL_INCREMENT
-    return base_delta * starpilot_toggles.cruise_increase
+    return base_delta * self._get_cruise_delta_interval(starpilot_toggles.cruise_increase)
+
+  @staticmethod
+  def _get_cruise_delta_interval(interval: float | None) -> float:
+    return interval if isinstance(interval, (int, float)) and interval > 0 else 1.0
 
   def _normalize_initialized_v_cruise(self, v_cruise_kph: float, starpilot_toggles: SimpleNamespace) -> float:
     if starpilot_toggles.cruise_increase % 5 != 0:
@@ -119,7 +123,8 @@ class VCruiseHelper:
     if not self.button_change_states[button_type]["enabled"]:
       return
 
-    v_cruise_delta_interval = starpilot_toggles.cruise_increase_long if long_press else starpilot_toggles.cruise_increase
+    delta_interval = starpilot_toggles.cruise_increase_long if long_press else starpilot_toggles.cruise_increase
+    v_cruise_delta_interval = self._get_cruise_delta_interval(delta_interval)
     v_cruise_delta = v_cruise_delta * v_cruise_delta_interval
     if v_cruise_delta_interval % 5 == 0 and self.v_cruise_kph % v_cruise_delta != 0:  # partial interval
       self.v_cruise_kph = CRUISE_NEAREST_FUNC[button_type](self.v_cruise_kph / v_cruise_delta) * v_cruise_delta

--- a/selfdrive/car/tests/test_cruise_speed.py
+++ b/selfdrive/car/tests/test_cruise_speed.py
@@ -232,3 +232,31 @@ class TestVCruiseHelper:
     )
 
     assert self.v_cruise_helper.v_cruise_kph == initial_v_cruise_kph
+
+  def test_missing_custom_cruise_toggles_fall_back_to_single_step(self):
+    self.enable(V_CRUISE_INITIAL * CV.KPH_TO_MS, False)
+    initial_v_cruise_kph = self.v_cruise_helper.v_cruise_kph
+    self.starpilot_toggles.cruise_increase = None
+    self.starpilot_toggles.cruise_increase_long = None
+
+    pressed_cs = car.CarState(cruiseState={"available": True})
+    pressed_cs.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=True)]
+    self.v_cruise_helper.update_v_cruise(
+      pressed_cs,
+      enabled=True,
+      is_metric=False,
+      speed_limit_changed=False,
+      starpilot_toggles=self.starpilot_toggles,
+    )
+
+    released_cs = car.CarState(cruiseState={"available": True})
+    released_cs.buttonEvents = [ButtonEvent(type=ButtonType.accelCruise, pressed=False)]
+    self.v_cruise_helper.update_v_cruise(
+      released_cs,
+      enabled=True,
+      is_metric=False,
+      speed_limit_changed=False,
+      starpilot_toggles=self.starpilot_toggles,
+    )
+
+    assert self.v_cruise_helper.v_cruise_kph == pytest.approx(initial_v_cruise_kph + IMPERIAL_INCREMENT)


### PR DESCRIPTION
### Motivation
- Some StarPilot toggle values like `cruise_increase` and `cruise_increase_long` can be missing or non-numeric for certain ports/vehicles, which can cause errors when computing cruise speed deltas. 
- Provide a safe fallback so set-speed button behavior still works and defaults to single-step increments when custom intervals are not available.

### Description
- Add a static helper ` _get_cruise_delta_interval(interval)` that returns the numeric positive interval or `1.0` as a safe default. 
- Use the helper from `_get_short_press_delta` and in the long/short press interval selection in `_update_v_cruise_non_pcm` so both short- and long-press paths are guarded. 
- Add a regression test `test_missing_custom_cruise_toggles_fall_back_to_single_step` to verify `None` values for `cruise_increase` and `cruise_increase_long` fall back to a single imperial step.

### Testing
- `python -m py_compile selfdrive/car/cruise.py selfdrive/car/tests/test_cruise_speed.py` completed successfully. 
- `pytest -q selfdrive/car/tests/test_cruise_speed.py -k 'missing_custom_cruise_toggles_fall_back_to_single_step or speed_limit_confirmation_does_not_adjust_cruise'` could not run to completion in this environment due to a missing compiled dependency (`openpilot/common/params_pyx.so`). 
- The new test was added and is expected to pass when the test environment includes the project native extensions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf012bc08c832986075fccc2ef1359)