### PR TITLE
feat(lateral): Lane Centering, Lane Center Offset, and Camera Offset UI

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -371,6 +371,8 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"IssueReported", {CLEAR_ON_MANAGER_START, JSON, "{}", "{}"}},
     {"KonikDongleId", {PERSISTENT, STRING, "", "", 0}},
     {"KonikMinutes", {PERSISTENT, INT, "0", "0", 0}},
+    {"LaneCentering", {PERSISTENT, BOOL, "0", "0", 2, SETTINGS_SIMPLE}},
+    {"LaneCenterOffset", {PERSISTENT, FLOAT, "0.0", "0.0", 3, SETTINGS_SIMPLE}},
     {"LaneChanges", {PERSISTENT, BOOL, "1", "1", 0, SETTINGS_SIMPLE}},
     {"LaneChangeSmoothing", {PERSISTENT, INT, "5", "10", 1, SETTINGS_SIMPLE}},
     {"LaneChangeTime", {PERSISTENT, FLOAT, "1.0", "0.0", 1, SETTINGS_SIMPLE}},

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -13,7 +13,7 @@ from opendbc.car.car_helpers import interfaces
 from opendbc.car.chrysler.values import pacifica_hybrid_aol_stock_acc_mode
 from opendbc.car.gm.values import CAR as GM_CAR
 from opendbc.car.vehicle_model import VehicleModel
-from openpilot.selfdrive.controls.lib.drive_helpers import MAX_LATERAL_JERK, clip_curvature, get_lateral_active
+from openpilot.selfdrive.controls.lib.drive_helpers import LaneCenteringController, MAX_LATERAL_JERK, clip_curvature, get_lateral_active
 from openpilot.selfdrive.controls.lib.latcontrol import LatControl
 from openpilot.selfdrive.controls.lib.latcontrol_pid import LatControlPID
 from openpilot.selfdrive.controls.lib.latcontrol_angle import LatControlAngle, STEER_ANGLE_SATURATION_THRESHOLD
@@ -305,6 +305,7 @@ class Controls:
     self.curvature = 0.0
     self.desired_curvature = 0.0
     self.lc_smooth_release = 0.0
+    self.lane_centering = LaneCenteringController()
     self.lc_entry_sign = 0.0
     self.lc_arrest_jerk_factor = 1.0
     self.turn_hold_curvature = 0.0
@@ -419,6 +420,7 @@ class Controls:
 
     if not CC.latActive:
       self.LaC.reset()
+      self.lane_centering.reset()
     if not CC.longActive:
       self.LoC.reset()
 
@@ -584,6 +586,16 @@ class Controls:
              lead_curvature * blinker_dir > abs(self.turn_hold_curvature):
             held_mag = min(lead_curvature * blinker_dir, abs(self.turn_hold_curvature) + CURVATURE_HOLD_RATCHET_RATE * DT_CTRL)
             self.turn_hold_curvature = math.copysign(held_mag, lead_curvature)
+
+    # Apply lane-line centering to the final model/turn-adjusted request. This keeps
+    # turn hold/lead bookkeeping on the raw model command while still subjecting the
+    # centering correction to the downstream curvature/jerk safety limits.
+    new_desired_curvature = self.lane_centering.update(
+      new_desired_curvature, model_v2, CS.vEgo,
+      bool(getattr(self.starpilot_toggles, "lane_centering", False)),
+      float(getattr(self.starpilot_toggles, "lane_center_offset", 0.0) or 0.0),
+      CC.latActive,
+      bool(self.sm.all_checks(['modelV2'])))
 
     jerk_factor = 1.0
     if self.starpilot_toggles.lane_change_pace < 10:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -85,3 +85,106 @@ def get_curvature_from_plan(yaws, yaw_rates, t_idxs, vego, action_t):
   psi_target = np.interp(action_t, t_idxs, yaws)
   psi_rate = yaw_rates[0]
   return curv_from_psis(psi_target, psi_rate, vego, action_t)
+
+
+_LC_MIN_V_EGO = 5.0
+_LC_MIN_PROB = 0.6
+_LC_MAX_STD = 0.3
+_LC_MIN_WIDTH = 2.6
+_LC_MAX_WIDTH = 4.8
+_LC_MAX_CORR = 0.004
+_LC_MAX_GAIN = 0.30
+_LC_SMOOTH_TAU = 0.4
+
+
+class LaneCenteringController:
+  def __init__(self):
+    self._correction = 0.0
+
+  def reset(self):
+    self._correction = 0.0
+
+  def update(self, model_curvature, model_v2, v_ego, enabled, offset, lat_active, model_valid) -> float:
+    model_curvature = float(model_curvature)
+
+    if not model_valid:
+      self.reset()
+      return model_curvature
+
+    try:
+      offset_f = float(offset)
+    except (TypeError, ValueError):
+      self.reset()
+      return model_curvature
+    if not np.isfinite(offset_f):
+      # Non-finite offset is an untrusted config boundary: hard-reset so NaN
+      # never reaches smooth_value.
+      self.reset()
+      return model_curvature
+
+    if not enabled or not lat_active or v_ego < _LC_MIN_V_EGO:
+      self.reset()
+      return model_curvature
+
+    try:
+      if int(model_v2.meta.laneChangeState) != 0:
+        # Lane change in progress: hard-reset to drop any 0.4s filtered residual
+        # instead of smearing the pre-change correction into the lane change.
+        self.reset()
+        return model_curvature
+    except (AttributeError, TypeError, ValueError):
+      pass
+
+    valid, raw = self._raw_correction(model_v2, v_ego, offset_f)
+    target = float(np.clip(raw, -_LC_MAX_CORR, _LC_MAX_CORR)) * _LC_MAX_GAIN if valid else 0.0
+    self._correction = float(smooth_value(target, self._correction, _LC_SMOOTH_TAU, dt=DT_CTRL))
+    return model_curvature + self._correction
+
+  def _raw_correction(self, model_v2, v_ego, offset) -> tuple[bool, float]:
+    try:
+      lane_lines = model_v2.laneLines
+      probs = model_v2.laneLineProbs
+      stds = model_v2.laneLineStds
+      if len(lane_lines) < 3 or len(probs) < 3 or len(stds) < 3:
+        return False, 0.0
+      if int(model_v2.meta.laneChangeState) != 0:
+        return False, 0.0
+      if probs[1] < _LC_MIN_PROB or probs[2] < _LC_MIN_PROB:
+        return False, 0.0
+      if stds[1] > _LC_MAX_STD or stds[2] > _LC_MAX_STD:
+        return False, 0.0
+
+      left_x = np.asarray(lane_lines[1].x, dtype=float)
+      left_y = np.asarray(lane_lines[1].y, dtype=float)
+      right_x = np.asarray(lane_lines[2].x, dtype=float)
+      right_y = np.asarray(lane_lines[2].y, dtype=float)
+      if (left_x.size < 2 or left_x.size != left_y.size or
+          right_x.size < 2 or right_x.size != right_y.size):
+        return False, 0.0
+      if not (np.isfinite(left_x).all() and np.isfinite(left_y).all() and
+              np.isfinite(right_x).all() and np.isfinite(right_y).all()):
+        return False, 0.0
+      if not (np.all(np.diff(left_x) > 0) and np.all(np.diff(right_x) > 0)):
+        return False, 0.0
+
+      lookahead = float(np.clip(v_ego * 1.0, 8.0, 35.0))
+      left = float(np.interp(lookahead, left_x, left_y))
+      right = float(np.interp(lookahead, right_x, right_y))
+      width = right - left
+      if width < _LC_MIN_WIDTH or width > _LC_MAX_WIDTH:
+        return False, 0.0
+
+      center_y = 0.5 * (left + right)
+
+      pos_x = np.asarray(model_v2.position.x, dtype=float)
+      pos_y = np.asarray(model_v2.position.y, dtype=float)
+      if pos_x.size < 2 or pos_x.size != pos_y.size:
+        return False, 0.0
+      if not (np.isfinite(pos_x).all() and np.isfinite(pos_y).all() and np.all(np.diff(pos_x) > 0)):
+        return False, 0.0
+      model_y = float(np.interp(lookahead, pos_x, pos_y))
+      error = (center_y + offset) - model_y
+      raw = 2.0 * error / (lookahead ** 2)
+      return True, float(raw)
+    except (AttributeError, IndexError, TypeError, ValueError):
+      return False, 0.0

