### PR TITLE
Revert radar/following logic changes

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -176,7 +176,7 @@ def match_vision_to_track(v_ego: float, lead: capnp._DynamicStructReader, model_
   return None
 
 
-def get_RadarState_from_vision(lead_msg: capnp._DynamicStructReader, v_ego: float, model_v_ego: float, model_prob: float):
+def get_RadarState_from_vision(lead_msg: capnp._DynamicStructReader, v_ego: float, model_v_ego: float):
   prev_aLeadK = getattr(get_RadarState_from_vision, "prev_aLeadK", 0.0)
   blended_aLeadK = 0.8 * float(lead_msg.a[0]) + 0.2 * prev_aLeadK
   get_RadarState_from_vision.prev_aLeadK = blended_aLeadK
@@ -189,52 +189,30 @@ def get_RadarState_from_vision(lead_msg: capnp._DynamicStructReader, v_ego: floa
     "aLeadK": blended_aLeadK,
     "aLeadTau": 0.3,
     "fcw": False,
-    "modelProb": float(model_prob),
+    "modelProb": float(lead_msg.prob),
     "status": True,
     "radar": False,
     "radarTrackId": -1,
   }
 
 
-def get_lead_field(lead: Any, field: str, default: Any) -> Any:
-  if isinstance(lead, dict):
-    return lead.get(field, default)
-  return getattr(lead, field, default)
-
-
-def leads_are_duplicate(lead_one: Any, lead_two: Any) -> bool:
-  if not get_lead_field(lead_one, "status", False) or not get_lead_field(lead_two, "status", False):
-    return False
-
-  lead_one_radar = bool(get_lead_field(lead_one, "radar", False))
-  lead_two_radar = bool(get_lead_field(lead_two, "radar", False))
-
-  if not lead_one_radar or not lead_two_radar:
-    return False
-
-  lead_one_track_id = int(get_lead_field(lead_one, "radarTrackId", -1))
-  lead_two_track_id = int(get_lead_field(lead_two, "radarTrackId", -1))
-  return lead_one_track_id != -1 and lead_one_track_id == lead_two_track_id
-
-
 def get_lead(v_ego: float, ready: bool, tracks: dict[int, Track], lead_msg: capnp._DynamicStructReader,
              model_v_ego: float, model_data: capnp._DynamicStructReader, standstill: bool,
              starpilot_plan: capnp._DynamicStructReader, starpilot_toggles: SimpleNamespace,
-             low_speed_override: bool = True, g90_radar_filter: bool = False, lead_prob: float | None = None) -> dict[str, Any]:
+             low_speed_override: bool = True, g90_radar_filter: bool = False) -> dict[str, Any]:
   lead_detection_probability = float(getattr(starpilot_toggles, "lead_detection_probability", 0.35))
-  filtered_lead_prob = float(lead_msg.prob if lead_prob is None else lead_prob)
 
   # Determine leads, this is where the essential logic happens
-  if len(tracks) > 0 and ready and filtered_lead_prob > lead_detection_probability:
+  if len(tracks) > 0 and ready and lead_msg.prob > lead_detection_probability:
     track = match_vision_to_track(v_ego, lead_msg, model_data, tracks, starpilot_toggles, g90_radar_filter)
   else:
     track = None
 
   lead_dict = {'status': False}
   if track is not None:
-    lead_dict = track.get_RadarState(filtered_lead_prob)
-  elif (track is None) and ready and (filtered_lead_prob > lead_detection_probability):
-    lead_dict = get_RadarState_from_vision(lead_msg, v_ego, model_v_ego, filtered_lead_prob)
+    lead_dict = track.get_RadarState(lead_msg.prob)
+  elif (track is None) and ready and (lead_msg.prob > lead_detection_probability):
+    lead_dict = get_RadarState_from_vision(lead_msg, v_ego, model_v_ego)
 
   if low_speed_override:
     if g90_radar_filter:
@@ -275,7 +253,6 @@ class RadarD:
     self.tracks: dict[int, Track] = {}
     self.kalman_params = KalmanParams(radar_ts)
     self.g90_radar_filter = g90_radar_filter
-    self.lead_prob_filters = [FirstOrderFilter(0.0, 0.2, radar_ts) for _ in range(2)]
 
     self.v_ego = 0.0
     self.v_ego_hist = deque([0.0], maxlen=int(round(delay / DT_MDL)) + 1)
@@ -331,24 +308,12 @@ class RadarD:
 
     leads_v3 = sm['modelV2'].leadsV3
     if len(leads_v3) > 1:
-      for i in range(2):
-        lead_prob = float(leads_v3[i].prob)
-        if lead_prob > self.lead_prob_filters[i].x:
-          self.lead_prob_filters[i].x = lead_prob
-        else:
-          self.lead_prob_filters[i].update(lead_prob)
-
       self.radar_state.leadOne = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[0], model_v_ego, sm['modelV2'],
                                           sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=True,
