### PR TITLE
AOL: keep lateral active when braking disengages longitudinal on full OP for HKG with LKAS

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/values.py
+++ b/opendbc_repo/opendbc/car/hyundai/values.py
@@ -70,6 +70,7 @@ class HyundaiSafetyFlags(IntFlag):
 
 class HyundaiStarPilotSafetyFlags(IntFlag):
   HAS_LDA_BUTTON = 1024
+  AOL_LKAS_ON_ENGAGE = 2048
 
 
 class HyundaiFlags(IntFlag):

--- a/opendbc_repo/opendbc/car/interfaces.py
+++ b/opendbc_repo/opendbc/car/interfaces.py
@@ -218,6 +218,8 @@ class CarInterfaceBase(ABC):
 
         if CP.flags & HyundaiFlags.HAS_LDA_BUTTON:
           fp_ret.safetyConfigs[-1].safetyParam |= HyundaiStarPilotSafetyFlags.HAS_LDA_BUTTON.value
+        if CP.openpilotLongitudinalControl and starpilot_toggles.always_on_lateral_lkas:
+          fp_ret.safetyConfigs[-1].safetyParam |= HyundaiStarPilotSafetyFlags.AOL_LKAS_ON_ENGAGE.value
 
       elif platform in TOYOTA:
         fp_ret.canUsePedal = not CP.autoResumeSng

--- a/opendbc_repo/opendbc/safety/modes/hyundai_common.h
+++ b/opendbc_repo/opendbc/safety/modes/hyundai_common.h
@@ -45,6 +45,9 @@ bool hyundai_alt_limits_2 = false;
 extern bool hyundai_has_lda_button;
 bool hyundai_has_lda_button = false;
 
