### PR TITLE
GM: route SDGM friction brake to the correct bus for XT5

### DIFF
--- a/opendbc_repo/opendbc/car/gm/carcontroller.py
+++ b/opendbc_repo/opendbc/car/gm/carcontroller.py
@@ -333,6 +333,14 @@ def get_friction_brake_bus(CP):
 
   if CP.networkLocation == NetworkLocation.fwdCamera:
     if CP.carFingerprint in SDGM_CAR:
+      # cam-long: 0x315 goes where the panda whitelist allows it and the EBCM hears it
+      safety_cfg = getattr(CP, "safetyConfigs", ())
+      safety_param = safety_cfg[0].safetyParam if safety_cfg else 0
+      if safety_param & GMSafetyFlags.HW_CAM_LONG.value:
+        # SASCM relays 0x315 to the EBCM off its camera-bus (bus2) leg; bare SDGM uses the pt bus
+        if CP.flags & GMFlags.SASCM.value:
+          return CanBus.CAMERA
+        return CanBus.POWERTRAIN
       return CanBus.CAMERA
     return CanBus.POWERTRAIN
 

--- a/opendbc_repo/opendbc/safety/modes/gm.h
+++ b/opendbc_repo/opendbc/safety/modes/gm.h
@@ -581,7 +581,7 @@ static safety_config gm_init(uint16_t param) {
 
   // block PSCMStatus (0x184); forwarded through openpilot to hide an alert from the camera
   static const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true}, {0x315, 0, 5, .check_relay = true}, {0x2CB, 0, 8, .check_relay = true}, {0x2CD, 0, 5, .check_relay = true}, {0x370, 0, 6, .check_relay = true}, {0x3D1, 0, 8, .check_relay = false},  // pt bus
-                                               {0x184, 2, 8, .check_relay = true},  // camera bus
+                                               {0x184, 2, 8, .check_relay = true}, {0x315, 2, 5, .check_relay = false},  // camera bus (SASCM brake relay)
                                                {0x200, 0, 6, .check_relay = false}, {0x1E1, 0, 7, .check_relay = false},
                                                {0xBD, 0, 7, .check_relay = false}, {0x1F5, 0, 8, .check_relay = false}};  // pt bus
 


### PR DESCRIPTION
On an SDGM car with camera longitudinal, openpilot could accelerate but not brake — the friction-brake command (0x315) went out on a bus the panda safety dropped.

Route 0x315 where the EBCM actually receives it:
- SDGM + SASCM (e.g. Cadillac XT5): the SASCM relays it to the EBCM off its camera-bus (bus2) leg → send on the camera bus.
- bare SDGM: powertrain bus.

Also whitelist 0x315 on the camera bus in GM_CAM_LONG_TX_MSGS.

Requires a panda rebuild (safety TX-table change). Confirmed braking on-car on a Cadillac XT5 (SDGM-B harness + SASCM).