### PR TITLE
Fix several issues with the settings layout in galaxy

### DIFF
--- a/starpilot/system/the_pond/assets/components/tools/device_settings.js
+++ b/starpilot/system/the_pond/assets/components/tools/device_settings.js
@@ -43,6 +43,18 @@ function getSectionsWithSlug() {
   }))
 }
 
+function isGroupParam(param) {
+  return param?.ui_type === "group"
+}
+
+function isParamEnabledForChildren(paramOrKey) {
+  const param = typeof paramOrKey === "string" ? state.paramMetaByKey[paramOrKey] : paramOrKey
+  if (isGroupParam(param)) return true
+
+  const key = typeof paramOrKey === "string" ? paramOrKey : param?.key
+  return !!state.values[key]
+}
+
 function toSelectValue(value) {
   return value === null || value === undefined ? "" : String(value)
 }
@@ -715,12 +727,13 @@ function handleSectionTabClick(sectionSlug, event) {
 
 function renderSettingRow(p) {
   if (p.parent_key && !state.filter) {
-    if (!state.values[p.parent_key]) return ""
+    if (!isParamEnabledForChildren(p.parent_key)) return ""
     if (!state.expanded[p.parent_key]) return ""
   }
 
   const isNumeric = p.ui_type === "numeric"
   const isColor = p.ui_type === "color"
+  const isGroup = isGroupParam(p)
   const isChild = p.parent_key ? "ds-child-modifier" : ""
   const lockReason = getSettingLockReason(p)
   const isLocked = lockReason !== ""
@@ -733,7 +746,7 @@ function renderSettingRow(p) {
           ${p.description ? html`<div class="ds-row-desc">${p.description}</div>` : ""}
           ${lockReason ? html`<div class="ds-row-desc"><strong>Locked:</strong> ${lockReason}</div>` : ""}
 
-          ${() => p.is_parent_toggle && state.values[p.key] ? html`
+          ${() => p.is_parent_toggle && isParamEnabledForChildren(p) ? html`
             <div class="ds-manage-btn" @click="${() => toggleManage(p.key)}">
               ${state.expanded[p.key] ? "Close" : "Manage"}
               <i class="bi bi-chevron-${state.expanded[p.key] ? "up" : "down"}"></i>
@@ -829,7 +842,7 @@ function renderSettingRow(p) {
             ?disabled="${() => isLocked || isStockColorValue(state.values[p.key])}"
             @click="${() => resetColorParam(p)}">Stock</button>
         </div>
-      ` : html`
+      ` : isGroup ? "" : html`
         <input
           type="checkbox"
           class="ds-toggle"
@@ -853,7 +866,7 @@ function renderSettingTree(paramsList, parentKey = null) {
     if (row) rendered.push(row)
 
     if (!hasChildParams(paramsList, param.key)) continue
-    if (!state.values[param.key] || !state.expanded[param.key]) continue
+    if (!isParamEnabledForChildren(param) || !state.expanded[param.key]) continue
 
     rendered.push(...renderSettingTree(paramsList, param.key))
   }

--- a/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
+++ b/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
@@ -1087,15 +1087,14 @@
         "description": "Automatically adjust driving behavior based on real-time weather. Helps maintain comfort and safety in low visibility, rain, or snow.",
         "data_type": "bool",
         "ui_type": "toggle",
-        "is_parent_toggle": true
+        "is_parent_toggle": true,
         "parent_key": "QOLLongitudinal"
       },
       {
-        "key": "LowVisiblityWeather",
+        "key": "LowVisibilityOffsets",
         "label": "Low Visibility (fog)",
         "description": "Customise settings for driving in low visibility situations",
-        "data_type": "bool",
-        "ui_type": "toggle",
+        "ui_type": "group",
         "is_parent_toggle": true,
         "parent_key": "WeatherPresets"
       },
@@ -1108,7 +1107,7 @@
         "min": 0.0,
         "max": 3.0,
         "step": 0.01,
-        "parent_key": "LowVisiblityWeather"
+        "parent_key": "LowVisibilityOffsets"
       },
       {
         "key": "IncreasedStoppedDistanceLowVisibility",
@@ -1118,7 +1117,7 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 10.0,
-        "parent_key": "LowVisiblityWeather"
+        "parent_key": "LowVisibilityOffsets"
       },
       {
         "key": "ReduceAccelerationLowVisibility",
@@ -1129,7 +1128,7 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "LowVisiblityWeather"
+        "parent_key": "LowVisibilityOffsets"
       },
       {
         "key": "ReduceLateralAccelerationLowVisibility",
@@ -1140,14 +1139,13 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "LowVisiblityWeather"
+        "parent_key": "LowVisibilityOffsets"
       },
       {
-        "key": "RainWeather",
+        "key": "RainOffsets",
         "label": "Light/Medium Rain",
         "description": "Customise settings for driving in light & medium rain",
-        "data_type": "bool",
-        "ui_type": "toggle",
+        "ui_type": "group",
         "is_parent_toggle": true,
         "parent_key": "WeatherPresets"
       },
@@ -1160,7 +1158,7 @@
         "min": 0.0,
         "max": 3.0,
         "step": 0.01,
-        "parent_key": "RainWeather"
+        "parent_key": "RainOffsets"
       },
       {
         "key": "IncreasedStoppedDistanceRain",
@@ -1170,7 +1168,7 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 10.0,
-        "parent_key": "RainWeather"
+        "parent_key": "RainOffsets"
       },
       {
         "key": "ReduceAccelerationRain",
@@ -1181,7 +1179,7 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "RainWeather"
+        "parent_key": "RainOffsets"
       },
       {
         "key": "ReduceLateralAccelerationRain",
@@ -1192,14 +1190,13 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "RainWeather"
+        "parent_key": "RainOffsets"
       },
       {
-        "key": "HeavyRainWeather",
+        "key": "RainStormOffsets",
         "label": "Heavy Rain",
         "description": "Customise settings for driving in heavy rain",
-        "data_type": "bool",
-        "ui_type": "toggle",
+        "ui_type": "group",
         "is_parent_toggle": true,
         "parent_key": "WeatherPresets"
       },
@@ -1212,7 +1209,7 @@
         "min": 0.0,
         "max": 3.0,
         "step": 0.01,
-        "parent_key": "HeavyRainWeather"
+        "parent_key": "RainStormOffsets"
       },
       {
         "key": "IncreasedStoppedDistanceRainStorm",
@@ -1222,7 +1219,7 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 10.0,
-        "parent_key": "HeavyRainWeather"
+        "parent_key": "RainStormOffsets"
       },
       {
         "key": "ReduceAccelerationRainStorm",
@@ -1233,7 +1230,7 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "HeavyRainWeather"
+        "parent_key": "RainStormOffsets"
       },
       {
         "key": "ReduceLateralAccelerationRainStorm",
@@ -1244,14 +1241,13 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "HeavyRainWeather"
+        "parent_key": "RainStormOffsets"
       },
       {
-        "key": "SnowWeather",
+        "key": "SnowOffsets",
         "label": "Snow",
         "description": "Customise settings for driving in snow",
-        "data_type": "bool",
-        "ui_type": "toggle",
+        "ui_type": "group",
         "is_parent_toggle": true,
         "parent_key": "WeatherPresets"
       },
@@ -1264,7 +1260,7 @@
         "min": 0.0,
         "max": 3.0,
         "step": 0.01,
-        "parent_key": "SnowWeather"
+        "parent_key": "SnowOffsets"
       },
       {
         "key": "IncreasedStoppedDistanceSnow",
@@ -1274,7 +1270,7 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 10.0,
-        "parent_key": "SnowWeather"
+        "parent_key": "SnowOffsets"
       },
       {
         "key": "ReduceAccelerationSnow",
@@ -1285,7 +1281,7 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "SnowWeather"
+        "parent_key": "SnowOffsets"
       },
       {
         "key": "ReduceLateralAccelerationSnow",
@@ -1296,7 +1292,7 @@
         "min": 0.0,
         "max": 99.0,
         "step": 1.0,
-        "parent_key": "SnowWeather"
+        "parent_key": "SnowOffsets"
       },
       {
         "key": "SpeedLimitController",

--- a/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
+++ b/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
@@ -1370,6 +1370,7 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 30.0,
+        "step": 0.1,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1380,6 +1381,7 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 30.0,
+        "step": 0.1,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1506,6 +1508,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1516,6 +1519,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1526,6 +1530,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1536,6 +1541,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1546,6 +1552,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1556,6 +1563,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {
@@ -1566,6 +1574,7 @@
         "ui_type": "numeric",
         "min": -99.0,
         "max": 99.0,
+        "step": 1.0,
         "parent_key": "SpeedLimitController"
       },
       {

--- a/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
+++ b/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
@@ -1311,7 +1311,9 @@
         "label": "Vision Speed Limit Detection",
         "description": "Use the road camera to detect speed limit signs for SLC and speed limit filling.",
         "data_type": "bool",
-        "ui_type": "toggle"
+        "ui_type": "toggle",
+        "is_parent_toggle": true,
+        "parent_key": "SpeedLimitController"
       },
       {
         "key": "VisionSpeedLimitAutoBookmark",

--- a/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
+++ b/starpilot/system/the_pond/assets/components/tools/device_settings_layout.json
@@ -1087,7 +1087,17 @@
         "description": "Automatically adjust driving behavior based on real-time weather. Helps maintain comfort and safety in low visibility, rain, or snow.",
         "data_type": "bool",
         "ui_type": "toggle",
+        "is_parent_toggle": true
         "parent_key": "QOLLongitudinal"
+      },
+      {
+        "key": "LowVisiblityWeather",
+        "label": "Low Visibility (fog)",
+        "description": "Customise settings for driving in low visibility situations",
+        "data_type": "bool",
+        "ui_type": "toggle",
+        "is_parent_toggle": true,
+        "parent_key": "WeatherPresets"
       },
       {
         "key": "IncreaseFollowingLowVisibility",
@@ -1097,7 +1107,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 3.0,
-        "step": 0.01
+        "step": 0.01,
+        "parent_key": "LowVisiblityWeather"
       },
       {
         "key": "IncreasedStoppedDistanceLowVisibility",
@@ -1106,7 +1117,8 @@
         "data_type": "float",
         "ui_type": "numeric",
         "min": 0.0,
-        "max": 10.0
+        "max": 10.0,
+        "parent_key": "LowVisiblityWeather"
       },
       {
         "key": "ReduceAccelerationLowVisibility",
@@ -1116,7 +1128,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "LowVisiblityWeather"
       },
       {
         "key": "ReduceLateralAccelerationLowVisibility",
@@ -1126,7 +1139,17 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "LowVisiblityWeather"
+      },
+      {
+        "key": "RainWeather",
+        "label": "Light/Medium Rain",
+        "description": "Customise settings for driving in light & medium rain",
+        "data_type": "bool",
+        "ui_type": "toggle",
+        "is_parent_toggle": true,
+        "parent_key": "WeatherPresets"
       },
       {
         "key": "IncreaseFollowingRain",
@@ -1136,7 +1159,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 3.0,
-        "step": 0.01
+        "step": 0.01,
+        "parent_key": "RainWeather"
       },
       {
         "key": "IncreasedStoppedDistanceRain",
@@ -1145,7 +1169,8 @@
         "data_type": "float",
         "ui_type": "numeric",
         "min": 0.0,
-        "max": 10.0
+        "max": 10.0,
+        "parent_key": "RainWeather"
       },
       {
         "key": "ReduceAccelerationRain",
@@ -1155,7 +1180,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "RainWeather"
       },
       {
         "key": "ReduceLateralAccelerationRain",
@@ -1165,7 +1191,17 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "RainWeather"
+      },
+      {
+        "key": "HeavyRainWeather",
+        "label": "Heavy Rain",
+        "description": "Customise settings for driving in heavy rain",
+        "data_type": "bool",
+        "ui_type": "toggle",
+        "is_parent_toggle": true,
+        "parent_key": "WeatherPresets"
       },
       {
         "key": "IncreaseFollowingRainStorm",
@@ -1175,7 +1211,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 3.0,
-        "step": 0.01
+        "step": 0.01,
+        "parent_key": "HeavyRainWeather"
       },
       {
         "key": "IncreasedStoppedDistanceRainStorm",
@@ -1184,7 +1221,8 @@
         "data_type": "float",
         "ui_type": "numeric",
         "min": 0.0,
-        "max": 10.0
+        "max": 10.0,
+        "parent_key": "HeavyRainWeather"
       },
       {
         "key": "ReduceAccelerationRainStorm",
@@ -1194,7 +1232,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "HeavyRainWeather"
       },
       {
         "key": "ReduceLateralAccelerationRainStorm",
@@ -1204,7 +1243,17 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "HeavyRainWeather"
+      },
+      {
+        "key": "SnowWeather",
+        "label": "Snow",
+        "description": "Customise settings for driving in snow",
+        "data_type": "bool",
+        "ui_type": "toggle",
+        "is_parent_toggle": true,
+        "parent_key": "WeatherPresets"
       },
       {
         "key": "IncreaseFollowingSnow",
@@ -1214,7 +1263,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 3.0,
-        "step": 0.01
+        "step": 0.01,
+        "parent_key": "SnowWeather"
       },
       {
         "key": "IncreasedStoppedDistanceSnow",
@@ -1223,7 +1273,8 @@
         "data_type": "float",
         "ui_type": "numeric",
         "min": 0.0,
-        "max": 10.0
+        "max": 10.0,
+        "parent_key": "SnowWeather"
       },
       {
         "key": "ReduceAccelerationSnow",
@@ -1233,7 +1284,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "SnowWeather"
       },
       {
         "key": "ReduceLateralAccelerationSnow",
@@ -1243,7 +1295,8 @@
         "ui_type": "numeric",
         "min": 0.0,
         "max": 99.0,
-        "step": 1.0
+        "step": 1.0,
+        "parent_key": "SnowWeather"
       },
       {
         "key": "SpeedLimitController",


### PR DESCRIPTION
Added SLC offsets step values 1.0 
      (previously undefined)
Added SLC look ahead step values 0.1 
      (previously undefined)

Fixed hierarchy of toggles for SLC Vision settings
      Also fixes missing toggles for SLC Vision settings

Fixed hierarchy of toggles for weather presets to match the 'tree' layout of the driving personality prefixes
      Previously had no hierarchy and was always visible