+extern bool hyundai_aol_lkas_on_engage;
+bool hyundai_aol_lkas_on_engage = false;
+
 static uint8_t hyundai_last_button_interaction;  // button messages since the user pressed an enable button
 
 void hyundai_common_init(uint16_t param) {
@@ -57,6 +60,7 @@ void hyundai_common_init(uint16_t param) {
   const uint16_t HYUNDAI_PARAM_ALT_LIMITS_2 = 512;
 
   const int HYUNDAI_PARAM_HAS_LDA_BUTTON = 1024;
+  const uint16_t HYUNDAI_PARAM_AOL_LKAS_ON_ENGAGE = 2048;
 
   hyundai_ev_gas_signal = GET_FLAG(param, HYUNDAI_PARAM_EV_GAS);
   hyundai_hybrid_gas_signal = !hyundai_ev_gas_signal && GET_FLAG(param, HYUNDAI_PARAM_HYBRID_GAS);
@@ -67,6 +71,7 @@ void hyundai_common_init(uint16_t param) {
   hyundai_alt_limits_2 = GET_FLAG(param, HYUNDAI_PARAM_ALT_LIMITS_2);
 
   hyundai_has_lda_button = GET_FLAG(param, HYUNDAI_PARAM_HAS_LDA_BUTTON);
+  hyundai_aol_lkas_on_engage = GET_FLAG(param, HYUNDAI_PARAM_AOL_LKAS_ON_ENGAGE);
 
   hyundai_last_button_interaction = HYUNDAI_PREV_BUTTON_SAMPLES;
 
@@ -108,6 +113,10 @@ void hyundai_common_cruise_buttons_check(const int cruise_button, const bool mai
     bool res = (cruise_button != HYUNDAI_BTN_RESUME) && (cruise_button_prev == HYUNDAI_BTN_RESUME);
     if (set || res) {
       controls_allowed = true;
+
+      if (hyundai_aol_lkas_on_engage && ((alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL) != 0)) {
+        lkas_on = true;
+      }
     }
 
     // exit controls on cancel press

--- a/opendbc_repo/opendbc/safety/safety.h
+++ b/opendbc_repo/opendbc/safety/safety.h
@@ -374,7 +374,7 @@ static void generic_rx_checks(void) {
   }
   steering_disengage_prev = steering_disengage;
 
-  aol_allowed = (acc_main_on || lkas_on) && (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL);
+  aol_allowed = (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL) != 0U;
 }
 
 static void stock_ecu_check(bool stock_ecu_detected) {

--- a/opendbc_repo/opendbc/safety/safety.h
+++ b/opendbc_repo/opendbc/safety/safety.h
@@ -374,7 +374,7 @@ static void generic_rx_checks(void) {
   }
   steering_disengage_prev = steering_disengage;
 
-  aol_allowed = (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL) != 0U;
+  aol_allowed = (acc_main_on || lkas_on) && (alternative_experience & ALT_EXP_ALWAYS_ON_LATERAL);
 }
 
 static void stock_ecu_check(bool stock_ecu_detected) {

--- a/opendbc_repo/opendbc/safety/tests/hyundai_common.py
+++ b/opendbc_repo/opendbc/safety/tests/hyundai_common.py
@@ -1,5 +1,6 @@
 import unittest
 
+from opendbc.safety import ALTERNATIVE_EXPERIENCE
 import opendbc.safety.tests.common as common
 from opendbc.safety.tests.libsafety import libsafety_py
 from opendbc.safety.tests.common import make_msg
@@ -171,3 +172,22 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
     self.assertFalse(self.safety.get_relay_malfunction())
     self._rx(make_msg(bus, addr, 8))
     self.assertTrue(self.safety.get_relay_malfunction())
+
+
+class HyundaiAolLkasOnEngageBase:
+  def test_aol_lkas_auto_enables_on_set_engagement(self):
+    torque_cmd = self.MAX_RATE_UP
+
+    self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.ALWAYS_ON_LATERAL)
+    self.safety.set_controls_allowed(False)
+
+    self._set_prev_torque(0)
+    self.assertFalse(self._tx(self._torque_cmd_msg(torque_cmd)))
+
+    self._rx(self._button_msg(Buttons.SET))
+    self._rx(self._button_msg(Buttons.NONE))
+    self.assertTrue(self.safety.get_controls_allowed())
+
+    self.safety.set_controls_allowed(False)
+    self._set_prev_torque(0)
+    self.assertTrue(self._tx(self._torque_cmd_msg(torque_cmd)))

--- a/opendbc_repo/opendbc/safety/tests/test_hyundai.py
+++ b/opendbc_repo/opendbc/safety/tests/test_hyundai.py
@@ -2,12 +2,12 @@
 import random
 import unittest
 
-from opendbc.car.hyundai.values import HyundaiSafetyFlags
+from opendbc.car.hyundai.values import HyundaiSafetyFlags, HyundaiStarPilotSafetyFlags
 from opendbc.car.structs import CarParams
 from opendbc.safety.tests.libsafety import libsafety_py
 import opendbc.safety.tests.common as common
 from opendbc.safety.tests.common import CANPackerSafety
-from opendbc.safety.tests.hyundai_common import HyundaiButtonBase, HyundaiLongitudinalBase
+from opendbc.safety.tests.hyundai_common import HyundaiAolLkasOnEngageBase, HyundaiButtonBase, HyundaiLongitudinalBase
 
 
 # 4 bit checkusm used in some hyundai messages
@@ -276,6 +276,15 @@ class TestHyundaiSafetyFCEVLong(TestHyundaiLongitudinalSafety, TestHyundaiSafety
     self.packer = CANPackerSafety("hyundai_kia_generic")
     self.safety = libsafety_py.libsafety
     self.safety.set_safety_hooks(CarParams.SafetyModel.hyundai, HyundaiSafetyFlags.FCEV_GAS | HyundaiSafetyFlags.LONG)
+    self.safety.init_tests()
+
+
+class TestHyundaiLongitudinalAolLkasOnEngageSafety(HyundaiAolLkasOnEngageBase, TestHyundaiLongitudinalSafety):
+  def setUp(self):
+    self.packer = CANPackerSafety("hyundai_kia_generic")
+    self.safety = libsafety_py.libsafety
+    self.safety.set_safety_hooks(CarParams.SafetyModel.hyundai,
+                                 HyundaiSafetyFlags.LONG | HyundaiStarPilotSafetyFlags.AOL_LKAS_ON_ENGAGE)
     self.safety.init_tests()
 
 

--- a/opendbc_repo/opendbc/safety/tests/test_hyundai_canfd.py
+++ b/opendbc_repo/opendbc/safety/tests/test_hyundai_canfd.py
@@ -2,12 +2,12 @@
 from parameterized import parameterized_class
 import unittest
 
-from opendbc.car.hyundai.values import HyundaiSafetyFlags
+from opendbc.car.hyundai.values import HyundaiSafetyFlags, HyundaiStarPilotSafetyFlags
 from opendbc.car.structs import CarParams
 from opendbc.safety.tests.libsafety import libsafety_py
 import opendbc.safety.tests.common as common
 from opendbc.safety.tests.common import CANPackerSafety
-from opendbc.safety.tests.hyundai_common import HyundaiButtonBase, HyundaiLongitudinalBase
+from opendbc.safety.tests.hyundai_common import HyundaiAolLkasOnEngageBase, HyundaiButtonBase, HyundaiLongitudinalBase
 
 # All combinations of radar/camera-SCC and gas/hybrid/EV cars
 ALL_GAS_EV_HYBRID_COMBOS = [
@@ -324,6 +324,18 @@ class TestHyundaiCanfdLFASteeringLongAltButtons(TestHyundaiCanfdLFASteeringLongB
   def test_acc_cancel(self):
     # Alt buttons does not use SCC_CONTROL to cancel if longitudinal
     pass
+
+
+class TestHyundaiCanfdLKASteeringLongAolLkasOnEngageEV(HyundaiAolLkasOnEngageBase, TestHyundaiCanfdLKASteeringLongEV):
+  def setUp(self):
+    self.packer = CANPackerSafety("hyundai_canfd_generated")
+    self.safety = libsafety_py.libsafety
+    self.safety.set_safety_hooks(CarParams.SafetyModel.hyundaiCanfd,
+                                 HyundaiSafetyFlags.CANFD_LKA_STEERING |
+                                 HyundaiSafetyFlags.LONG |
+                                 HyundaiSafetyFlags.EV_GAS |
+                                 HyundaiStarPilotSafetyFlags.AOL_LKAS_ON_ENGAGE)
+    self.safety.init_tests()
 
 
 

--- a/starpilot/controls/starpilot_card.py
+++ b/starpilot/controls/starpilot_card.py
@@ -17,6 +17,7 @@ class StarPilotCard:
 
     self.accel_pressed = False
     self.always_on_lateral_allowed = False
+    self.prev_active = False
     self.decel_pressed = False
     self.distancePressed_previously = False
     self.force_coast = False
@@ -77,6 +78,13 @@ class StarPilotCard:
           self.always_on_lateral_allowed = not self.always_on_lateral_allowed
     elif starpilot_toggles.always_on_lateral_main:
       self.always_on_lateral_allowed = carState.cruiseState.available
+
+    # On rising edge of engagement (SET press enabling lat+long), auto-enable AOL
+    # so that lateral persists when braking disengages longitudinal
+    if sm["selfdriveState"].active and not self.prev_active and self.always_on_lateral_set and starpilot_toggles.always_on_lateral_lkas:
+      self.always_on_lateral_allowed = True
+
+    self.prev_active = sm["selfdriveState"].active
 
     self.always_on_lateral_enabled = self.always_on_lateral_allowed and self.always_on_lateral_set
     self.always_on_lateral_enabled &= carState.gearShifter not in NON_DRIVING_GEARS


### PR DESCRIPTION
Replacement for #51, scoped so GM behavior does not regress.

Changes:
- keep the SET-edge AOL enable in StarPilotCard for Hyundai LKAS mode
- restore the global panda AOL gate so GM still requires ACC main or LKAS state
- add a Hyundai-only StarPilot safety flag that latches LKAS-side AOL on SET/RES engagement only for Hyundai full openpilot longitudinal + LKAS AOL mode
- add focused Hyundai safety tests for the new latch path

Focused verification run locally:
- `uv run --extra testing pytest opendbc/safety/tests/test_gm.py -q -n0 -k always_on_lateral`
- `uv run --extra testing pytest opendbc/safety/tests/test_hyundai.py -q -n0 -k "always_on_lateral or aol_lkas_auto_enables_on_set_engagement"`
- `uv run --extra testing pytest opendbc/safety/tests/test_hyundai_canfd.py -q -n0 -k "always_on_lateral or aol_lkas_auto_enables_on_set_engagement"`