--- a/selfdrive/controls/tests/test_drive_helpers.py
+++ b/selfdrive/controls/tests/test_drive_helpers.py
@@ -1,3 +1,21 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+if "smbus2" not in sys.modules:
+  _smbus2 = ModuleType("smbus2")
+
+  class SMBus:  # noqa: N801
+    def __init__(self, *a, **k):
+      pass
+
+    def close(self):
+      pass
+
+  _smbus2.SMBus = SMBus
+  sys.modules["smbus2"] = _smbus2
+
+import numpy as np
+
 from openpilot.selfdrive.controls.lib.drive_helpers import get_lateral_active
 
 
@@ -7,3 +25,282 @@ def test_get_lateral_active_requires_enabled_without_aol():
 
 def test_get_lateral_active_allows_aol_while_disabled():
   assert get_lateral_active(False, False, True, False, False, False, False, True)
+
+
+# ---------------------------------------------------------------------------
+# LaneCenteringController — deterministic RED tests.
+#
+# Locked contract: .slim/deepwork/lane-center-control.md
+#   class LaneCenteringController in drive_helpers.py
+#   update(model_curvature, model_v2, v_ego, enabled, offset, lat_active, model_valid) -> float
+#
+# Sign conventions (controlsd / latcontrol_torque):
+#   laneLines[1] left  -> y negative     laneLines[2] right -> y positive
+#   measured_curvature = -VM.calc_curvature(SA); get_steer_from_curvature(-desired)
+#   => openpilot curvature positive -> steer right; negative -> steer left
+#   offset positive -> desire right of geometric center
+#
+# Gates (all must pass or model_curvature is returned unchanged):
+#   enabled, lat_active, model_valid, laneChangeState == off, v_ego >= 5 m/s,
+#   both probs >= 0.6, both stds <= 0.3 m, finite non-empty arrays,
+#   width in [2.6, 4.8] m.
+# ---------------------------------------------------------------------------
+
+_V_EGO = 20.0
+_XS = np.linspace(0.0, 50.0, 52)
+
+
+def _lane(y_val):
+  return SimpleNamespace(x=_XS.copy(), y=np.full_like(_XS, float(y_val)))
+
+
+def _model_v2(left_y=-1.8, right_y=1.8, *, model_y=0.0, left_prob=0.9, right_prob=0.9,
+              left_std=0.1, right_std=0.1, lane_change_state=0):
+  """SimpleNamespace fixture mirroring the modelV2 lane-line shape."""
+  return SimpleNamespace(
+    laneLines=[_lane(0), _lane(left_y), _lane(right_y), _lane(0)],
+    laneLineProbs=[0.0, left_prob, right_prob, 0.0],
+    laneLineStds=[0.0, left_std, right_std, 0.0],
+    position=_lane(model_y),
+    meta=SimpleNamespace(laneChangeState=int(lane_change_state)),
+  )
+
+
+def _ctrl():
+  from openpilot.selfdrive.controls.lib.drive_helpers import LaneCenteringController
+  return LaneCenteringController()
+
+
+def _converge(v2, offset=0.0, model_curv=0.0, steps=300):
+  c = _ctrl()
+  out = model_curv
+  for _ in range(steps):
+    out = c.update(model_curv, v2, _V_EGO, True, offset, True, True)
+  return c, out
+
+
+# ===== hard gates: gate failure returns model_curvature unchanged =====
+
+def test_lc_disabled_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6), _V_EGO, False, 0.0, True, True) == 0.01
+
+
+def test_lc_lateral_inactive_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6), _V_EGO, True, 0.0, False, True) == 0.01
+
+
+def test_lc_invalid_model_is_noop():
+  # Stale/invalid modelV2 must hard-reset; do not correct from cached lines.
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6), _V_EGO, True, 0.0, True, False) == 0.01
+
+
+def test_lc_low_speed_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6), 3.0, True, 0.0, True, True) == 0.01
+
+
+def test_lc_low_probability_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6, left_prob=0.3), _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_high_std_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6, right_std=0.5), _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_implausible_narrow_width_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=1.2), _V_EGO, True, 0.0, True, True) == 0.01  # width 2.2 < 2.6
+
+
+def test_lc_implausible_wide_width_is_noop():
+  assert _ctrl().update(0.01, _model_v2(left_y=-2.5, right_y=2.5), _V_EGO, True, 0.0, True, True) == 0.01  # width 5.0 > 4.8
+
+
+def test_lc_lane_change_is_noop():
+  for state in (1, 2, 3):
+    assert _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6, lane_change_state=state),
+                          _V_EGO, True, 0.0, True, True) == 0.01
+
+
+# ===== malformed data: treated as no-confidence (smooth fade target=0, not hard reset) =====
+
+def test_lc_nan_in_lane_line_is_noop():
+  bad = _model_v2(left_y=-1.0, right_y=2.6)
+  bad.laneLines[1].y[10] = np.nan
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_empty_lane_line_is_noop():
+  bad = _model_v2()
+  bad.laneLines[2] = SimpleNamespace(x=np.array([]), y=np.array([]))
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_empty_model_path_is_noop():
+  bad = _model_v2(left_y=-1.5, right_y=2.1)
+  bad.position = SimpleNamespace(x=np.array([]), y=np.array([]))
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_mismatched_lane_xy_lengths_are_noop():
+  bad = _model_v2(left_y=-1.5, right_y=2.1)
+  bad.laneLines[1].x = bad.laneLines[1].x[:-1]
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_non_monotonic_lane_x_is_noop():
+  bad = _model_v2(left_y=-1.5, right_y=2.1)
+  bad.laneLines[2].x[10] = bad.laneLines[2].x[9]
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_mismatched_model_path_xy_lengths_are_noop():
+  bad = _model_v2(left_y=-1.5, right_y=2.1)
+  bad.position.y = bad.position.y[:-1]
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+def test_lc_non_monotonic_model_path_x_is_noop():
+  bad = _model_v2(left_y=-1.5, right_y=2.1)
+  bad.position.x[10] = bad.position.x[9]
+  assert _ctrl().update(0.01, bad, _V_EGO, True, 0.0, True, True) == 0.01
+
+
+# ===== correction signs (positive openpilot curvature = steer right) =====
+
+def test_lc_symmetric_lane_no_correction():
+  _, out = _converge(_model_v2(left_y=-1.8, right_y=1.8))
+  assert abs(out) < 1e-6
+
+
+def test_lc_curved_lane_matching_model_path_has_no_correction():
+  _, out = _converge(_model_v2(left_y=-1.5, right_y=2.1, model_y=0.3))
+  assert abs(out) < 1e-6
+
+
+def test_lc_center_right_steers_right():
+  # Car left of geometric center => center_y > 0 => positive curvature (right)
+  _, out = _converge(_model_v2(left_y=-1.5, right_y=2.1))  # center +0.3 m right
+  assert out > 1e-6
+
+
+def test_lc_center_left_steers_left():
+  # Car right of geometric center => center_y < 0 => negative curvature (left)
+  _, out = _converge(_model_v2(left_y=-2.1, right_y=1.5))  # center -0.3 m left
+  assert out < -1e-6
+
+
+def test_lc_model_path_right_of_lane_center_steers_left():
+  _, out = _converge(_model_v2(left_y=-1.8, right_y=1.8, model_y=0.3))
+  assert out < -1e-6
+
+
+def test_lc_negative_offset_steers_left():
+  _, out = _converge(_model_v2(left_y=-1.8, right_y=1.8), offset=-0.3)
+  assert out < -1e-6
+
+
+def test_lc_positive_offset_steers_right():
+  _, out = _converge(_model_v2(left_y=-1.8, right_y=1.8), offset=0.3)
+  assert out > 1e-6
+
+
+# ===== magnitude properties =====
+
+def test_lc_correction_capped():
+  # center 1.5 m right -> raw 2*1.5/20^2 = 0.0075, above the 0.004 raw cap.
+  _, out = _converge(_model_v2(left_y=0.0, right_y=3.0), steps=500)
+  assert np.isclose(out, 0.004 * 0.30, atol=1e-8)
+
+
+def test_lc_offset_proportional():
+  _, o1 = _converge(_model_v2(left_y=-1.8, right_y=1.8), offset=0.15)
+  _, o2 = _converge(_model_v2(left_y=-1.8, right_y=1.8), offset=0.30)
+  assert abs(o2) > abs(o1) > 1e-6
+
+
+def test_lc_correction_additive_to_model_curvature():
+  _, base = _converge(_model_v2(left_y=-1.5, right_y=2.1), model_curv=0.0)
+  _, with_c = _converge(_model_v2(left_y=-1.5, right_y=2.1), model_curv=0.01)
+  assert abs((with_c - 0.01) - base) < 1e-4
+
+
+# ===== smooth stateful transitions =====
+
+def test_lc_smooth_activation():
+  c = _ctrl()
+  v2 = _model_v2(left_y=-1.5, right_y=2.1)
+  first = c.update(0.0, v2, _V_EGO, True, 0.0, True, True)
+  steady = 0.0
+  for _ in range(300):
+    steady = c.update(0.0, v2, _V_EGO, True, 0.0, True, True)
+  assert 0 < first < steady  # ramps up gradually, not instant
+
+
+def test_lc_smooth_fallback():
+  c = _ctrl()
+  v2_good = _model_v2(left_y=-1.5, right_y=2.1)
+  for _ in range(300):
+    c.update(0.0, v2_good, _V_EGO, True, 0.0, True, True)
+  # confidence drops -> correction fades, does not snap to zero
+  v2_bad = _model_v2(left_y=-1.5, right_y=2.1, left_prob=0.2)
+  fading = c.update(0.0, v2_bad, _V_EGO, True, 0.0, True, True)
+  assert abs(fading) > 1e-6
+  final = 0.0
+  for _ in range(300):
+    final = c.update(0.0, v2_bad, _V_EGO, True, 0.0, True, True)
+  assert abs(final) < 1e-6  # fully fades back to model curvature
+
+
+def test_lc_invalid_model_hard_resets_after_active():
+  c = _ctrl()
+  v2 = _model_v2(left_y=-1.5, right_y=2.1)
+  for _ in range(300):
+    c.update(0.0, v2, _V_EGO, True, 0.0, True, True)
+  # invalid/stale model: hard reset (unlike low-confidence smooth fade)
+  out = c.update(0.01, v2, _V_EGO, True, 0.0, True, False)
+  assert out == 0.01
+
+
+def test_lc_lane_change_hard_resets_after_active():
+  # Warm correction must not leave a 0.4s residual when a lane change begins.
+  # Cold-start laneChangeState==off checks are insufficient: residual only appears
+  # after nonzero correction has already been filtered in.
+  for state in (1, 2, 3):
+    c = _ctrl()
+    v2 = _model_v2(left_y=-1.5, right_y=2.1)
+    for _ in range(300):
+      c.update(0.0, v2, _V_EGO, True, 0.0, True, True)
+    assert abs(c._correction) > 1e-6
+    v2.meta.laneChangeState = state
+    out = c.update(0.01, v2, _V_EGO, True, 0.0, True, True)
+    assert out == 0.01
+    assert c._correction == 0.0
+
+
+def test_lc_non_finite_offset_hard_resets_cold():
+  import math
+  for bad_offset in (float("nan"), float("inf"), float("-inf"), math.nan):
+    out = _ctrl().update(0.01, _model_v2(left_y=-1.0, right_y=2.6), _V_EGO, True, bad_offset, True, True)
+    assert out == 0.01
+    assert math.isfinite(out)
+
+
+def test_lc_non_finite_offset_hard_resets_after_active():
+  import math
+  for bad_offset in (float("nan"), float("inf"), float("-inf")):
+    c = _ctrl()
+    v2 = _model_v2(left_y=-1.5, right_y=2.1)
+    for _ in range(300):
+      c.update(0.0, v2, _V_EGO, True, 0.0, True, True)
+    assert abs(c._correction) > 1e-6
+    out = c.update(0.01, v2, _V_EGO, True, bad_offset, True, True)
+    assert out == 0.01
+    assert c._correction == 0.0
+    assert math.isfinite(out)
+
+
+def test_lc_update_requires_explicit_model_valid():
+  import inspect
+  from openpilot.selfdrive.controls.lib.drive_helpers import LaneCenteringController
+  sig = inspect.signature(LaneCenteringController.update)
+  assert "model_valid" in sig.parameters
+  assert sig.parameters["model_valid"].default is inspect.Parameter.empty