-                                          g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[0].x)
+                                          g90_radar_filter=self.g90_radar_filter)
       self.radar_state.leadTwo = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego, sm['modelV2'],
                                           sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=False,
-                                          g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[1].x)
-      # The model exposes two lead slots, but both can occasionally fuse to the
-      # same radar object. Publishing that as two separate leads makes MPC churn
-      # between lead0/lead1 even though the scene only has one physical target.
-      if leads_are_duplicate(self.radar_state.leadOne, self.radar_state.leadTwo):
-        self.radar_state.leadTwo = {'status': False}
+                                          g90_radar_filter=self.g90_radar_filter)
 
     if self.ready and (self.starpilot_toggles.adjacent_lead_tracking or self.starpilot_toggles.human_lane_changes):
       self.starpilot_radar_state.leadLeft = get_adjacent_lead(self.tracks, sm['carState'].standstill, sm['modelV2'], left=True)

--- a/selfdrive/controls/tests/test_leads.py
+++ b/selfdrive/controls/tests/test_leads.py
@@ -4,7 +4,7 @@ import cereal.messaging as messaging
 
 from opendbc.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.test.process_replay import replay_process_with_name
-from openpilot.selfdrive.controls.radard import g90_low_speed_radar_lead_sane, g90_radar_lead_lateral_sane, leads_are_duplicate
+from openpilot.selfdrive.controls.radard import g90_low_speed_radar_lead_sane, g90_radar_lead_lateral_sane
 
 
 class TestLeads:
@@ -21,78 +21,6 @@ class TestLeads:
     assert g90_radar_lead_lateral_sane(close_centered_track)
     assert g90_low_speed_radar_lead_sane(centered_track, 2.0)
     assert not g90_low_speed_radar_lead_sane(far_low_speed_track, 3.5)
-
-  def test_duplicate_radar_leads_share_track(self):
-    lead_one = {
-      "status": True,
-      "radar": True,
-      "radarTrackId": 20293,
-    }
-    lead_two = {
-      "status": True,
-      "radar": True,
-      "radarTrackId": 20293,
-    }
-    different_track = {
-      "status": True,
-      "radar": True,
-      "radarTrackId": 20326,
-    }
-    vision_only = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-    }
-
-    assert leads_are_duplicate(lead_one, lead_two)
-    assert not leads_are_duplicate(lead_one, different_track)
-    assert not leads_are_duplicate(lead_one, vision_only)
-
-  def test_vision_leads_are_not_force_deduped(self):
-    lead_one = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-      "dRel": 48.3,
-      "vLead": 18.9,
-      "yRel": 0.14,
-      "modelProb": 0.99,
-    }
-    lead_two = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-      "dRel": 48.4,
-      "vLead": 19.0,
-      "yRel": 0.14,
-      "modelProb": 1.00,
-    }
-    distinct_lead = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-      "dRel": 48.3,
-      "vLead": 18.9,
-      "yRel": 1.10,
-      "modelProb": 0.99,
-    }
-
-    assert not leads_are_duplicate(lead_one, lead_two)
-    assert not leads_are_duplicate(lead_one, distinct_lead)
-
-  def test_duplicate_lead_helper_supports_attribute_objects(self):
-    lead_one = SimpleNamespace(
-      status=True,
-      radar=True,
-      radarTrackId=1234,
-    )
-    lead_two = SimpleNamespace(
-      status=True,
-      radar=True,
-      radarTrackId=1234,
-    )
-
-    assert leads_are_duplicate(lead_one, lead_two)
 
   def test_radar_fault(self):
     # if there's no radar-related can traffic, radard should either not respond or respond with an error


### PR DESCRIPTION
### Motivation
- Revert recent radar/following changes that altered how model lead probabilities are handled and introduced duplicate-lead suppression, because the new fusion behavior is not desired.

### Description
- Restore direct use of the model lead probability (`lead_msg.prob`) in `get_RadarState_from_vision()` and `get_lead()`.
- Remove the lead probability smoothing path and the `lead_prob_filters` state from `RadarD`.
- Remove the duplicate-lead helper (`leads_are_duplicate` and `get_lead_field`) and the logic that suppressed `leadTwo`, allowing both model lead slots to be published independently again.
- Update tests by removing the duplicate-lead unit tests and corresponding import in `selfdrive/controls/tests/test_leads.py`.

### Testing
- Ran `pytest -q selfdrive/controls/tests/test_leads.py`, which was blocked by a missing runtime dependency with error `ModuleNotFoundError: No module named 'smbus2'`.
- Ran a staged diff check with `git diff --check --cached`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee7c42cc083299709cc366137b652)