### PR TITLE
gm: set BUICK_LACROSSE_ASCM_19US minSteerSpeed to 28 mph (LKA threshold)

### DIFF
--- a/opendbc_repo/opendbc/car/gm/interface.py
+++ b/opendbc_repo/opendbc/car/gm/interface.py
@@ -425,7 +425,7 @@ class CarInterface(CarInterfaceBase):
     elif candidate in (CAR.BUICK_LACROSSE, CAR.BUICK_LACROSSE_ASCM, CAR.BUICK_LACROSSE_ASCM_19US):
       CarInterfaceBase.configure_torque_tune(CAR.BUICK_LACROSSE, ret.lateralTuning)
       if candidate == CAR.BUICK_LACROSSE_ASCM_19US:
-        ret.minSteerSpeed = 26 * CV.MPH_TO_MS
+        ret.minSteerSpeed = 28 * CV.MPH_TO_MS
 
     elif candidate == CAR.CADILLAC_ESCALADE:
       ret.minEnableSpeed = -1.  # engage speed is decided by pcm


### PR DESCRIPTION
## Change

Raise `BUICK_LACROSSE_ASCM_19US` `minSteerSpeed` from **26 → 28 mph**.

## Why

The US 2019 Buick LaCrosse EPS/PSCM only keeps LKA active above roughly
**12.5 m/s (~28 mph / 45 km/h)**. When openpilot is still asserting LKA torque
as the car decelerates **down through** that threshold, the PSCM deactivates and
throws *"LKAS Fault: Restart the car to engage"*. (Up-crossings activate cleanly;
only the down-crossing while op is active faults.)

`26 mph` is `11.6 m/s`, which is **below** that threshold, so openpilot keeps
commanding LKA right through the deactivation point and can still trip the fault
on deceleration. `28 mph` (`12.5 m/s`) puts `minSteerSpeed` **right at** the
threshold, so openpilot releases LKA exactly as the PSCM drops it — no
down-crossing fault — while keeping the widest usable steering range.

Only the `BUICK_LACROSSE_ASCM_19US` variant is affected; the base LaCrosse
platforms are unchanged.

---

Supersedes #69 (which added the variant — already merged into `Dom`).