--- a/selfdrive/controls/tests/test_lane_centering_controlsd_contract.py
+++ b/selfdrive/controls/tests/test_lane_centering_controlsd_contract.py
@@ -1,0 +1,21 @@
+"""Source-contract: controlsd must gate LaneCentering on modelV2 all_checks.
+
+SubMaster.valid only reflects msg.valid. Stale/low-freq modelV2 must also drop
+the correction; all_checks = all_alive & all_freq_ok & all_valid.
+"""
+
+from pathlib import Path
+
+
+_CTRLD = (Path(__file__).resolve().parents[1] / "controlsd.py").read_text(encoding="utf-8")
+
+
+def test_controlsd_passes_modelv2_all_checks_to_lane_centering():
+  # Integration expression must use freshness/frequency/validity, not payload valid alone.
+  assert "self.sm.all_checks(['modelV2'])" in _CTRLD
+  assert "self.sm.valid['modelV2']" not in _CTRLD
+
+
+def test_controlsd_lane_centering_update_receives_bool_all_checks():
+  # Call site must wrap the all_checks result in bool(...) for the model_valid arg.
+  assert "bool(self.sm.all_checks(['modelV2']))" in _CTRLD

--- a/selfdrive/ui/layouts/settings/starpilot/lateral.py
+++ b/selfdrive/ui/layouts/settings/starpilot/lateral.py
@@ -300,6 +300,27 @@ class StarPilotLateralLayout(_SettingsPage):
         on_click=lambda: self._show_slider("SteerRatio", max(0.01, cs.steerRatio) * 0.5, max(0.01, cs.steerRatio) * 1.5, step=0.01, value_type="float"),
         visible=lambda: alt_on() and cs.steerRatio != 0,
       ),
