### PR TITLE
Use current traffic conditions in navigation via mapbox API

### DIFF
--- a/starpilot/navigation/route_engine.py
+++ b/starpilot/navigation/route_engine.py
@@ -390,7 +390,7 @@ class NavigationRoute:
 
 
 class MapboxRouteEngine:
-  DIRECTIONS_URL = "https://api.mapbox.com/directions/v5/mapbox/driving"
+  DIRECTIONS_URL = "https://api.mapbox.com/directions/v5/mapbox/driving-traffic"
 
   def __init__(self, session: Any = requests):
     self._session = session


### PR DESCRIPTION
Switches `driving` profile to `driving-traffic` provided by mapbox directions API
When unavailable, mapbox automatically falls back to the existing `driving` profile.
Matches galaxy navigation utility