### PR TITLE
Wire preAlert sound to Distracted Driver volume control

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -344,6 +344,8 @@ class Soundd:
       AudibleAlert.promptRepeat: self.starpilot_toggles.prompt_volume / 100.0,
       AudibleAlert.promptDistracted: self.starpilot_toggles.promptDistracted_volume / 100.0,
 
+      AudibleAlert.preAlert: self.starpilot_toggles.promptDistracted_volume / 100.0,
+
       AudibleAlert.warningSoft: self.starpilot_toggles.warningSoft_volume / 100.0,
       AudibleAlert.warningImmediate: self.starpilot_toggles.warningImmediate_volume / 100.0,
 


### PR DESCRIPTION
## Problem

The driver monitoring sound refactor introduced `AudibleAlert.preAlert` for the `driverDistracted1` pre-warning (the black "Pay Attention" alert), but it was never added to soundd's `volume_map`. Unmapped sounds fall through to the `1.01` auto-volume sentinel, so with the Alert Volume Controller enabled, setting Distracted Driver volume to Muted silenced `promptDistracted` (the orange warning) while the pre-warning kept playing at auto volume.

## Fix

Map `AudibleAlert.preAlert` to `PromptDistractedVolume`. `preAlert` is only used by `driverDistracted1`, so it follows the same volume control as the rest of the distraction alert chain (the red `warningImmediate` stays on its own Immediate Warning control).