+      SettingRow(
+        "LaneCentering", "toggle", tr_noop("Lane Centering"),
+        subtitle=tr_noop("Center the car using both detected lane lines. Automatically falls back to standard lane keeping when both lines are not detected."),
+        get_state=lambda: p.get_bool("LaneCentering"),
+        set_state=lambda s: p.put_bool("LaneCentering", s),
+        visible=alt_on,
+      ),
+      SettingRow(
+        "LaneCenterOffset", "value", tr_noop("Lane Center Offset"),
+        subtitle=tr_noop("Shift the centered position within the lane. Negative moves left, positive moves right. Requires both detected lane lines."),
+        get_value=lambda: f"{p.get_float('LaneCenterOffset'):.2f} m",
+        on_click=lambda: self._show_slider("LaneCenterOffset", -0.5, 0.5, step=0.01, unit=" m", value_type="float"),
+        visible=lambda: alt_on() and p.get_bool("LaneCentering"),
+      ),
+      SettingRow(
+        "CameraOffset", "value", tr_noop("Camera Offset"),
+        subtitle=tr_noop("Virtually shift the driving model camera. Positive biases the model left; negative biases it right. Development use only."),
+        get_value=lambda: f"{p.get_float('CameraOffset'):.2f} m",
+        on_click=lambda: self._show_slider("CameraOffset", -0.35, 0.35, step=0.01, unit=" m", value_type="float"),
+        visible=alt_on,
+      ),
     ]
 
     self._manager_view = SteeringManagerView(

--- a/selfdrive/ui/tests/test_lateral_settings.py
+++ b/selfdrive/ui/tests/test_lateral_settings.py
@@ -1,0 +1,194 @@
+import importlib
+import sys
+import types
+import unittest
+
+from openpilot.selfdrive.ui.tests.test_aethergrid import (
+  _clear_modules,
+  _install_aethergrid_stubs,
+  _install_panel_stubs,
+)
+
+AETHERGRID_MODULE = "openpilot.selfdrive.ui.layouts.settings.starpilot.aethergrid"
+PANEL_MODULE = "openpilot.selfdrive.ui.layouts.settings.starpilot.panel"
+LATERAL_MODULE = "openpilot.selfdrive.ui.layouts.settings.starpilot.lateral"
+
+
+class FakeParams:
+  def __init__(self, memory=False):
+    self.store = {}
+
+  def get(self, key, **kwargs):
+    v = self.store.get(key)
+    return None if v is None else str(v).encode()
+
+  def get_bool(self, key, **kwargs):
+    return bool(self.store.get(key, False))
+
+  def get_int(self, key, **kwargs):
+    return int(self.store.get(key, 0))
+
+  def get_float(self, key, **kwargs):
+    return float(self.store.get(key, 0.0))
+
+  def put(self, key, val, **kwargs):
+    self.store[key] = val
+
+  def put_bool(self, key, val, **kwargs):
+    self.store[key] = bool(val)
+
+  def put_int(self, key, val, **kwargs):
+    self.store[key] = int(val)
+
+  def put_float(self, key, val, **kwargs):
+    self.store[key] = float(val)
+
+  def remove(self, key):
+    self.store.pop(key, None)
+
+
+def _install_lateral_stubs():
+  _install_aethergrid_stubs()
+
+  sys.modules["openpilot.system.ui.lib.multilang"].tr_noop = lambda text: text
+  sys.modules["openpilot.system.ui.lib.application"].gui_app.push_widget = lambda widget: None
+
+  hardware_mod = types.ModuleType("openpilot.system.hardware")
+  hardware_mod.HARDWARE = types.SimpleNamespace(reboot=lambda: None)
+  sys.modules["openpilot.system.hardware"] = hardware_mod
+
+  state_mod = types.ModuleType("openpilot.selfdrive.ui.lib.starpilot_state")
+  state_mod.starpilot_state = types.SimpleNamespace(
+    car_state=types.SimpleNamespace(
+      hasNNFFLog=False,
+      isAngleCar=False,
+      isTorqueCar=True,
+      hasAutoTune=False,
+      steerActuatorDelay=0.0,
+      friction=0.0,
+      steerKp=0.0,
+      latAccelFactor=0.0,
+      steerRatio=0.0,
+    )
+  )
+  sys.modules["openpilot.selfdrive.ui.lib.starpilot_state"] = state_mod
+
+  variables_mod = types.ModuleType("openpilot.starpilot.common.starpilot_variables")
+  variables_mod.update_starpilot_toggles = lambda: None
+  sys.modules["openpilot.starpilot.common.starpilot_variables"] = variables_mod
+
+
+def _import_lateral():
+  _install_lateral_stubs()
+  _clear_modules(AETHERGRID_MODULE)
+  aethergrid = importlib.import_module(AETHERGRID_MODULE)
+  _install_panel_stubs(aethergrid)
+
+  params_mod = types.ModuleType("openpilot.common.params")
+  params_mod.Params = FakeParams
+  params_mod.UnknownKeyName = Exception
+  sys.modules["openpilot.common.params"] = params_mod
+
+  _clear_modules(PANEL_MODULE, LATERAL_MODULE)
+  importlib.import_module(PANEL_MODULE)
+  return importlib.import_module(LATERAL_MODULE)
+
+
+class TestLateralLaneCenteringRows(unittest.TestCase):
+  def setUp(self):
+    lateral = _import_lateral()
+    self.layout = lateral.StarPilotLateralLayout()
+    self.params = self.layout._params
+    self.rows = {row.id: row for row in self.layout._advanced_rows}
+
+  def test_rows_exist_with_expected_types(self):
+    self.assertIn("LaneCentering", self.rows)
+    self.assertIn("LaneCenterOffset", self.rows)
+    self.assertIn("CameraOffset", self.rows)
+    self.assertEqual(self.rows["LaneCentering"].type, "toggle")
+    self.assertEqual(self.rows["LaneCenterOffset"].type, "value")
+    self.assertEqual(self.rows["CameraOffset"].type, "value")
+
+  def test_visibility_requires_advanced_parent(self):
+    self.params.put_bool("AdvancedLateralTune", False)
+    self.params.put_bool("LaneCentering", True)
+    self.assertFalse(self.rows["LaneCentering"].visible())
+    self.assertFalse(self.rows["LaneCenterOffset"].visible())
+
+  def test_offset_visible_only_while_lane_centering_enabled(self):
+    self.params.put_bool("AdvancedLateralTune", True)
+    self.params.put_bool("LaneCentering", False)
+    self.assertTrue(self.rows["LaneCentering"].visible())
+    self.assertFalse(self.rows["LaneCenterOffset"].visible())
+
+    self.params.put_bool("LaneCentering", True)
+    self.assertTrue(self.rows["LaneCenterOffset"].visible())
+
+  def test_toggle_params_callback(self):
+    self.assertFalse(self.rows["LaneCentering"].get_state())
+    self.rows["LaneCentering"].set_state(True)
+    self.assertTrue(self.params.get_bool("LaneCentering"))
+    self.assertTrue(self.rows["LaneCentering"].get_state())
+    self.rows["LaneCentering"].set_state(False)
+    self.assertFalse(self.params.get_bool("LaneCentering"))
+
+  def test_offset_display_shows_meters(self):
+    self.params.put_float("LaneCenterOffset", 0.25)
+    self.assertEqual(self.rows["LaneCenterOffset"].get_value(), "0.25 m")
+    self.params.put_float("LaneCenterOffset", -0.1)
+    self.assertEqual(self.rows["LaneCenterOffset"].get_value(), "-0.10 m")
+
+  def test_offset_slider_range_step_and_unit(self):
+    calls = []
+    self.layout._show_slider = lambda *args, **kwargs: calls.append((args, kwargs))
+    self.rows["LaneCenterOffset"].on_click()
+    self.assertEqual(len(calls), 1)
+    args, kwargs = calls[0]
+    self.assertEqual(args, ("LaneCenterOffset", -0.5, 0.5))
+    self.assertEqual(kwargs["step"], 0.01)
+    self.assertEqual(kwargs["unit"], " m")
+    self.assertEqual(kwargs["value_type"], "float")
+
+  def test_camera_offset_display_and_slider_contract(self):
+    self.params.put_float("CameraOffset", -0.12)
+    self.assertEqual(self.rows["CameraOffset"].get_value(), "-0.12 m")
+
+    calls = []
+    self.layout._show_slider = lambda *args, **kwargs: calls.append((args, kwargs))
+    self.rows["CameraOffset"].on_click()
+    self.assertEqual(len(calls), 1)
+    args, kwargs = calls[0]
+    self.assertEqual(args, ("CameraOffset", -0.35, 0.35))
+    self.assertEqual(kwargs["step"], 0.01)
+    self.assertEqual(kwargs["unit"], " m")
+    self.assertEqual(kwargs["value_type"], "float")
+
+  def test_slider_confirm_writes_float_param(self):
+    panel = importlib.import_module(PANEL_MODULE)
+    captured = {}
+
+    class FakeDialog:
+      def __init__(self, title, min_v, max_v, step, current, callback, **kwargs):
+        captured["range"] = (min_v, max_v)
+        captured["step"] = step
+        captured["unit"] = kwargs.get("unit")
+        captured["callback"] = callback
+
+    original = panel.AetherSliderDialog
+    panel.AetherSliderDialog = FakeDialog
+    try:
+      self.layout._show_slider("LaneCenterOffset", -0.5, 0.5, step=0.01, unit=" m", value_type="float")
+    finally:
+      panel.AetherSliderDialog = original
+
+    self.assertEqual(captured["range"], (-0.5, 0.5))
+    self.assertEqual(captured["step"], 0.01)
+    self.assertEqual(captured["unit"], " m")
+
+    confirm = sys.modules["openpilot.system.ui.widgets"].DialogResult.CONFIRM
+    captured["callback"](confirm, 0.3)
+    self.assertAlmostEqual(self.params.get_float("LaneCenterOffset"), 0.3)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/starpilot/common/safe_mode.py
+++ b/starpilot/common/safe_mode.py
@@ -33,6 +33,8 @@ SAFE_MODE_MANAGED_KEYS = (
   "SteerKP",
   "SteerLatAccel",
   "SteerRatio",
+  "LaneCentering",
+  "LaneCenterOffset",
   "LaneChanges",
   "LaneChangeTime",
   "LaneDetectionWidth",

--- a/starpilot/common/starpilot_variables.py
+++ b/starpilot/common/starpilot_variables.py
@@ -705,6 +705,7 @@ class StarPilotVariables:
     toggle.use_wheel_speed = self.get_value("WheelSpeed", condition=advanced_custom_ui)
 
     advanced_lateral_tuning = self.get_value("AdvancedLateralTune")
+    toggle.lane_centering = self.get_value("LaneCentering", condition=advanced_lateral_tuning)
     toggle.force_auto_tune = self.get_value("ForceAutoTune", condition=advanced_lateral_tuning and not has_auto_tune and is_torque_car and not is_angle_car)
     # Force-off is also meaningful on manually tuned torque cars: it locks the
     # vehicle-model parameters instead of allowing paramsd to learn over them.
@@ -729,6 +730,7 @@ class StarPilotVariables:
     honda_pid_lateral = toggle.car_make == "honda" and CP.lateralTuning.which() == "pid" and not is_angle_car
     toggle.honda_lateral_pid_kp_scale = self.get_value("HondaLateralPidKpScale", cast=float, condition=honda_pid_lateral, default=1.0, min=0.1, max=4.0)
     toggle.honda_lateral_pid_ki_scale = self.get_value("HondaLateralPidKiScale", cast=float, condition=honda_pid_lateral, default=1.0, min=0.1, max=4.0)
+    toggle.lane_center_offset = self.get_value("LaneCenterOffset", cast=float, condition=advanced_lateral_tuning and toggle.lane_centering, default=0.0, min=-0.5, max=0.5)
 
     advanced_longitudinal_tuning = toggle.openpilot_longitudinal and self.get_value("AdvancedLongitudinalTune")
     ev_vehicle = default_ev_tuning_enabled(CP)

--- a/starpilot/common/tests/test_lane_centering_ui_contract.py
+++ b/starpilot/common/tests/test_lane_centering_ui_contract.py
@@ -1,0 +1,96 @@
+"""Source/JSON contract tests for LaneCentering + LaneCenterOffset UI wiring.
+
+Lightweight: scans Qt sources, the Galaxy layout JSON, and the_galaxy.py
+without importing heavy native dependencies.
+"""
+
+import json
+import re
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_QT_CC = (_REPO_ROOT / "starpilot/ui/qt/offroad/lateral_settings.cc").read_text(encoding="utf-8")
+_QT_H = (_REPO_ROOT / "starpilot/ui/qt/offroad/lateral_settings.h").read_text(encoding="utf-8")
+_GALAXY_PY = (_REPO_ROOT / "starpilot/system/the_galaxy/the_galaxy.py").read_text(encoding="utf-8")
+_GALAXY_LAYOUT = json.loads(
+  (_REPO_ROOT / "starpilot/system/the_galaxy/assets/components/tools/device_settings_layout.json").read_text(encoding="utf-8")
+)
+
+
+def _lateral_section_params():
+  for section in _GALAXY_LAYOUT:
+    if section.get("name") == "Lateral (Steering)":
+      return {p["key"]: p for p in section["params"]}
+  raise AssertionError("Lateral (Steering) section not found in Galaxy layout")
+
+
+def test_galaxy_lane_centering_toggle_under_advanced_lateral():
+  entry = _lateral_section_params()["LaneCentering"]
+  assert entry["data_type"] == "bool"
+  assert entry["ui_type"] == "toggle"
+  assert entry["parent_key"] == "AdvancedLateralTune"
+  assert entry.get("is_parent_toggle") is True, "LaneCentering must parent LaneCenterOffset"
+
+
+def test_galaxy_lane_center_offset_numeric_contract():
+  entry = _lateral_section_params()["LaneCenterOffset"]
+  assert entry["data_type"] == "float"
+  assert entry["ui_type"] == "numeric"
+  assert entry["min"] == -0.5
+  assert entry["max"] == 0.5
+  assert entry["step"] == 0.01
+  assert entry["precision"] == 2
+  assert entry["parent_key"] == "LaneCentering", "offset must nest under LaneCentering so it only shows when enabled"
+
+
+def test_qt_tuple_entries_and_constructor_contract():
+  assert '{"LaneCentering"' in _QT_CC, "LaneCentering tuple entry missing"
+  assert '{"LaneCenterOffset"' in _QT_CC, "LaneCenterOffset tuple entry missing"
+
+  idx = _QT_CC.find('param == "LaneCenterOffset"')
+  assert idx != -1, "LaneCenterOffset constructor branch missing"
+  window = _QT_CC[idx:idx + 400]
+  assert "StarPilotParamValueControl" in window
+  assert re.search(r"-0\.5,\s*0\.5", window), "LaneCenterOffset range must be -0.5..0.5"
+  assert "0.01" in window, "LaneCenterOffset step must be 0.01"
+
+
+def test_qt_camera_offset_numeric_contract():
+  assert '{"CameraOffset"' in _QT_CC, "CameraOffset tuple entry missing"
+
+  idx = _QT_CC.find('param == "CameraOffset"')
+  assert idx != -1, "CameraOffset constructor branch missing"
+  window = _QT_CC[idx:idx + 400]
+  assert "StarPilotParamValueControl" in window
+  assert re.search(r"-0\.35,\s*0\.35", window), "CameraOffset range must be -0.35..0.35"
+  assert "0.01" in window, "CameraOffset step must be 0.01"
+
+
+def test_qt_offset_visibility_gated_on_lane_centering():
+  idx = _QT_CC.find('key == "LaneCenterOffset"')
+  assert idx != -1, "LaneCenterOffset updateToggles branch missing"
+  window = _QT_CC[idx:idx + 300]
+  assert 'params.getBool("LaneCentering")' in window, "offset must only show when centering is enabled"
+
+  keys_idx = _QT_CC.find("forceUpdateKeys")
+  assert '"LaneCentering"' in _QT_CC[keys_idx:keys_idx + 300], "LaneCentering must trigger updateToggles"
+
+
+def test_qt_header_advanced_lateral_keys():
+  idx = _QT_H.find("advancedLateralTuneKeys")
+  assert idx != -1
+  window = _QT_H[idx:idx + 400]
+  assert '"LaneCentering"' in window
+  assert '"LaneCenterOffset"' in window
+  assert '"CameraOffset"' in window
+
+
+def test_galaxy_troubleshoot_advanced_lateral_keys():
+  start = _GALAXY_PY.find("_TROUBLESHOOT_ADVANCED_LATERAL_KEYS")
+  assert start != -1
+  end = _GALAXY_PY.find("]", start)
+  block = _GALAXY_PY[start:end]
+  assert '"LaneCentering"' in block
+  assert '"LaneCenterOffset"' in block

--- a/starpilot/common/tests/test_safe_mode_lane_centering_contract.py
+++ b/starpilot/common/tests/test_safe_mode_lane_centering_contract.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+_SOURCE = (Path(__file__).resolve().parent.parent / "safe_mode.py").read_text(encoding="utf-8")
+
+
+def test_safe_mode_manages_lane_centering_settings():
+  block = _SOURCE[_SOURCE.index("SAFE_MODE_MANAGED_KEYS = ("):_SOURCE.index(")", _SOURCE.index("SAFE_MODE_MANAGED_KEYS = ("))]
+  assert chr(34) + "LaneCentering" + chr(34) in block
+  assert chr(34) + "LaneCenterOffset" + chr(34) in block

--- a/starpilot/common/tests/test_starpilot_variables_contract.py
+++ b/starpilot/common/tests/test_starpilot_variables_contract.py
@@ -1,0 +1,62 @@
+"""Source-contract tests for lane-centering Params (run without importing spv).
+
+These tests assert the exact loader contract by scanning starpilot_variables.py.
+They run standalone without heavy native dependencies (msgq/ipc_pyx.so).
+The loaders are kept in one AdvancedLateralTune block with explicit bounds.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+_STARPILOT_VARIABLES_SOURCE = (
+  Path(__file__).resolve().parent.parent / "starpilot_variables.py"
+).read_text(encoding="utf-8")
+
+
+def _advanced_lateral_block(source: str = _STARPILOT_VARIABLES_SOURCE) -> str:
+  start = source.find("advanced_lateral_tuning = ")
+  assert start != -1, "advanced_lateral_tuning block not found"
+  end = source.find("advanced_longitudinal_tuning = ", start)
+  assert end != -1, "advanced_longitudinal_tuning boundary not found"
+  return source[start:end]
+
+
+def _loader_window(block: str, key: str, before: int = 400, after: int = 400) -> str:
+  idx = block.find(f'"{key}"')
+  assert idx != -1, f"{key} must be loaded inside AdvancedLateralTune block"
+  return block[max(0, idx - before): idx + after]
+
+
+def test_lane_centering_bool_loader_wired_under_advanced_lateral_gate():
+  block = _advanced_lateral_block()
+  window = _loader_window(block, "LaneCentering", before=120, after=200)
+  assert "get_value" in window, "LaneCentering must be loaded via get_value"
+  assert "cast=float" not in window, "LaneCentering must be a bool loader, not float"
+
+
+def test_lane_center_offset_float_loader_clamped_to_half_meter():
+  window = _loader_window(_advanced_lateral_block(), "LaneCenterOffset", before=0, after=400)
+  assert "cast=float" in window, "LaneCenterOffset must be cast to float"
+  assert "min=-0.5" in window, "LaneCenterOffset must clamp min=-0.5"
+  assert "max=0.5" in window, "LaneCenterOffset must clamp max=0.5"
+
+
+def test_lane_centering_loaders_appear_once_each():
+  for key in ("LaneCentering", "LaneCenterOffset"):
+    count = _STARPILOT_VARIABLES_SOURCE.count(f'"{key}"')
+    assert count == 1, f"{key} must be loaded exactly once (got {count})"
+
+
+@pytest.mark.parametrize(
+  "key, lo, hi",
+  [
+    ("LaneCenterOffset", -0.5, 0.5),
+  ],
+)
+def test_offset_keys_use_symmetric_clamps(key, lo, hi):
+  window = _loader_window(_advanced_lateral_block(), key, before=0, after=400)
+  assert f"min={lo}" in window, f"{key} must clamp min={lo}"
+  assert f"max={hi}" in window, f"{key} must clamp max={hi}"

--- a/starpilot/system/the_galaxy/assets/components/tools/device_settings_layout.json
+++ b/starpilot/system/the_galaxy/assets/components/tools/device_settings_layout.json
@@ -124,6 +124,27 @@
         "settings_tier": "advanced"
       },
       {
+        "key": "LaneCentering",
+        "label": "Lane Centering",
+        "description": "Use both recognized lane lines to actively center the vehicle in the lane. Falls back to stock steering when both lane lines are not confidently detected.",
+        "data_type": "bool",
+        "ui_type": "toggle",
+        "is_parent_toggle": true,
+        "parent_key": "AdvancedLateralTune"
+      },
+      {
+        "key": "LaneCenterOffset",
+        "label": "Lane Center Offset",
+        "description": "Shift the target position within the lane, in meters. Negative values move the vehicle toward the left side of the lane; positive values move it toward the right.",
+        "data_type": "float",
+        "ui_type": "numeric",
+        "min": -0.5,
+        "max": 0.5,
+        "step": 0.01,
+        "precision": 2,
+        "parent_key": "LaneCentering"
+      },
+      {
         "key": "AlwaysOnLateral",
         "label": "Always On Lateral",
         "description": "openpilot's steering remains active even when the accelerator or brake pedals are pressed.",

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -959,6 +959,8 @@ _TROUBLESHOOT_ADVANCED_LATERAL_KEYS = [
   "ForceAutoTune",
   "ForceAutoTuneOff",
   "ForceTorqueController",
+  "LaneCentering",
+  "LaneCenterOffset",
 ]
 
 _TROUBLESHOOT_ADVANCED_LONGITUDINAL_KEYS = [

--- a/starpilot/ui/qt/offroad/lateral_settings.cc
+++ b/starpilot/ui/qt/offroad/lateral_settings.cc
@@ -37,6 +37,9 @@ StarPilotLateralPanel::StarPilotLateralPanel(StarPilotSettingsWindow *parent, bo
     {"SteerKP", parent->steerKp != 0 ? QString(tr("Kp Factor (Default: %1)")).arg(QString::number(parent->steerKp, 'f', 2)) : tr("Kp Factor"), tr("<b>How strongly openpilot corrects lane position.</b> Higher is tighter but twitchier; lower is smoother but slower. Auto-learned by default."), ""},
     {"SteerLatAccel", parent->latAccelFactor != 0 ? QString(tr("Lateral Acceleration (Default: %1)")).arg(QString::number(parent->latAccelFactor, 'f', 2)) : tr("Lateral Acceleration"), tr("<b>Maps steering torque to turning response.</b> Increase for sharper turns; decrease for gentler steering. Auto-learned by default."), ""},
     {"SteerRatio", parent->steerRatio != 0 ? QString(tr("Steer Ratio (Default: %1)")).arg(QString::number(parent->steerRatio, 'f', 2)) : tr("Steer Ratio"), tr("<b>The relationship between steering wheel rotation and road wheel angle.</b> Increase if steering feels too quick or twitchy; decrease if it feels too slow or weak. Auto-learned by default."), ""},
+    {"LaneCentering", tr("Lane Centering"), tr("<b>Use both recognized lane lines to actively center the vehicle in the lane.</b> Falls back to stock steering when both lane lines are not confidently detected."), ""},
+    {"LaneCenterOffset", tr("Lane Center Offset"), tr("<b>Shift the target position within the lane, in meters.</b> Negative moves the vehicle toward the left side of the lane; positive moves it toward the right. Only applies while \"Lane Centering\" is active."), ""},
+    {"CameraOffset", tr("Camera Offset"), tr("<b>Virtually shift the camera perspective used by the driving model.</b> Positive values bias the model center left; negative values bias it right. Use only for development."), ""},
     {"ForceAutoTune", tr("Force Auto-Tune On"), tr("<b>Force-enable openpilot's live auto-tuning for \"Friction\" and \"Lateral Acceleration\".</b>"), ""},
     {"ForceAutoTuneOff", tr("Force Auto-Tune Off"), tr("<b>Force-disable openpilot's live auto-tuning for \"Friction\" and \"Lateral Acceleration\" and use the set value instead.</b>"), ""},
     {"ForceTorqueController", tr("Force Torque Controller"), tr("<b>Use torque-based steering control instead of angle-based control for smoother lane keeping, especially in curves.</b>"), ""},
@@ -87,6 +90,10 @@ StarPilotLateralPanel::StarPilotLateralPanel(StarPilotSettingsWindow *parent, bo
     } else if (param == "SteerRatio") {
       std::vector<QString> steerRatioButton{"Reset"};
       lateralToggle = new StarPilotParamValueButtonControl(param, title, desc, icon, parent->steerRatio * 0.5, parent->steerRatio * 1.5, QString(), std::map<float, QString>(), 0.01, false, {}, steerRatioButton, false, false);
+    } else if (param == "LaneCenterOffset") {
+      lateralToggle = new StarPilotParamValueControl(param, title, desc, icon, -0.5, 0.5, tr(" m"), std::map<float, QString>(), 0.01);
+    } else if (param == "CameraOffset") {
+      lateralToggle = new StarPilotParamValueControl(param, title, desc, icon, -0.35, 0.35, tr(" m"), std::map<float, QString>(), 0.01);
 
     } else if (param == "AlwaysOnLateral") {
       StarPilotManageControl *aolToggle = new StarPilotManageControl(param, title, desc, icon);
@@ -182,7 +189,7 @@ StarPilotLateralPanel::StarPilotLateralPanel(StarPilotSettingsWindow *parent, bo
     });
   }
 
-  QSet<QString> forceUpdateKeys = {"ForceAutoTune", "ForceAutoTuneOff", "LateralTune", "NNFF", "NudgelessLaneChange"};
+  QSet<QString> forceUpdateKeys = {"ForceAutoTune", "ForceAutoTuneOff", "LaneCentering", "LateralTune", "NNFF", "NudgelessLaneChange"};
   for (const QString &key : forceUpdateKeys) {
     QObject::connect(static_cast<ToggleControl*>(toggles[key]), &ToggleControl::toggleFlipped, this, &StarPilotLateralPanel::updateToggles);
   }
@@ -370,6 +377,10 @@ void StarPilotLateralPanel::updateToggles() {
       else if (key == "ForceTorqueController") {
         setVisible &= !parent->isAngleCar;
         setVisible &= !parent->isTorqueCar;
+      }
+
+      else if (key == "LaneCenterOffset") {
+        setVisible &= params.getBool("LaneCentering");
       }
 
       else if (key == "LaneChangeTime") {

--- a/starpilot/ui/qt/offroad/lateral_settings.h
+++ b/starpilot/ui/qt/offroad/lateral_settings.h
@@ -24,7 +24,7 @@ private:
 
   std::map<QString, AbstractControl*> toggles;
 
-  QSet<QString> advancedLateralTuneKeys = {"ForceAutoTune", "ForceAutoTuneOff", "ForceTorqueController", "SteerDelay", "SteerFriction", "SteerLatAccel", "SteerKP", "SteerRatio"};
+  QSet<QString> advancedLateralTuneKeys = {"CameraOffset", "ForceAutoTune", "ForceAutoTuneOff", "ForceTorqueController", "LaneCentering", "LaneCenterOffset", "SteerDelay", "SteerFriction", "SteerLatAccel", "SteerKP", "SteerRatio"};
   QSet<QString> aolKeys = {"PauseAOLOnBrake"};
   QSet<QString> laneChangeKeys = {"LaneChangeSmoothing", "LaneChangeTime", "LaneDetectionWidth", "MinimumLaneChangeSpeed", "NudgelessLaneChange", "OneLaneChange"};
   QSet<QString> lateralTuneKeys = {"NNFF", "NNFFLite", "TurnDesires", "NavDesiresAllowed"};


### PR DESCRIPTION
## Overview

This PR adds lane-line-based centering and an adjustable in-lane target offset to the `Dom` branch. It also exposes the existing `CameraOffset` model parameter in the on-device settings UI.

The branch contains one feature commit based directly on `Dom`; it does not include unrelated `paddle5` commits.

## Features

### Lane Centering

`LaneCenteringController` derives a small curvature correction from the midpoint of the detected left and right lane lines, then adds that correction to the final model/turn-adjusted curvature request in `controlsd`.

The correction is deliberately conservative:

- It is only active while lateral control is active and vehicle speed is at least `5 m/s`.
- It requires both lane lines to have probability >= `0.6` and standard deviation <= `0.3 m`.
- It rejects implausible lane widths outside `2.6 m` to `4.8 m`.
- It is disabled during lane changes, invalid/stale `modelV2` data, malformed/non-finite model arrays, or when the feature is off.
- The raw correction is capped at `0.004 1/m`, scaled by a maximum gain of `0.30`, and filtered with a `0.4 s` time constant.
- The controller resets immediately when lateral control is inactive, `modelV2` is invalid, or a lane change starts, preventing residual correction from carrying into an unsafe state.

The correction is applied before the existing downstream curvature and jerk limits, so standard control safety constraints remain in effect.

### Lane Center Offset

`LaneCenterOffset` shifts the target from the geometric lane midpoint while Lane Centering is enabled:

- Range: `-0.50 m` to `+0.50 m`
- Step: `0.01 m`
- Positive values target the right side of the lane.
- Negative values target the left side of the lane.

The setting is hidden unless Lane Centering is enabled.

### Camera Offset UI

`CameraOffset` already exists in `modeld` and in the Galaxy Developer page. This PR additionally exposes it in the on-device Advanced Lateral Tuning panels for both Qt and Raylib UI implementations:

- Range: `-0.35 m` to `+0.35 m`
- Step: `0.01 m`
- Positive values bias the model center left.
- Negative values bias the model center right.

This setting changes the model camera transform and is labeled for development use.

## Integration

- Adds persistent `LaneCentering` and `LaneCenterOffset` Params.
- Loads both values through `starpilot_variables` only under Advanced Lateral Tuning.
- Includes both settings in safe-mode managed keys and Galaxy troubleshooting reset handling.
- Adds Galaxy layout definitions for Lane Centering and Lane Center Offset.
- Adds Qt and Raylib on-device setting rows.

## Validation

- [x] 35 deterministic `LaneCenteringController` tests, including sign behavior, confidence gates, lane-width bounds, malformed input, invalid model state, lane changes, smoothing, reset behavior, and curvature caps.
- [x] Source-contract tests for `controlsd`, StarPilot variable loading, safe-mode handling, Galaxy layout, Qt UI, and Camera Offset UI wiring.
- [x] Raylib lateral-settings unit tests.
- [x] `py_compile` for modified Python files.
- [x] `git diff --check`.
- [ ] Full Qt/on-device build was not run in this environment because the local dependency setup is missing `portaudio.h` while building `pyaudio`.

## Notes

Lane Centering is an additive assist to the existing model path; it is not a replacement for the model path or the stock lateral safety limits. Camera Offset and Lane Center Offset use opposite directional conventions, as documented above, so they should be tuned independently.