### PR TITLE
Remove radar lead deduplication

### DIFF
--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -196,27 +196,6 @@ def get_RadarState_from_vision(lead_msg: capnp._DynamicStructReader, v_ego: floa
   }
 
 
-def get_lead_field(lead: Any, field: str, default: Any) -> Any:
-  if isinstance(lead, dict):
-    return lead.get(field, default)
-  return getattr(lead, field, default)
-
-
-def leads_are_duplicate(lead_one: Any, lead_two: Any) -> bool:
-  if not get_lead_field(lead_one, "status", False) or not get_lead_field(lead_two, "status", False):
-    return False
-
-  lead_one_radar = bool(get_lead_field(lead_one, "radar", False))
-  lead_two_radar = bool(get_lead_field(lead_two, "radar", False))
-
-  if not lead_one_radar or not lead_two_radar:
-    return False
-
-  lead_one_track_id = int(get_lead_field(lead_one, "radarTrackId", -1))
-  lead_two_track_id = int(get_lead_field(lead_two, "radarTrackId", -1))
-  return lead_one_track_id != -1 and lead_one_track_id == lead_two_track_id
-
-
 def get_lead(v_ego: float, ready: bool, tracks: dict[int, Track], lead_msg: capnp._DynamicStructReader,
              model_v_ego: float, model_data: capnp._DynamicStructReader, standstill: bool,
              starpilot_plan: capnp._DynamicStructReader, starpilot_toggles: SimpleNamespace,
@@ -344,11 +323,6 @@ class RadarD:
       self.radar_state.leadTwo = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego, sm['modelV2'],
                                           sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=False,
                                           g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[1].x)
-      # The model exposes two lead slots, but both can occasionally fuse to the
-      # same radar object. Publishing that as two separate leads makes MPC churn
-      # between lead0/lead1 even though the scene only has one physical target.
-      if leads_are_duplicate(self.radar_state.leadOne, self.radar_state.leadTwo):
-        self.radar_state.leadTwo = {'status': False}
 
     if self.ready and (self.starpilot_toggles.adjacent_lead_tracking or self.starpilot_toggles.human_lane_changes):
       self.starpilot_radar_state.leadLeft = get_adjacent_lead(self.tracks, sm['carState'].standstill, sm['modelV2'], left=True)

--- a/selfdrive/controls/tests/test_leads.py
+++ b/selfdrive/controls/tests/test_leads.py
@@ -4,7 +4,7 @@ import cereal.messaging as messaging
 
 from opendbc.car.toyota.values import CAR as TOYOTA
 from openpilot.selfdrive.test.process_replay import replay_process_with_name
-from openpilot.selfdrive.controls.radard import g90_low_speed_radar_lead_sane, g90_radar_lead_lateral_sane, leads_are_duplicate
+from openpilot.selfdrive.controls.radard import g90_low_speed_radar_lead_sane, g90_radar_lead_lateral_sane
 
 
 class TestLeads:
@@ -21,78 +21,6 @@ class TestLeads:
     assert g90_radar_lead_lateral_sane(close_centered_track)
     assert g90_low_speed_radar_lead_sane(centered_track, 2.0)
     assert not g90_low_speed_radar_lead_sane(far_low_speed_track, 3.5)
-
-  def test_duplicate_radar_leads_share_track(self):
-    lead_one = {
-      "status": True,
-      "radar": True,
-      "radarTrackId": 20293,
-    }
-    lead_two = {
-      "status": True,
-      "radar": True,
-      "radarTrackId": 20293,
-    }
-    different_track = {
-      "status": True,
-      "radar": True,
-      "radarTrackId": 20326,
-    }
-    vision_only = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-    }
-
-    assert leads_are_duplicate(lead_one, lead_two)
-    assert not leads_are_duplicate(lead_one, different_track)
-    assert not leads_are_duplicate(lead_one, vision_only)
-
-  def test_vision_leads_are_not_force_deduped(self):
-    lead_one = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-      "dRel": 48.3,
-      "vLead": 18.9,
-      "yRel": 0.14,
-      "modelProb": 0.99,
-    }
-    lead_two = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-      "dRel": 48.4,
-      "vLead": 19.0,
-      "yRel": 0.14,
-      "modelProb": 1.00,
-    }
-    distinct_lead = {
-      "status": True,
-      "radar": False,
-      "radarTrackId": -1,
-      "dRel": 48.3,
-      "vLead": 18.9,
-      "yRel": 1.10,
-      "modelProb": 0.99,
-    }
-
-    assert not leads_are_duplicate(lead_one, lead_two)
-    assert not leads_are_duplicate(lead_one, distinct_lead)
-
-  def test_duplicate_lead_helper_supports_attribute_objects(self):
-    lead_one = SimpleNamespace(
-      status=True,
-      radar=True,
-      radarTrackId=1234,
-    )
-    lead_two = SimpleNamespace(
-      status=True,
-      radar=True,
-      radarTrackId=1234,
-    )
-
-    assert leads_are_duplicate(lead_one, lead_two)
 
   def test_radar_fault(self):
     # if there's no radar-related can traffic, radard should either not respond or respond with an error


### PR DESCRIPTION
### Motivation
- Duplicate lead filtering caused incorrect suppression of valid radar `leadTwo` outputs and was previously removed for vision but remained enabled for radar, which degraded behavior.
- The change removes that deduplication so radar-backed lead slots are preserved and the radar/vision fusion behaves consistently.

### Description
- Remove the `get_lead_field` and `leads_are_duplicate` helper code from `selfdrive/controls/radard.py` and delete the branch that replaced `leadTwo` with `{'status': False}` when both leads shared a radar track id.
- Preserve normal `get_lead` processing and keep radar-provided `leadTwo` instead of force-suppressing it. 
- Update `selfdrive/controls/tests/test_leads.py` to remove the tests and import that asserted the old duplicate-lead filtering behavior while keeping existing G90 filtering and radar fault tests intact.

### Testing
- Ran `python -m compileall -q selfdrive/controls/radard.py selfdrive/controls/tests/test_leads.py` which succeeded.
- Attempted `pytest selfdrive/controls/tests/test_leads.py` but it could not run to completion due to a missing system dependency (`ModuleNotFoundError: No module named 'smbus2'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee8b46ea88329ab0d7018fdef4002)