### PR TITLE
Fix draw_circle_gradient calls to new Vector2 center API (prevent UI crash on engage)

### DIFF
--- a/selfdrive/ui/mici/onroad/hud_renderer.py
+++ b/selfdrive/ui/mici/onroad/hud_renderer.py
@@ -408,7 +408,7 @@ class HudRenderer(Widget):
 
     # draw drop shadow
     circle_radius = 162 // 2
-    rl.draw_circle_gradient(int(x + circle_radius), int(y + circle_radius), circle_radius,
+    rl.draw_circle_gradient(rl.Vector2(x + circle_radius, y + circle_radius), circle_radius,
                             rl.Color(0, 0, 0, int(255 / 2 * alpha)), rl.BLANK)
 
     set_speed_color = rl.Color(255, 255, 255, int(255 * 0.9 * alpha))
@@ -630,7 +630,7 @@ class HudRenderer(Widget):
     center = rl.Vector2(button_rect.x + button_rect.width / 2, button_rect.y + button_rect.height / 2)
     radius = min(button_rect.width, button_rect.height) / 2
 
-    rl.draw_circle_gradient(int(center.x), int(center.y), radius, rl.Color(0, 0, 0, 90), rl.BLANK)
+    rl.draw_circle_gradient(center, radius, rl.Color(0, 0, 0, 90), rl.BLANK)
     rl.draw_circle(int(center.x), int(center.y), radius, fill)
     rl.draw_ring(center, radius - 6, radius, 0, 360, 48, outline)
 

--- a/system/ui/widgets/mici_keyboard.py
+++ b/system/ui/widgets/mici_keyboard.py
@@ -353,7 +353,7 @@ class MiciKeyboard(Widget):
 
           # draw black circle behind selected key
           circle_alpha = int(self._selected_key_filter.x * 225)
-          rl.draw_circle_gradient(int(key_x + key.rect.width / 2), int(key_y + key.rect.height / 2),
+          rl.draw_circle_gradient(rl.Vector2(key_x + key.rect.width / 2, key_y + key.rect.height / 2),
                                   SELECTED_CHAR_FONT_SIZE, rl.Color(0, 0, 0, circle_alpha), rl.BLANK)
         else:
           # move other keys away from selected key a bit


### PR DESCRIPTION
### Motivation
- After the AGNOS/pyray update the `draw_circle_gradient` call signature changed and caused a `TypeError` (wrong arg count) which crashes the on-road UI when engaging, so the gradient calls must be updated to the new center argument form.

### Description
- Update `selfdrive/ui/mici/onroad/hud_renderer.py` to call `rl.draw_circle_gradient` with a `rl.Vector2(...)` center for the set-speed drop shadow and to pass the `center` variable for the prompt-button shadow.
- Update `system/ui/widgets/mici_keyboard.py` to call `rl.draw_circle_gradient` with a `rl.Vector2(...)` center for the selected-key background shadow.
- No visual behavior changes intended beyond using the compatible argument types for the updated `pyray` API.

### Testing
- Ran `git diff --check` to validate diffs and formatting, which reported no issues.
- Ran `python -m compileall -q selfdrive/ui/mici/onroad/hud_renderer.py system/ui/widgets/mici_keyboard.py`, which succeeded with no syntax errors.
- Ran `ruff check selfdrive/ui/mici/onroad/hud_renderer.py system/ui/widgets/mici_keyboard.py`, which returned `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82fc06b6e883229f8be0dec9b96a78)