### PR TITLE
gm: route SDGM cam-long friction brake to the correct bus (fix XT5 braking)

### DIFF
--- a/opendbc_repo/opendbc/car/gm/carcontroller.py
+++ b/opendbc_repo/opendbc/car/gm/carcontroller.py
@@ -344,6 +344,14 @@ def get_friction_brake_bus(CP):
       safety_cfg = getattr(CP, "safetyConfigs", ())
       safety_param = safety_cfg[0].safetyParam if safety_cfg else 0
       if safety_param & GMSafetyFlags.HW_CAM_LONG.value:
+        # A SASCM (SmartASCM) module, when installed, sits at the ASCM location and relays comma's
+        # 0x315 to the EBCM off its comma-feed leg, which is wired to the camera bus (bus2), NOT the
+        # powertrain bus. Route the friction brake to bus2 so the SASCM receives it (op_ctrl_mode)
+        # and forwards it to the EBCM; the panda cam-long whitelist allows 0x315 on both buses.
+        # Without a SASCM (0x2FF absent from the powertrain fingerprint) keep it on the powertrain
+        # bus, unchanged -- a bare SDGM camera car has no EBCM brake path either way.
+        if CP.flags & GMFlags.SASCM.value:
+          return CanBus.CAMERA
         return CanBus.POWERTRAIN
       return CanBus.CAMERA
     return CanBus.POWERTRAIN

--- a/opendbc_repo/opendbc/car/gm/carcontroller.py
+++ b/opendbc_repo/opendbc/car/gm/carcontroller.py
@@ -333,6 +333,18 @@ def get_friction_brake_bus(CP):
 
   if CP.networkLocation == NetworkLocation.fwdCamera:
     if CP.carFingerprint in SDGM_CAR:
+      # With camera longitudinal the panda safety whitelists EBCMFrictionBrakeCmd (0x315) on
+      # the powertrain bus (GM_CAM_LONG_TX_MSGS), so the friction brake must go there to reach
+      # the EBCM and pass the TX check. Stock-long SDGM (e.g. Volt auto-hold) keeps it on the
+      # camera bus. Gate on the HW_CAM_LONG safety flag specifically -- the same bit the panda
+      # uses to select GM_CAM_LONG_TX_MSGS -- because an SDGM gas-interceptor install also sets
+      # openpilotLongitudinalControl but runs HW_CAM (not cam-long), where 0x315 must stay off
+      # the powertrain bus. Without this, cam-long SDGM brake commands hit the camera bus and
+      # the panda drops them, so openpilot can accelerate but cannot brake.
+      safety_cfg = getattr(CP, "safetyConfigs", ())
+      safety_param = safety_cfg[0].safetyParam if safety_cfg else 0
+      if safety_param & GMSafetyFlags.HW_CAM_LONG.value:
+        return CanBus.POWERTRAIN
       return CanBus.CAMERA
     return CanBus.POWERTRAIN
 

--- a/opendbc_repo/opendbc/safety/modes/gm.h
+++ b/opendbc_repo/opendbc/safety/modes/gm.h
@@ -581,7 +581,7 @@ static safety_config gm_init(uint16_t param) {
 
   // block PSCMStatus (0x184); forwarded through openpilot to hide an alert from the camera
   static const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true}, {0x315, 0, 5, .check_relay = true}, {0x2CB, 0, 8, .check_relay = true}, {0x2CD, 0, 5, .check_relay = true}, {0x370, 0, 6, .check_relay = true}, {0x3D1, 0, 8, .check_relay = false},  // pt bus
-                                               {0x184, 2, 8, .check_relay = true},  // camera bus
+                                               {0x184, 2, 8, .check_relay = true}, {0x315, 2, 5, .check_relay = false},  // camera bus (0x315 = SDGM+SASCM friction-brake relay leg)
                                                {0x200, 0, 6, .check_relay = false}, {0x1E1, 0, 7, .check_relay = false},
                                                {0xBD, 0, 7, .check_relay = false}, {0x1F5, 0, 8, .check_relay = false}};  // pt bus
 


### PR DESCRIPTION
## Problem

On an SDGM car running **camera longitudinal**, openpilot could accelerate but
could **not brake**: the EBCM friction-brake command (`0x315`) was being sent on
the wrong CAN bus, so the panda safety `TX` check dropped 100% of the frames.

`get_friction_brake_bus()` returned the camera bus for every SDGM car, but the
`GM_CAM_LONG_TX_MSGS` whitelist only allowed `0x315` on the powertrain bus.

## Fix

Two commits, routing `0x315` to the bus the EBCM actually receives it on:

1. **Bare SDGM cam-long → powertrain bus.** Gate on the `HW_CAM_LONG` safety
   flag (the same bit the panda uses to select `GM_CAM_LONG_TX_MSGS`) so an SDGM
   gas-interceptor install that runs `HW_CAM` (not cam-long) is left unchanged.

2. **SDGM + SASCM → camera bus.** A SmartASCM (SASCM) module sits at the ASCM
   location and relays comma's `0x315` to the EBCM off its comma-feed leg, which
   is wired to the **camera bus (bus2)**, not the powertrain bus. When a SASCM is
   detected (`CP.flags & GMFlags.SASCM`) route the friction brake to bus2 so the
   module receives it (sets `op_ctrl_mode`) and forwards it to the EBCM. The
   panda cam-long whitelist now allows `0x315` on both buses. Stock-long SDGM
   (e.g. Volt auto-hold) is untouched.

## Notes

- Touches `opendbc/safety/modes/gm.h` (adds `0x315` to the camera bus in
  `GM_CAM_LONG_TX_MSGS`), so this **requires a panda firmware rebuild** to take
  effect on-device.
- Confirmed working on a Cadillac XT5 (SDGM-B harness + SASCM): openpilot
  longitudinal now brakes.
- Bare SDGM camera cars (no SASCM, `0x2FF` absent from the powertrain
  fingerprint) keep the powertrain-bus path and are unaffected.
