### PR TITLE
FLM: add guarded custom trial editor

### DIFF
--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -339,6 +339,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"ForceTorqueController", {PERSISTENT, BOOL, "0", "0", 3}},
     {"FLMActiveOverrides", {PERSISTENT, JSON, "{}", "{}", 2}},
     {"FLMActiveProfileId", {PERSISTENT, STRING, "", "", 2}},
+    {"FLMCustomValuesEnabled", {PERSISTENT | DONT_LOG, BOOL, "0", "0", 0}},
     {"FLMSubmittedTune", {CLEAR_ON_MANAGER_START, JSON, "{}", "{}"}},
     {"FLMTrialBaseline", {PERSISTENT | DONT_LOG, JSON, "{}", "{}"}},
     {"FLMTrialApplied", {PERSISTENT, BOOL, "0", "0", 2}},

--- a/starpilot/system/the_galaxy/assets/components/tools/device_settings_layout.json
+++ b/starpilot/system/the_galaxy/assets/components/tools/device_settings_layout.json
@@ -4104,6 +4104,15 @@
         "settings_tier": "simple"
       },
       {
+        "key": "FLMCustomValuesEnabled",
+        "label": "Custom FLM Values",
+        "description": "Show the custom FLM trial editor. Numeric changes are limited to 20% from the values captured by the latest analysis; complete another drive and analysis to reset the range.",
+        "data_type": "bool",
+        "ui_type": "toggle",
+        "parent_key": "GalaxyDeveloperMode",
+        "settings_tier": "advanced"
+      },
+      {
         "key": "AlphaLongitudinalEnabled",
         "label": "openpilot Longitudinal Control (Alpha)",
         "description": "Enable openpilot longitudinal control for vehicles that support it. This replaces the vehicle's stock ACC and may disable automatic emergency braking. Changing this setting restarts the driving stack.",

--- a/starpilot/system/the_galaxy/assets/components/tools/tuning.css
+++ b/starpilot/system/the_galaxy/assets/components/tools/tuning.css
@@ -10,6 +10,7 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--border-radius-md);
   margin-top: var(--margin-base);
+  min-width: 0;
   padding: var(--padding-base);
 }
 
@@ -382,6 +383,144 @@
   color: var(--text-muted);
   font-size: var(--font-size-xs);
   padding: 0.15rem 0.45rem;
+}
+
+.flmCustomField input[type="number"] {
+  background: var(--input-bg);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius-sm);
+  box-sizing: border-box;
+  color: var(--text-color);
+  max-width: 100%;
+  min-width: 0;
+  padding: var(--padding-sm);
+  width: 100%;
+}
+
+.flmCustomTrial {
+  border-color: rgba(139, 108, 197, 0.45);
+}
+
+.flmCustomPresetBar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-xs);
+  margin-top: var(--margin-base);
+}
+
+.flmCustomBadge {
+  background: var(--main-fg);
+  border-radius: 999px;
+  color: var(--main-bg);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-demi-bold);
+  padding: 0.2rem 0.55rem;
+}
+
+.flmCustomSection {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: var(--margin-base);
+  padding-top: var(--padding-base);
+}
+
+.flmCustomSection > h4 {
+  margin-top: 0;
+}
+
+.flmCustomGrid {
+  display: grid;
+  gap: var(--gap-sm);
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.flmFrictionGrid {
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.flmCustomField {
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--border-radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  min-width: 0;
+  padding: var(--padding-sm);
+}
+
+.flmCustomFieldHeading {
+  align-items: flex-start;
+  display: flex;
+  gap: var(--gap-xs);
+  justify-content: space-between;
+}
+
+.flmCustomFieldHeading > span {
+  font-weight: var(--font-weight-demi-bold);
+}
+
+.flmControlHelpButton {
+  align-items: center;
+  background: rgba(139, 108, 197, 0.18);
+  border: 1px solid rgba(139, 108, 197, 0.55);
+  border-radius: 50%;
+  color: var(--text-color);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 1.35rem;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-demi-bold);
+  height: 1.35rem;
+  justify-content: center;
+  padding: 0;
+  width: 1.35rem;
+}
+
+.flmControlHelpButton[aria-expanded="true"] {
+  background: var(--main-fg);
+  color: var(--main-bg);
+}
+
+.flmControlHelp {
+  background: rgba(139, 108, 197, 0.09);
+  border: 1px solid rgba(139, 108, 197, 0.28);
+  border-radius: var(--border-radius-sm);
+  color: var(--text-color);
+  font-size: var(--font-size-xs);
+  padding: var(--padding-sm);
+}
+
+.flmControlHelp p {
+  line-height: 1.4;
+  margin: 0 0 var(--margin-xs);
+}
+
+.flmControlHelp p:last-child {
+  margin-bottom: 0;
+}
+
+.flmControlAnalysisHelp {
+  border-top: 1px solid rgba(139, 108, 197, 0.28);
+  margin-top: var(--margin-sm);
+  padding-top: var(--padding-sm);
+}
+
+.flmControlAnalysisHelp > div {
+  margin-top: var(--margin-xs);
+}
+
+.flmCustomField small,
+.flmCustomField code {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.flmCustomBoolean input {
+  align-self: flex-start;
+  min-height: 1.2rem;
+  min-width: 1.2rem;
 }
 
 @media only screen and (max-width: 900px) {

--- a/starpilot/system/the_galaxy/assets/components/tools/tuning.js
+++ b/starpilot/system/the_galaxy/assets/components/tools/tuning.js
@@ -16,9 +16,14 @@ const state = reactive({
   routeProgress: 0,
   routeTotal: 0,
   connectDongleId: "",
-  workspace: { reports: [], savedTunes: [], activeTrial: null, status: {} },
+  workspace: { reports: [], savedTunes: [], customValuesEnabled: false, activeTrial: null, status: {} },
   status: {},
   report: null,
+  customTrialSchema: null,
+  customTrialPreset: "",
+  customTrialValues: null,
+  customTrialHelpKey: "",
+  loadingCustomTrial: false,
   feedbackAccepted: [],
   feedbackIgnored: [],
   feedbackNotes: "",
@@ -55,6 +60,18 @@ function formatReportSegmentRanges(report) {
 function safeCount(value) {
   const n = Number(value)
   return Number.isFinite(n) ? n : 0
+}
+
+function formatBytes(value) {
+  const bytes = Math.max(0, safeCount(value))
+  if (bytes < 1024) return `${Math.round(bytes)} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+function cloneJson(value) {
+  return value == null ? value : JSON.parse(JSON.stringify(value))
 }
 
 function formatRouteLength(route) {
@@ -229,6 +246,41 @@ function syncFeedbackState(report) {
   state.feedbackNotes = typeof feedback.notes === "string" ? feedback.notes : ""
 }
 
+function selectCustomPreset(presetKey) {
+  const preset = state.customTrialSchema?.presets?.[presetKey]
+  if (!preset?.values) return
+  state.customTrialPreset = presetKey
+  state.customTrialValues = cloneJson(preset.values)
+}
+
+async function loadCustomTrialSchema(reportId, preferredPreset = "") {
+  state.customTrialSchema = null
+  state.customTrialValues = null
+  state.customTrialPreset = ""
+  state.customTrialHelpKey = ""
+  if (!state.workspace?.customValuesEnabled || !reportId || state.report?.car?.controlPath !== "torque") return
+  try {
+    state.loadingCustomTrial = true
+    const response = await fetch(`/api/flm/report/${encodeURIComponent(reportId)}/custom-trial`, { cache: "no-store" })
+    const payload = await response.json()
+    if (!response.ok) throw new Error(payload.error || "Failed to load custom trial controls.")
+    state.customTrialSchema = payload
+    selectCustomPreset(preferredPreset || payload.defaultPreset || "current")
+  } catch (error) {
+    state.error = error?.message || "Failed to load custom trial controls."
+  } finally {
+    state.loadingCustomTrial = false
+  }
+}
+
+async function fillCustomPreset(presetKey) {
+  if (presetKey !== "current") {
+    selectCustomPreset(presetKey)
+    return
+  }
+  await loadCustomTrialSchema(state.report?.reportId, "current")
+}
+
 async function loadReport(reportId) {
   if (!reportId) return
   try {
@@ -238,6 +290,7 @@ async function loadReport(reportId) {
     state.report = payload
     syncFeedbackState(payload)
     await fetchWorkspace()
+    await loadCustomTrialSchema(reportId)
   } catch (error) {
     state.error = error?.message || "Failed to load tuning report."
   }
@@ -255,6 +308,10 @@ async function deleteReport(reportId) {
 
     if (state.report?.reportId === reportId) {
       state.report = null
+      state.customTrialSchema = null
+      state.customTrialValues = null
+      state.customTrialPreset = ""
+      state.customTrialHelpKey = ""
       syncFeedbackState(null)
     }
     state.workspace = payload.workspace || state.workspace
@@ -273,6 +330,8 @@ async function fetchStatus() {
     const response = await fetch("/api/flm/status")
     const payload = await response.json()
     if (!response.ok) throw new Error(payload.error || "Failed to load tuning status.")
+    const customValuesWereEnabled = !!state.workspace?.customValuesEnabled
+    const customValuesEnabled = !!payload.customValuesEnabled
     state.status = {
       ...(payload.status || {}),
       isOnroad: !!payload.isOnroad,
@@ -283,6 +342,17 @@ async function fetchStatus() {
         activeTrial: payload.activeTrial,
         reports: payload.reports || state.workspace.reports,
         savedTunes: payload.savedTunes || state.workspace.savedTunes,
+        customValuesEnabled,
+      }
+    }
+    if (customValuesEnabled !== customValuesWereEnabled) {
+      if (customValuesEnabled && state.report?.reportId) {
+        await loadCustomTrialSchema(state.report.reportId)
+      } else if (!customValuesEnabled) {
+        state.customTrialSchema = null
+        state.customTrialValues = null
+        state.customTrialPreset = ""
+        state.customTrialHelpKey = ""
       }
     }
     const reportId = state.status.reportId
@@ -413,10 +483,85 @@ async function applyProfile(profileId) {
     const payload = await response.json()
     if (!response.ok) throw new Error(payload.error || "Failed to apply trial profile.")
     state.error = ""
-    await fetchWorkspace()
+    await Promise.all([fetchWorkspace(), loadCustomTrialSchema(state.report.reportId, "current")])
     showSnackbar(payload.message || "Trial profile applied.")
   } catch (error) {
     state.error = error?.message || "Failed to apply trial profile."
+    showSnackbar(state.error, "error")
+  } finally {
+    state.runningAction = false
+  }
+}
+
+function setCustomGenericValue(key, value) {
+  if (!state.customTrialValues) return
+  state.customTrialPreset = "custom"
+  state.customTrialValues = {
+    ...state.customTrialValues,
+    genericParams: {
+      ...(state.customTrialValues.genericParams || {}),
+      [key]: value,
+    },
+  }
+}
+
+function setCustomFrictionValue(index, value) {
+  if (!state.customTrialValues || !state.customTrialSchema) return
+  const family = state.customTrialSchema.controls.frictionCurve.family
+  const currentOverrides = state.customTrialValues.flmOverrides || {}
+  const currentFamily = currentOverrides.baseFrictionThresholds?.[family] || {}
+  const values = [...(currentFamily.values || [])]
+  values[index] = value
+  state.customTrialPreset = "custom"
+  state.customTrialValues = {
+    ...state.customTrialValues,
+    flmOverrides: {
+      ...currentOverrides,
+      baseFrictionThresholds: {
+        ...(currentOverrides.baseFrictionThresholds || {}),
+        [family]: { ...currentFamily, values },
+      },
+    },
+  }
+}
+
+function setCustomKnobValue(key, value) {
+  if (!state.customTrialValues) return
+  const currentOverrides = state.customTrialValues.flmOverrides || {}
+  state.customTrialPreset = "custom"
+  state.customTrialValues = {
+    ...state.customTrialValues,
+    flmOverrides: {
+      ...currentOverrides,
+      vehicleKnobs: {
+        ...(currentOverrides.vehicleKnobs || {}),
+        [key]: value,
+      },
+    },
+  }
+}
+
+async function applyCustomTrial() {
+  if (!state.workspace?.customValuesEnabled || !state.report?.reportId || !state.customTrialValues || state.runningAction || state.status?.isOnroad) return
+  const knobCount = safeCount(state.customTrialSchema?.vehicleKnobCount)
+  if (!window.confirm(
+    `Apply this exact custom FLM trial with ${knobCount} vehicle controls? Revert Trial will restore the settings from before the FLM trial. Apply while parked and evaluate changes cautiously.`
+  )) return
+
+  state.runningAction = true
+  try {
+    const response = await fetch(`/api/flm/report/${encodeURIComponent(state.report.reportId)}/custom-trial`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(state.customTrialValues),
+    })
+    const payload = await response.json()
+    if (!response.ok) throw new Error(payload.error || "Failed to apply custom FLM trial.")
+    state.error = ""
+    state.workspace = payload.workspace || state.workspace
+    showSnackbar(payload.message || "Custom FLM trial applied.")
+  } catch (error) {
+    state.error = error?.message || "Failed to apply custom FLM trial."
     showSnackbar(state.error, "error")
   } finally {
     state.runningAction = false
@@ -458,6 +603,7 @@ async function applySavedTune(tuneId) {
     if (!response.ok) throw new Error(payload.error || "Failed to apply saved tune.")
     state.error = ""
     state.workspace = payload.workspace || state.workspace
+    await loadCustomTrialSchema(state.report?.reportId, "current")
     showSnackbar(payload.message || "Saved tune applied.")
   } catch (error) {
     state.error = error?.message || "Failed to apply saved tune."
@@ -556,6 +702,7 @@ async function selectPath(pathKey) {
     if (!response.ok) throw new Error(payload.error || "Failed to select tuning path.")
     state.report = payload.report
     syncFeedbackState(state.report)
+    await loadCustomTrialSchema(state.report.reportId)
     showSnackbar(payload.message || "Tuning path selected.")
   } catch (error) {
     state.error = error?.message || "Failed to select tuning path."
@@ -647,7 +794,7 @@ async function saveFeedback() {
       profiles: payload.profiles || state.report.profiles,
     }
     syncFeedbackState(state.report)
-    await fetchWorkspace()
+    await Promise.all([fetchWorkspace(), loadCustomTrialSchema(state.report.reportId)])
     showSnackbar(payload.message || "Feedback saved.")
   } catch (error) {
     state.error = error?.message || "Failed to save tuning feedback."
@@ -806,7 +953,7 @@ function comparisonValueChanged(row) {
 }
 
 function renderTuneComparison() {
-  const rows = tuneComparisonRows()
+  const rows = tuneComparisonRows().filter(comparisonValueChanged)
   if (!rows.length) return ""
   const profile = activeTrialProfile()
   const angleControl = state.report?.car?.controlPath === "angle"
@@ -984,6 +1131,205 @@ function renderTrackingOverview() {
         `)}
       </div>
     </div>
+  `
+}
+
+function toggleCustomTrialHelp(helpKey, event) {
+  event?.preventDefault?.()
+  event?.stopPropagation?.()
+  state.customTrialHelpKey = state.customTrialHelpKey === helpKey ? "" : helpKey
+}
+
+function renderCustomTrialHelp(help) {
+  if (!help?.summary) return ""
+  const analysis = Array.isArray(help.analysis) ? help.analysis : []
+  return html`
+    <div class="flmControlHelp">
+      <p>${help.summary}</p>
+      ${help.more ? html`<p><strong>${help.moreLabel || "Higher value"}:</strong> ${help.more}</p>` : ""}
+      ${help.less ? html`<p><strong>${help.lessLabel || "Lower value"}:</strong> ${help.less}</p>` : ""}
+      ${help.whyThisControl ? html`<p><strong>Why FLM uses it:</strong> ${help.whyThisControl}</p>` : ""}
+      ${analysis.length ? html`
+        <div class="flmControlAnalysisHelp">
+          <strong>Why this analysis selected it</strong>
+          ${analysis.map((rationale) => html`
+            <div>
+              ${rationale.observedBehavior ? html`<p><strong>Observed:</strong> ${rationale.observedBehavior}</p>` : ""}
+              ${rationale.likelyInterpretation ? html`<p><strong>Interpretation:</strong> ${rationale.likelyInterpretation}</p>` : ""}
+              ${rationale.primaryAdjustment ? html`<p><strong>Suggested move:</strong> ${rationale.primaryAdjustment}</p>` : ""}
+              ${rationale.whyThisKnob ? html`<p><strong>Rationale:</strong> ${rationale.whyThisKnob}</p>` : ""}
+              ${rationale.logSupport ? html`<p><strong>Log support:</strong> ${rationale.logSupport}</p>` : ""}
+            </div>
+          `)}
+        </div>
+      ` : ""}
+    </div>
+  `
+}
+
+function renderCustomFieldHeading(label, helpKey, help) {
+  return html`
+    <div class="flmCustomFieldHeading">
+      <span>${label}</span>
+      ${help?.summary ? html`
+        <button
+          type="button"
+          class="flmControlHelpButton"
+          title="Explain what this control changes"
+          aria-label="Explain ${label}"
+          aria-expanded="${() => state.customTrialHelpKey === helpKey}"
+          @click="${event => toggleCustomTrialHelp(helpKey, event)}">?</button>
+      ` : ""}
+    </div>
+    ${() => state.customTrialHelpKey === helpKey ? renderCustomTrialHelp(help) : ""}
+  `
+}
+
+function renderCustomTrialEditor() {
+  if (!state.workspace?.customValuesEnabled) return ""
+  if (state.loadingCustomTrial) {
+    return html`<section class="flmCard"><h3>Custom Active Trial</h3><p class="longManeuverMuted">Loading every available FLM control...</p></section>`
+  }
+  const schema = state.customTrialSchema
+  const values = state.customTrialValues
+  if (!schema || !values) return ""
+  const genericControls = schema.controls?.genericParams || []
+  const friction = schema.controls?.frictionCurve || {}
+  const frictionValues = values.flmOverrides?.baseFrictionThresholds?.[friction.family]?.values || []
+  const vehicleControls = schema.controls?.vehicleKnobs || []
+  return html`
+    <section class="flmCard flmCustomTrial">
+      <div class="flmCardHeader">
+        <div>
+          <h3>Custom Active Trial</h3>
+          <p class="longManeuverMuted">
+            Start from the analysis result, then edit every supported value. This report exposes ${schema.vehicleKnobCount} vehicle controls plus generic settings and the five-point ${friction.family} friction curve.
+          </p>
+        </div>
+        <button
+          class="longManeuverButton"
+          disabled="${() => state.runningAction || state.status?.isOnroad || !state.customTrialValues || state.workspace?.activeTrial?.rollbackAvailable === false}"
+          @click="${applyCustomTrial}">
+          Apply Custom Trial
+        </button>
+      </div>
+
+      <div class="flmCustomPresetBar">
+        <strong>Fill from:</strong>
+        ${Object.entries(schema.presets || {}).map(([key, preset]) => html`
+          <button
+            class="${() => `longManeuverButton ${state.customTrialPreset === key ? "selected" : ""}`}"
+            title="${preset.clippedToAnalysisLimits ? "Some values were clipped to this analysis's 20% custom range." : ""}"
+            disabled="${() => state.runningAction || state.loadingCustomTrial}"
+            @click="${() => fillCustomPreset(key)}">
+            ${preset.label}${preset.clippedToAnalysisLimits ? " (limited)" : ""}
+          </button>
+        `)}
+        ${() => state.customTrialPreset === "custom" ? html`<span class="flmCustomBadge">Edited</span>` : ""}
+      </div>
+
+      <div class="flmTrackingNotice">
+        Custom trials force Advanced Lateral Tune on and automatic torque tuning off so the entered values remain active. Each numeric field is limited to ${schema.changeLimitPercent}% above or below the Current values captured by this analysis; zero-value controls may move by one step. Fill presets are clipped to that window. Drive with the trial and complete a new analysis to reset the limits. Apply only while parked; stay ready to steer and use Revert Trial if behavior is not clearly better.
+      </div>
+
+      <div class="flmCustomSection">
+        <h4>Generic Lateral Settings</h4>
+        <div class="flmCustomGrid">
+          ${genericControls.map((control) => control.type === "boolean" ? html`
+            <div class="flmCustomField flmCustomBoolean">
+              ${renderCustomFieldHeading(control.label, `generic:${control.key}`, control.help)}
+              <input
+                type="checkbox"
+                aria-label="${control.label}"
+                checked="${() => !!state.customTrialValues?.genericParams?.[control.key]}"
+                @change="${event => setCustomGenericValue(control.key, event.target.checked)}" />
+              <code>${control.key}</code>
+            </div>
+          ` : html`
+            <div class="flmCustomField">
+              ${renderCustomFieldHeading(control.label, `generic:${control.key}`, control.help)}
+              <input
+                type="number"
+                aria-label="${control.label}"
+                min="${control.min}"
+                max="${control.max}"
+                step="${control.precision}"
+                value="${() => state.customTrialValues?.genericParams?.[control.key] ?? ""}"
+                @input="${event => setCustomGenericValue(control.key, event.target.value)}" />
+              <small>Analysis value ${control.analysisBaseline}; allowed ${control.min} to ${control.max}, step ${control.precision}</small>
+              <code>${control.key}</code>
+            </div>
+          `)}
+        </div>
+      </div>
+
+      <div class="flmCustomSection">
+        <h4>${friction.family} Friction Threshold Curve</h4>
+        <div class="flmCustomGrid flmFrictionGrid">
+          ${(friction.speedKnots || []).map((speed, index) => {
+            const limit = friction.valueLimits?.[index] || friction
+            return html`
+            <div class="flmCustomField">
+              ${renderCustomFieldHeading(
+                `${Number(speed).toFixed(0)} m/s (${Math.round(Number(speed) * 3.6)} km/h, ${Math.round(Number(speed) * 2.23694)} mph)`,
+                `friction:${index}`,
+                friction.help,
+              )}
+              <input
+                type="number"
+                aria-label="${friction.family} friction threshold at ${Number(speed).toFixed(0)} meters per second"
+                min="${limit.min}"
+                max="${limit.max}"
+                step="${friction.precision}"
+                value="${() => state.customTrialValues?.flmOverrides?.baseFrictionThresholds?.[friction.family]?.values?.[index] ?? ""}"
+                @input="${event => setCustomFrictionValue(index, event.target.value)}" />
+              <small>Analysis value ${limit.analysisBaseline}; allowed ${limit.min} to ${limit.max}, step ${friction.precision}</small>
+            </div>
+          `})}
+        </div>
+      </div>
+
+      <div class="flmCustomSection">
+        <div class="flmCardHeader">
+          <div>
+            <h4>All Vehicle FLM Controls (${vehicleControls.length})</h4>
+            <p class="longManeuverMuted">Every field is submitted and becomes part of the active custom trial.</p>
+          </div>
+        </div>
+        <div class="flmCustomGrid">
+          ${vehicleControls.map((control) => html`
+            <div class="flmCustomField">
+              ${renderCustomFieldHeading(control.label, `vehicle:${control.key}`, control.help)}
+              <input
+                type="number"
+                aria-label="${control.label}"
+                min="${control.min}"
+                max="${control.max}"
+                step="${control.precision}"
+                value="${() => state.customTrialValues?.flmOverrides?.vehicleKnobs?.[control.key] ?? ""}"
+                @input="${event => setCustomKnobValue(control.key, event.target.value)}" />
+              <small>Analysis value ${control.analysisBaseline}; allowed ${control.min} to ${control.max}, step ${control.precision}</small>
+              <code title="${control.key}">${control.key}</code>
+            </div>
+          `)}
+        </div>
+      </div>
+
+      <div class="longManeuverActions">
+        <button
+          class="longManeuverButton"
+          disabled="${() => state.runningAction || state.status?.isOnroad || state.workspace?.activeTrial?.rollbackAvailable === false}"
+          @click="${applyCustomTrial}">
+          Apply Exact Custom Values
+        </button>
+        <button
+          class="longManeuverButton"
+          disabled="${() => state.runningAction || !schema.presets?.recommended}"
+          @click="${() => selectCustomPreset(schema.presets?.recommended ? "recommended" : schema.defaultPreset)}">
+          Reset Form to Recommended
+        </button>
+      </div>
+    </section>
   `
 }
 
@@ -1423,6 +1769,8 @@ export function Tuning() {
               ${((primaryPath()?.suggestions) || []).map((suggestion) => renderSuggestion(suggestion))}
             </div>
           </section>
+
+          ${() => renderCustomTrialEditor()}
 
           <section class="flmCard">
             <h3>Trial Profiles</h3>

--- a/starpilot/system/the_galaxy/flm_workspace.py
+++ b/starpilot/system/the_galaxy/flm_workspace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -84,6 +85,8 @@ FLM_ADVANCED_LATERAL_PARAM_KEYS = {
   "SteerRatio",
 }
 FLM_TRIAL_BASELINE_PARAM = "FLMTrialBaseline"
+FLM_CUSTOM_VALUES_PARAM = "FLMCustomValuesEnabled"
+CUSTOM_TRIAL_CHANGE_LIMIT = 0.20
 
 GENERIC_PARAM_METADATA = {
   "SteerDelay": {"min": 0.01, "max": 1.0, "precision": 0.001, "deltaType": "absolute", "safeLiveTrial": True},
@@ -91,6 +94,62 @@ GENERIC_PARAM_METADATA = {
   "SteerKP": {"min": 0.1, "max": 1.5, "precision": 0.001, "deltaType": "absolute", "safeLiveTrial": True},
   "SteerLatAccel": {"min": 0.5, "max": 5.0, "precision": 0.001, "deltaType": "absolute", "safeLiveTrial": True},
   "SteerRatio": {"min": 5.0, "max": 25.0, "precision": 0.001, "deltaType": "absolute", "safeLiveTrial": True},
+}
+
+CUSTOM_GENERIC_PARAM_LABELS = {
+  "UseAutoSteerDelay": "Automatic steer delay",
+  "SteerDelay": "Steer delay",
+  "SteerFriction": "Steer friction",
+  "SteerKP": "Steer KP",
+  "SteerLatAccel": "Steer lateral acceleration",
+  "SteerRatio": "Steer ratio",
+}
+CUSTOM_GENERIC_CONTROL_HELP = {
+  "UseAutoSteerDelay": {
+    "summary": "Chooses whether StarPilot learns the full steering delay or uses the manual SteerDelay value.",
+    "moreLabel": "On",
+    "more": "The learned delay is active and the manual SteerDelay field is ignored.",
+    "lessLabel": "Off",
+    "less": "The entered SteerDelay becomes active, so its timing must match the car closely.",
+    "whyThisControl": "Delay affects timing rather than steering strength, so FLM keeps learning enabled unless a manual delay trial is intentional.",
+  },
+  "SteerDelay": {
+    "summary": "The full time in seconds between a steering command and the vehicle's response.",
+    "more": "Assumes a slower steering system and aligns control farther ahead. Too high can make transitions arrive early.",
+    "less": "Assumes a quicker response. Too low can leave turn-in and unwind behind the requested path.",
+    "whyThisControl": "This is a timing calibration, not a direct steering-strength control.",
+  },
+  "SteerFriction": {
+    "summary": "The torque compensation used to overcome steering-system friction around small errors and direction changes.",
+    "more": "Adds stronger friction compensation. It can wake up a reluctant response, but too much can make center corrections busy.",
+    "less": "Softens friction compensation. It can reduce twitch, but too little can create hesitation or a dead feeling.",
+    "whyThisControl": "Used to calm chatter or wake up low-speed response without pretending the whole torque map is wrong.",
+  },
+  "SteerKP": {
+    "summary": "The proportional feedback gain applied to lateral-acceleration tracking error.",
+    "more": "Corrects tracking error more strongly and quickly; too high can oscillate or feel nervous.",
+    "less": "Corrects more gently; too low can feel slow and leave persistent path error.",
+    "whyThisControl": "This changes feedback correction, while feedforward knobs change the predicted steering command.",
+  },
+  "SteerLatAccel": {
+    "summary": "The estimated lateral acceleration produced by one unit of steering torque.",
+    "more": "Tells the controller the car is more responsive, so it commands less torque for the same lateral-acceleration target.",
+    "less": "Tells the controller the car is less responsive, so it commands more torque for the same target.",
+    "whyThisControl": "This is a whole-car torque calibration; it should not be treated as a simple aggressiveness slider.",
+  },
+  "SteerRatio": {
+    "summary": "The steering-wheel-to-road-wheel geometry ratio used by the vehicle model.",
+    "more": "Assumes more steering-wheel rotation is required for the same road-wheel angle and changes the calculated curvature accordingly.",
+    "less": "Assumes less steering-wheel rotation is required for the same road-wheel angle.",
+    "whyThisControl": "A wrong ratio creates broad geometry and curve-tracking errors; it is not a phase-specific cleanup knob.",
+  },
+}
+CUSTOM_FRICTION_METADATA = {
+  "min": 0.0,
+  "max": 1.0,
+  "precision": 0.001,
+  "deltaType": "absolute",
+  "safeLiveTrial": True,
 }
 
 FLM_REFERENCE_MODEL = {
@@ -2696,6 +2755,699 @@ def select_report_path(report_id: str, path_key: str) -> dict[str, Any]:
   }
 
 
+def _custom_knob_label(symbol: str) -> str:
+  suffix = str(symbol).split(".", 1)[-1]
+  aliases = {"ff": "Feed Forward", "kp": "KP"}
+  return " ".join(aliases.get(word, word.capitalize()) for word in suffix.split("_"))
+
+
+def _custom_help(summary: str, more: str, less: str, why: str,
+                 more_label: str = "Higher value", less_label: str = "Lower value") -> dict[str, Any]:
+  return {
+    "summary": summary,
+    "moreLabel": more_label,
+    "more": more,
+    "lessLabel": less_label,
+    "less": less,
+    "whyThisControl": why,
+  }
+
+
+def _custom_vehicle_knob_help(symbol: str) -> dict[str, Any]:
+  suffix = str(symbol).split(".", 1)[-1]
+  side = "left turns" if suffix.endswith("_left") else "right turns" if suffix.endswith("_right") else "both directions"
+  analysis_why = _why_this_knob({"type": "vehicle_knob", "symbol": symbol})
+
+  if suffix.startswith("ff_gain_"):
+    return _custom_help(
+      f"Scales the car-specific feedforward contribution for {side} through its nonlinear operating band.",
+      f"Adds more predicted steering for {side}; response becomes stronger, but too much can overshoot.",
+      f"Adds less predicted steering for {side}; response becomes calmer, but too little can lag or run wide.",
+      analysis_why,
+    )
+  if suffix.startswith("turn_in_boost_"):
+    return _custom_help(
+      f"Changes the extra feedforward applied while entering {side}, with the strongest effect at lower speeds.",
+      "Makes curve entry quicker and more eager; too much can dive into the curve or spike past the plan.",
+      "Makes curve entry gentler; too little can delay turn-in.",
+      analysis_why,
+    )
+  if suffix.startswith("base_unwind_taper_"):
+    return _custom_help(
+      f"Reduces the base feedforward contribution while unwinding {side} through the vehicle's tuned speed window.",
+      "Removes more base feedforward on exit, so steering releases sooner; too much can release abruptly.",
+      "Keeps more base feedforward on exit; too little reduction can make steering hang on.",
+      "This separates the vehicle's base unwind behavior from its additional nonlinear feedforward layer.",
+    )
+  if suffix.startswith("unwind_taper_"):
+    return _custom_help(
+      f"Tapers the additional feedforward contribution while unwinding {side}.",
+      "Removes more feedforward on exit, making release quicker; too much can snap back.",
+      "Keeps more feedforward on exit; too little taper can make steering drag past the intended release.",
+      analysis_why,
+    )
+  if suffix == "center_taper_max":
+    return _custom_help(
+      "Sets the maximum feedforward reduction near straight-ahead steering in its normal speed band.",
+      "Calms more near-center activity, but too much can make light corrections feel lazy.",
+      "Preserves more near-center authority, but too little can leave straight-road nibbling.",
+      FLM_REFERENCE_MODEL["families"]["center_taper"]["reason"],
+    )
+  if suffix == "highway_center_taper_max":
+    return _custom_help(
+      "Sets the maximum feedforward reduction near center at highway speeds.",
+      "Calms more highway micro-correction activity, but too much can delay gentle lane-centering corrections.",
+      "Preserves more highway center authority, but too little can leave the wheel busy.",
+      "This isolates high-speed near-center behavior from normal curve authority.",
+    )
+  if suffix == "center_output_taper_max":
+    return _custom_help(
+      "Sets the maximum reduction of final steering output near center in the vehicle-specific speed band.",
+      "Reduces more final output and can calm center activity; too much can make the car reluctant around center.",
+      "Leaves more final output available; too little taper can keep small corrections active.",
+      "This acts on final output near center rather than changing the whole feedforward map.",
+    )
+  if suffix.startswith("center_deadband_"):
+    speed_band = suffix.removeprefix("center_deadband_").removesuffix("_deg").replace("_", " ")
+    return _custom_help(
+      f"Adds a steering-angle deadband around center at the {speed_band} speed knot; neighboring speeds are interpolated.",
+      "Ignores a larger tiny angle mismatch and can stop chatter; too much can delay light corrections.",
+      "Ignores less mismatch and stays more responsive; too little may leave center reversals active.",
+      analysis_why,
+    )
+  if suffix.startswith("turn_in_threshold_reduction_"):
+    return _custom_help(
+      f"Reduces the small-error friction threshold during turn-in for {side}.",
+      "Lowers the threshold more, so friction compensation wakes sooner on entry; too much can feel twitchy.",
+      "Keeps a higher entry threshold, making response calmer but potentially more reluctant.",
+      analysis_why,
+    )
+  if suffix.startswith("unwind_threshold_increase_"):
+    return _custom_help(
+      f"Raises the small-error friction threshold during unwind for {side}.",
+      "Softens more small friction corrections during release; too much can leave exit error uncorrected.",
+      "Keeps friction compensation more active during release; too little can make unwind busy.",
+      analysis_why,
+    )
+  if suffix == "center_friction_threshold_gain":
+    return _custom_help(
+      "Raises the friction threshold near straight-ahead steering in the vehicle-specific speed band.",
+      "Mutes more tiny friction corrections and can calm center activity; too much can create reluctance.",
+      "Lets friction compensation engage sooner; too little can leave center chatter.",
+      FLM_REFERENCE_MODEL["families"]["friction_threshold_curve"]["reason"],
+    )
+  if suffix.startswith("crawl_turn_in_ff_boost_"):
+    return _custom_help(
+      f"Adds feedforward while entering {side} at crawl speed when the requested angle is not being reached.",
+      "Adds more crawl-speed entry assistance; too much can tug or enter the turn too sharply.",
+      "Adds less assistance; too little can leave parking-lot and junction turns unwilling.",
+      analysis_why,
+    )
+  if suffix == "low_speed_angle_assist_max_torque":
+    return _custom_help(
+      "Caps the extra torque used at very low speed to close the desired-versus-actual steering-angle gap.",
+      "Allows stronger low-speed assistance; too much can tug, overshoot, or feel abrupt.",
+      "Limits the assistance more; too little can leave tight turns behind the requested angle.",
+      analysis_why,
+    )
+  if suffix == "curvy_speed_min":
+    return _custom_help(
+      "Sets the lower-speed edge of the dedicated curvy-unwind cleanup window.",
+      "Starts the unwind cleanup at a higher speed, so less low/mid-speed driving is affected.",
+      "Starts the cleanup at a lower speed, extending it into slower curves.",
+      "This moves the lower boundary of the curvy unwind layer without changing its strength inside the window.",
+    )
+  if suffix == "curvy_speed_max":
+    return _custom_help(
+      "Sets the upper-speed edge of the dedicated curvy-unwind cleanup window.",
+      "Keeps the unwind cleanup active into faster curves.",
+      "Ends the cleanup sooner, preserving the base unwind behavior at lower speeds.",
+      analysis_why,
+    )
+  if suffix == "curvy_turn_in_trim_speed_min":
+    return _custom_help(
+      "Sets the lower-speed edge of the dedicated curvy turn-in trim window.",
+      "Starts the entry trim at a higher speed, so less low/mid-speed driving is affected.",
+      "Starts the entry trim at a lower speed, extending it into slower curves.",
+      "This changes where the curve-entry trim is active, not how strong the trim is.",
+    )
+  if suffix == "curvy_turn_in_trim_speed_max":
+    return _custom_help(
+      "Sets the upper-speed edge of the dedicated curvy turn-in trim window.",
+      "Keeps the entry trim active into faster curves.",
+      "Ends the entry trim sooner and returns to the base turn-in behavior at a lower speed.",
+      analysis_why,
+    )
+  if suffix.startswith("curvy_turn_in_trim_"):
+    return _custom_help(
+      f"Subtracts feedforward during curve-band turn-in for {side}.",
+      "Removes more entry feedforward and calms eagerness; too much can create late turn-in.",
+      "Removes less entry feedforward and makes entry stronger; too little trim can overshoot.",
+      analysis_why,
+    )
+  if suffix.startswith("curvy_unwind_floor_relief_"):
+    return _custom_help(
+      f"Lowers the feedforward floor that otherwise limits curvy-unwind reduction for {side}.",
+      "Allows a deeper torque reduction and quicker release; too much can make unwind abrupt.",
+      "Keeps a higher feedforward floor and more exit authority; too little relief can make steering hang on.",
+      analysis_why,
+    )
+  if suffix.startswith("curvy_unwind_extra_reduction_"):
+    return _custom_help(
+      f"Applies an additional feedforward reduction during curve-band unwind for {side}.",
+      "Removes more exit feedforward and releases steering sooner; too much can unwind too fast.",
+      "Removes less exit feedforward; too little can leave the car steering after the plan releases.",
+      analysis_why,
+    )
+  if suffix == "unwind_ff_reduction":
+    return _custom_help(
+      "Reduces feedforward during the vehicle-specific higher-speed unwind phase.",
+      "Removes more feedforward and releases steering sooner; too much can release too quickly.",
+      "Keeps more feedforward through unwind; too little reduction can make the car hold the curve.",
+      "This targets exit feedforward without changing turn-in or the whole torque calibration.",
+    )
+  return _custom_help(
+    "A car-specific FLM control used by the active torque-controller profile.",
+    "Moves the control toward its stronger or wider effect; evaluate the exact driving phase named by the control.",
+    "Moves the control toward its weaker or narrower effect.",
+    analysis_why,
+  )
+
+
+def _is_custom_profile_id(profile_id: Any) -> bool:
+  return str(profile_id or "").endswith(":custom")
+
+
+def _existing_custom_values_present(paths: dict[str, Path], params: Params) -> bool:
+  """Detect installs that used custom values before the Developer toggle existed."""
+  if _is_custom_profile_id(params.get("FLMActiveProfileId", encoding="utf-8")):
+    return True
+
+  active_snapshot = _read_json(paths["snapshots"] / "active.json", {})
+  if isinstance(active_snapshot, dict) and _is_custom_profile_id(active_snapshot.get("profileId")):
+    return True
+
+  for tune_path in paths["savedTunes"].glob("*.json"):
+    tune = _read_json(tune_path, {})
+    if isinstance(tune, dict) and _is_custom_profile_id(tune.get("sourceProfileId")):
+      return True
+  return False
+
+
+def custom_values_enabled() -> bool:
+  """Return the custom-value gate, migrating existing custom users to enabled once."""
+  raw_params = Params()
+  if raw_params.get(FLM_CUSTOM_VALUES_PARAM) is not None:
+    return raw_params.get_bool(FLM_CUSTOM_VALUES_PARAM)
+
+  paths = ensure_flm_workspace()
+  if _existing_custom_values_present(paths, raw_params):
+    raw_params.put_bool(FLM_CUSTOM_VALUES_PARAM, True)
+    return True
+  return Params(return_defaults=True).get_bool(FLM_CUSTOM_VALUES_PARAM)
+
+
+def _require_custom_values_enabled() -> None:
+  if not custom_values_enabled():
+    raise RuntimeError("Enable Custom FLM Values in Galaxy Developer settings first.")
+
+
+def _custom_report_rationales(selected_path: dict[str, Any]) -> dict[str, list[dict[str, str]]]:
+  rationales: dict[str, list[dict[str, str]]] = {}
+  for suggestion in selected_path.get("suggestions", []):
+    if not isinstance(suggestion, dict):
+      continue
+    comparison = suggestion.get("currentVsSuggested")
+    if not isinstance(comparison, dict):
+      continue
+    comparison_type = str(comparison.get("type", "") or "")
+    if comparison_type == "generic_param":
+      control_key = f"generic:{comparison.get('paramKey', '')}"
+    elif comparison_type == "vehicle_knob":
+      control_key = f"vehicle:{comparison.get('symbol', '')}"
+    elif comparison_type == "friction_curve":
+      control_key = f"friction:{comparison.get('family', '')}"
+    else:
+      continue
+    rationale = {
+      "observedBehavior": str(suggestion.get("observedBehavior", "") or ""),
+      "likelyInterpretation": str(suggestion.get("likelyInterpretation", "") or ""),
+      "primaryAdjustment": str(suggestion.get("primaryAdjustment", "") or ""),
+      "whyThisKnob": str(suggestion.get("whyThisKnob", "") or ""),
+      "logSupport": str(suggestion.get("logSupport", "") or ""),
+    }
+    existing = rationales.setdefault(control_key, [])
+    if rationale not in existing and len(existing) < 3:
+      existing.append(rationale)
+  return rationales
+
+
+def _custom_help_with_analysis(help_payload: dict[str, Any], rationales: dict[str, list[dict[str, str]]],
+                               control_key: str) -> dict[str, Any]:
+  return {
+    **help_payload,
+    "analysis": rationales.get(control_key, []),
+  }
+
+
+def _custom_trial_profiles(report: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+  report_paths = [path for path in report.get("paths", []) if isinstance(path, dict)]
+  selected_path_key = str(report.get("selectedPathKey") or report.get("primaryPathKey") or "")
+  selected_path = next((path for path in report_paths if path.get("key") == selected_path_key), None)
+  if selected_path is None:
+    selected_path = next((path for path in report_paths if path.get("isPrimary")), report_paths[0] if report_paths else {})
+  profiles = [profile for profile in selected_path.get("profiles", []) if isinstance(profile, dict)] if selected_path else []
+  if not profiles:
+    profiles = [profile for profile in report.get("profiles", []) if isinstance(profile, dict)]
+  return profiles, selected_path or {}
+
+
+def _custom_trial_supported_knobs(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+  profile_key = str(report.get("capabilities", {}).get("richProfileKey", "") or "")
+  return {
+    symbol: dict(metadata)
+    for symbol, metadata in get_flm_supported_vehicle_knobs().items()
+    if metadata.get("profile") == profile_key and metadata.get("safeLiveTrial", True)
+  }
+
+
+def _custom_numeric_default(value: Any, metadata: dict[str, Any]) -> float:
+  try:
+    number = float(value)
+  except (TypeError, ValueError):
+    number = float(metadata.get("min", 0.0))
+  if not math.isfinite(number):
+    number = float(metadata.get("min", 0.0))
+  return _round_to_precision(
+    _clamp(number, float(metadata["min"]), float(metadata["max"])),
+    float(metadata.get("precision", 0.001)),
+  )
+
+
+def _ceil_to_precision(value: float, precision: float) -> float:
+  if precision <= 0:
+    return float(value)
+  return round(math.ceil((float(value) / precision) - 1e-9) * precision, 6)
+
+
+def _floor_to_precision(value: float, precision: float) -> float:
+  if precision <= 0:
+    return float(value)
+  return round(math.floor((float(value) / precision) + 1e-9) * precision, 6)
+
+
+def _custom_trial_numeric_limit(value: Any, metadata: dict[str, Any]) -> dict[str, Any]:
+  """Limit one custom field around the immutable values captured by this analysis."""
+  baseline = _custom_numeric_default(value, metadata)
+  absolute_minimum = float(metadata["min"])
+  absolute_maximum = float(metadata["max"])
+  precision = float(metadata.get("precision", 0.001))
+  # A zero baseline would otherwise be impossible to change. Permit one control
+  # step while retaining the absolute schema bounds.
+  maximum_change = max(abs(baseline) * CUSTOM_TRIAL_CHANGE_LIMIT, precision)
+  minimum = _ceil_to_precision(max(absolute_minimum, baseline - maximum_change), precision)
+  maximum = _floor_to_precision(min(absolute_maximum, baseline + maximum_change), precision)
+  if minimum > maximum:
+    minimum = maximum = baseline
+  return {
+    **metadata,
+    "absoluteMin": absolute_minimum,
+    "absoluteMax": absolute_maximum,
+    "analysisBaseline": baseline,
+    "min": minimum,
+    "max": maximum,
+  }
+
+
+def _complete_custom_trial_values(report: dict[str, Any], profile: dict[str, Any] | None = None,
+                                  use_stock: bool = False) -> dict[str, Any]:
+  stock = report.get("stockParams", {}) if isinstance(report.get("stockParams"), dict) else {}
+  current = report.get("currentParams", {}) if isinstance(report.get("currentParams"), dict) else {}
+  current_overrides = normalize_flm_overrides(current.get("FLMActiveOverrides", {}))
+  profile = profile if isinstance(profile, dict) else {}
+  profile_overrides = normalize_flm_overrides(profile.get("flmOverrides", {}))
+
+  generic_params = {
+    "UseAutoSteerDelay": bool(stock.get("UseAutoSteerDelay", True) if use_stock else current.get("UseAutoSteerDelay", stock.get("UseAutoSteerDelay", True))),
+  }
+  for key, metadata in GENERIC_PARAM_METADATA.items():
+    base_value = stock.get(key, metadata["min"]) if use_stock else current.get(key, stock.get(key, metadata["min"]))
+    generic_params[key] = _custom_numeric_default(base_value, metadata)
+  for key, value in profile.get("genericParams", {}).items():
+    if key == "UseAutoSteerDelay":
+      generic_params[key] = bool(value)
+    elif key in GENERIC_PARAM_METADATA:
+      generic_params[key] = _custom_numeric_default(value, GENERIC_PARAM_METADATA[key])
+
+  family = str(report.get("capabilities", {}).get("frictionFamily", "standard") or "standard")
+  stock_curve_payload = stock.get("FLMBaseFrictionThresholds", {}).get(family, {}) if isinstance(stock.get("FLMBaseFrictionThresholds"), dict) else {}
+  stock_curve = stock_curve_payload.get("values", []) if isinstance(stock_curve_payload, dict) else []
+  if len(stock_curve) != len(FLM_FRICTION_SPEED_KNOTS):
+    stock_curve = _baseline_family_curve(family)
+  current_curve_payload = current_overrides.get("baseFrictionThresholds", {}).get(family, {})
+  current_curve = current_curve_payload.get("values", []) if isinstance(current_curve_payload, dict) else []
+  base_curve = stock_curve if use_stock or len(current_curve) != len(FLM_FRICTION_SPEED_KNOTS) else current_curve
+  profile_curve_payload = profile_overrides.get("baseFrictionThresholds", {}).get(family, {})
+  profile_curve = profile_curve_payload.get("values", []) if isinstance(profile_curve_payload, dict) else []
+  if len(profile_curve) == len(FLM_FRICTION_SPEED_KNOTS):
+    base_curve = profile_curve
+  friction_values = [_custom_numeric_default(value, CUSTOM_FRICTION_METADATA) for value in base_curve]
+
+  supported_knobs = _custom_trial_supported_knobs(report)
+  stock_knobs = stock.get("FLMVehicleKnobs", {}) if isinstance(stock.get("FLMVehicleKnobs"), dict) else {}
+  current_knobs = current_overrides.get("vehicleKnobs", {})
+  profile_knobs = profile_overrides.get("vehicleKnobs", {})
+  vehicle_knobs = {}
+  for symbol, metadata in supported_knobs.items():
+    value = stock_knobs.get(symbol, metadata.get("defaultValue", metadata["min"]))
+    if not use_stock:
+      value = current_knobs.get(symbol, value)
+    value = profile_knobs.get(symbol, value)
+    vehicle_knobs[symbol] = _custom_numeric_default(value, metadata)
+
+  return {
+    "genericParams": generic_params,
+    "flmOverrides": {
+      "schemaVersion": 1,
+      "baseFrictionThresholds": {
+        family: {
+          "speedKnots": list(FLM_FRICTION_SPEED_KNOTS),
+          "values": friction_values,
+        },
+      },
+      "vehicleKnobs": vehicle_knobs,
+    },
+  }
+
+
+def _constrain_custom_trial_preset(values: dict[str, Any], generic_controls: list[dict[str, Any]],
+                                   friction_limits: list[dict[str, Any]],
+                                   vehicle_controls: list[dict[str, Any]]) -> tuple[dict[str, Any], bool]:
+  """Keep every fill preset immediately applicable within this analysis window."""
+  constrained = json.loads(json.dumps(values))
+  changed = False
+
+  generic_values = constrained.get("genericParams", {})
+  for control in generic_controls:
+    if control.get("type") != "number" or control["key"] not in generic_values:
+      continue
+    original = generic_values[control["key"]]
+    generic_values[control["key"]] = _custom_numeric_default(original, control)
+    changed = changed or generic_values[control["key"]] != original
+
+  friction_payloads = constrained.get("flmOverrides", {}).get("baseFrictionThresholds", {})
+  for family_payload in friction_payloads.values():
+    if not isinstance(family_payload, dict):
+      continue
+    friction_values = family_payload.get("values", [])
+    if not isinstance(friction_values, list) or len(friction_values) != len(friction_limits):
+      continue
+    for index, limit in enumerate(friction_limits):
+      original = friction_values[index]
+      friction_values[index] = _custom_numeric_default(original, limit)
+      changed = changed or friction_values[index] != original
+
+  vehicle_values = constrained.get("flmOverrides", {}).get("vehicleKnobs", {})
+  for control in vehicle_controls:
+    if control["key"] not in vehicle_values:
+      continue
+    original = vehicle_values[control["key"]]
+    vehicle_values[control["key"]] = _custom_numeric_default(original, control)
+    changed = changed or vehicle_values[control["key"]] != original
+  return constrained, changed
+
+
+def _current_custom_trial_values(report: dict[str, Any]) -> tuple[dict[str, Any], str, bool]:
+  """Build the Current preset from live device params when they match this report's car."""
+  params = Params(return_defaults=True)
+  current_state = _snapshot_current_trial_state(params)
+  trial_active = bool(current_state.get("FLMTrialApplied", False))
+  paths = ensure_flm_workspace()
+  active_snapshot = _read_json(paths["snapshots"] / "active.json", {})
+  if not isinstance(active_snapshot, dict):
+    active_snapshot = {}
+
+  report_fingerprint = str(report.get("car", {}).get("carFingerprint", "") or "")
+  current_fingerprint = _current_car_identity(params)["carFingerprint"]
+  if not current_fingerprint and trial_active:
+    current_fingerprint = _active_trial_car_fingerprint(paths, active_snapshot)
+
+  # Without any device/trial identity, retain the report snapshot. This keeps
+  # offline report viewing deterministic and avoids mixing values across cars.
+  if (
+    (report_fingerprint and current_fingerprint and report_fingerprint != current_fingerprint)
+    or (report_fingerprint and not current_fingerprint and not trial_active)
+  ):
+    return _complete_custom_trial_values(report), "analysis", False
+
+  report_current = report.get("currentParams", {}) if isinstance(report.get("currentParams"), dict) else {}
+  live_report = {
+    **report,
+    "currentParams": {
+      **report_current,
+      **current_state,
+    },
+  }
+  source = "active_trial" if trial_active else "device"
+  return _complete_custom_trial_values(live_report), source, trial_active
+
+
+def build_custom_trial_schema(report_id: str) -> dict[str, Any]:
+  _require_custom_values_enabled()
+  report = load_report(report_id)
+  if report.get("car", {}).get("controlPath") != "torque":
+    raise RuntimeError("Custom FLM trials require a torque-control report.")
+
+  supported_knobs = _custom_trial_supported_knobs(report)
+  profiles, selected_path = _custom_trial_profiles(report)
+  report_rationales = _custom_report_rationales(selected_path)
+  analysis_values = _complete_custom_trial_values(report)
+  current_values, current_source, current_trial_active = _current_custom_trial_values(report)
+  presets = {
+    "stock": {"label": "Stock", "values": _complete_custom_trial_values(report, use_stock=True)},
+    "current": {
+      "label": "Current (Active Tune)" if current_trial_active else "Current",
+      "values": current_values,
+    },
+  }
+  for profile in profiles:
+    label = str(profile.get("label", "") or "").strip()
+    preset_key = label.lower().replace(" ", "_")
+    if preset_key not in ("conservative", "recommended", "assertive"):
+      continue
+    presets[preset_key] = {
+      "label": label,
+      "profileId": str(profile.get("id", "") or ""),
+      "values": _complete_custom_trial_values(report, profile=profile),
+    }
+
+  default_preset = "current" if current_trial_active else ("recommended" if "recommended" in presets else "current")
+  generic_controls = [{
+    "key": "UseAutoSteerDelay",
+    "label": CUSTOM_GENERIC_PARAM_LABELS["UseAutoSteerDelay"],
+    "type": "boolean",
+    "help": _custom_help_with_analysis(
+      CUSTOM_GENERIC_CONTROL_HELP["UseAutoSteerDelay"],
+      report_rationales,
+      "generic:UseAutoSteerDelay",
+    ),
+  }]
+  for key, metadata in GENERIC_PARAM_METADATA.items():
+    generic_controls.append({
+      "key": key,
+      "label": CUSTOM_GENERIC_PARAM_LABELS.get(key, key),
+      "type": "number",
+      "help": _custom_help_with_analysis(
+        CUSTOM_GENERIC_CONTROL_HELP.get(key, {}),
+        report_rationales,
+        f"generic:{key}",
+      ),
+      **_custom_trial_numeric_limit(analysis_values["genericParams"][key], metadata),
+    })
+
+  analysis_knobs = analysis_values["flmOverrides"]["vehicleKnobs"]
+  vehicle_controls = []
+  for symbol, metadata in supported_knobs.items():
+    vehicle_controls.append({
+      "key": symbol,
+      "label": _custom_knob_label(symbol),
+      "type": "number",
+      "help": _custom_help_with_analysis(
+        _custom_vehicle_knob_help(symbol),
+        report_rationales,
+        f"vehicle:{symbol}",
+      ),
+      **_custom_trial_numeric_limit(analysis_knobs[symbol], metadata),
+    })
+  friction_family = str(report.get("capabilities", {}).get("frictionFamily", "standard") or "standard")
+  analysis_friction = analysis_values["flmOverrides"]["baseFrictionThresholds"][friction_family]["values"]
+  friction_limits = [
+    _custom_trial_numeric_limit(value, CUSTOM_FRICTION_METADATA)
+    for value in analysis_friction
+  ]
+  friction_help = _custom_help(
+    f"The base small-error friction threshold at each road-speed knot for the {friction_family} controller family.",
+    "Delays and softens friction compensation at that speed, which can calm chatter but may feel reluctant.",
+    "Activates friction compensation sooner at that speed, which can improve response but may become twitchy.",
+    FLM_REFERENCE_MODEL["families"]["friction_threshold_curve"]["reason"],
+  )
+  for preset in presets.values():
+    preset["values"], preset["clippedToAnalysisLimits"] = _constrain_custom_trial_preset(
+      preset["values"],
+      generic_controls,
+      friction_limits,
+      vehicle_controls,
+    )
+  return {
+    "schemaVersion": 1,
+    "reportId": report_id,
+    "carFingerprint": str(report.get("car", {}).get("carFingerprint", "") or ""),
+    "profileKey": str(report.get("capabilities", {}).get("richProfileKey", "") or ""),
+    "profileLabel": str(report.get("capabilities", {}).get("richProfileLabel", "") or ""),
+    "pathKey": str(selected_path.get("key", "") or ""),
+    "pathLabel": str(selected_path.get("title", "") or ""),
+    "defaultPreset": default_preset,
+    "currentPresetSource": current_source,
+    "currentTrialActive": current_trial_active,
+    "changeLimitPercent": int(CUSTOM_TRIAL_CHANGE_LIMIT * 100),
+    "analysisCapturedAt": report.get("createdAt"),
+    "forcedSettings": {
+      "AdvancedLateralTune": True,
+      "ForceAutoTune": False,
+      "ForceAutoTuneOff": True,
+    },
+    "controls": {
+      "genericParams": generic_controls,
+      "frictionCurve": {
+        "family": friction_family,
+        "speedKnots": list(FLM_FRICTION_SPEED_KNOTS),
+        "help": _custom_help_with_analysis(
+          friction_help,
+          report_rationales,
+          f"friction:{friction_family}",
+        ),
+        **CUSTOM_FRICTION_METADATA,
+        "valueLimits": friction_limits,
+      },
+      "vehicleKnobs": vehicle_controls,
+    },
+    "vehicleKnobCount": len(vehicle_controls),
+    "presets": presets,
+  }
+
+
+def _validate_custom_number(value: Any, metadata: dict[str, Any], label: str) -> float:
+  if isinstance(value, bool):
+    raise ValueError(f"{label} must be a number.")
+  try:
+    number = float(value)
+  except (TypeError, ValueError):
+    raise ValueError(f"{label} must be a number.") from None
+  if not math.isfinite(number):
+    raise ValueError(f"{label} must be finite.")
+  minimum = float(metadata["min"])
+  maximum = float(metadata["max"])
+  if number < minimum or number > maximum:
+    raise ValueError(f"{label} must be between {minimum:g} and {maximum:g}.")
+  return _round_to_precision(number, float(metadata.get("precision", 0.001)))
+
+
+def validate_custom_trial_values(report_id: str, payload: Any) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+  if not isinstance(payload, dict):
+    raise ValueError("Custom trial values must be a JSON object.")
+  schema = build_custom_trial_schema(report_id)
+  generic_raw = payload.get("genericParams", {})
+  overrides_raw = payload.get("flmOverrides", {})
+  if not isinstance(generic_raw, dict) or not isinstance(overrides_raw, dict):
+    raise ValueError("Custom generic parameters and FLM overrides are required.")
+  expected_override_keys = {"schemaVersion", "baseFrictionThresholds", "vehicleKnobs"}
+  if unknown := sorted(set(overrides_raw) - expected_override_keys):
+    raise ValueError(f"Unknown custom FLM override field(s): {', '.join(unknown)}.")
+  if overrides_raw.get("schemaVersion") != 1:
+    raise ValueError("Custom FLM overrides must use schema version 1.")
+
+  expected_generic = {control["key"] for control in schema["controls"]["genericParams"]}
+  generic_keys = set(generic_raw)
+  if missing := sorted(expected_generic - generic_keys):
+    raise ValueError(f"Missing custom generic parameter(s): {', '.join(missing)}.")
+  if unknown := sorted(generic_keys - expected_generic):
+    raise ValueError(f"Unknown custom generic parameter(s): {', '.join(unknown)}.")
+
+  generic_params = dict(schema["forcedSettings"])
+  for control in schema["controls"]["genericParams"]:
+    key = control["key"]
+    if control["type"] == "boolean":
+      if not isinstance(generic_raw[key], bool):
+        raise ValueError(f"{control['label']} must be on or off.")
+      generic_params[key] = generic_raw[key]
+    else:
+      generic_params[key] = _validate_custom_number(generic_raw[key], control, control["label"])
+
+  family = schema["controls"]["frictionCurve"]["family"]
+  friction_raw = overrides_raw.get("baseFrictionThresholds", {})
+  if not isinstance(friction_raw, dict):
+    raise ValueError("Custom friction thresholds must be a JSON object.")
+  if missing := sorted({family} - set(friction_raw)):
+    raise ValueError(f"Missing custom friction family: {', '.join(missing)}.")
+  if unknown := sorted(set(friction_raw) - {family}):
+    raise ValueError(f"Unknown custom friction family: {', '.join(unknown)}.")
+  family_payload = friction_raw.get(family, {})
+  if not isinstance(family_payload, dict):
+    raise ValueError(f"The {family} friction curve must be a JSON object.")
+  if unknown := sorted(set(family_payload) - {"speedKnots", "values"}):
+    raise ValueError(f"Unknown {family} friction field(s): {', '.join(unknown)}.")
+  try:
+    speed_knots = [float(value) for value in family_payload.get("speedKnots", [])]
+  except (TypeError, ValueError):
+    speed_knots = []
+  if speed_knots != [float(value) for value in FLM_FRICTION_SPEED_KNOTS]:
+    raise ValueError(f"The {family} friction speed knots cannot be changed.")
+  friction_values_raw = family_payload.get("values", []) if isinstance(family_payload, dict) else []
+  if len(friction_values_raw) != len(FLM_FRICTION_SPEED_KNOTS):
+    raise ValueError(f"The {family} friction curve requires {len(FLM_FRICTION_SPEED_KNOTS)} values.")
+  friction_limits = schema["controls"]["frictionCurve"]["valueLimits"]
+  friction_values = [
+    _validate_custom_number(value, friction_limits[index], f"{family} friction value {index + 1}")
+    for index, value in enumerate(friction_values_raw)
+  ]
+
+  knobs_raw = overrides_raw.get("vehicleKnobs", {})
+  if not isinstance(knobs_raw, dict):
+    raise ValueError("Custom vehicle knobs must be a JSON object.")
+  controls_by_key = {control["key"]: control for control in schema["controls"]["vehicleKnobs"]}
+  expected_knobs = set(controls_by_key)
+  knob_keys = set(knobs_raw)
+  if missing := sorted(expected_knobs - knob_keys):
+    raise ValueError(f"Missing custom vehicle knob(s): {', '.join(missing[:5])}{'...' if len(missing) > 5 else ''}.")
+  if unknown := sorted(knob_keys - expected_knobs):
+    raise ValueError(f"Unknown or unsupported vehicle knob(s): {', '.join(unknown[:5])}{'...' if len(unknown) > 5 else ''}.")
+  vehicle_knobs = {
+    symbol: _validate_custom_number(knobs_raw[symbol], controls_by_key[symbol], controls_by_key[symbol]["label"])
+    for symbol in controls_by_key
+  }
+
+  for minimum_suffix, maximum_suffix in (
+    ("curvy_speed_min", "curvy_speed_max"),
+    ("curvy_turn_in_trim_speed_min", "curvy_turn_in_trim_speed_max"),
+  ):
+    minimum_symbol = next((symbol for symbol in vehicle_knobs if symbol.endswith(f".{minimum_suffix}")), "")
+    maximum_symbol = next((symbol for symbol in vehicle_knobs if symbol.endswith(f".{maximum_suffix}")), "")
+    if minimum_symbol and maximum_symbol and vehicle_knobs[minimum_symbol] >= vehicle_knobs[maximum_symbol]:
+      raise ValueError(f"{_custom_knob_label(minimum_symbol)} must be lower than {_custom_knob_label(maximum_symbol)}.")
+
+  flm_overrides = {
+    "schemaVersion": 1,
+    "baseFrictionThresholds": {
+      family: {
+        "speedKnots": list(FLM_FRICTION_SPEED_KNOTS),
+        "values": friction_values,
+      },
+    },
+    "vehicleKnobs": vehicle_knobs,
+  }
+  return generic_params, flm_overrides, schema
+
+
 def _active_trial_display_state(paths: dict[str, Path], snapshot: Any) -> dict[str, Any] | None:
   if not isinstance(snapshot, dict) or not snapshot:
     return None
@@ -2857,6 +3609,7 @@ def list_workspace() -> dict[str, Any]:
   return {
     "reports": reports[:20],
     "savedTunes": list_saved_tunes(paths, active_tune_id),
+    "customValuesEnabled": custom_values_enabled(),
     "currentCarFingerprint": current_car["carFingerprint"],
     "feedbackCount": len(feedback_files),
     "activeTrial": active_snapshot,
@@ -3467,6 +4220,87 @@ def apply_trial_profile(report_id: str, profile_id: str) -> dict[str, Any]:
   return {
     "message": f"Applied {profile.get('label', 'FLM')} profile.",
     "profile": profile,
+  }
+
+
+def apply_custom_trial(report_id: str, payload: Any) -> dict[str, Any]:
+  paths = ensure_flm_workspace()
+  params = Params(return_defaults=True)
+  _require_flm_offroad(params)
+  report = load_report(report_id)
+  report_fingerprint = str(report.get("car", {}).get("carFingerprint", "") or "")
+  current_car = _current_car_identity(params)
+  if current_car["carFingerprint"] and report_fingerprint and current_car["carFingerprint"] != report_fingerprint:
+    raise RuntimeError(
+      f"This report is for {report_fingerprint}, but the connected car is {current_car['carFingerprint']}."
+    )
+
+  generic_params, flm_overrides, schema = validate_custom_trial_values(report_id, payload)
+  current_state = _snapshot_current_trial_state(params)
+  raw_active_snapshot = _read_json(paths["snapshots"] / "active.json", {})
+  if not isinstance(raw_active_snapshot, dict):
+    raw_active_snapshot = {}
+  previous_display_state = _active_trial_display_state(paths, raw_active_snapshot) or {}
+  if current_state.get("FLMTrialApplied", False):
+    baseline_snapshot = _find_revert_snapshot(
+      paths,
+      raw_active_snapshot,
+      str(current_state.get("FLMActiveProfileId", "") or ""),
+      params,
+    )
+    if baseline_snapshot is None:
+      raise RuntimeError("The active FLM trial has no recoverable rollback baseline. Keep the current tune as the new baseline before applying custom values.")
+    baseline_params = baseline_snapshot["params"]
+    session_started_at = float(baseline_snapshot.get("sessionStartedAt", baseline_snapshot.get("capturedAt", time.time())) or time.time())
+  else:
+    baseline_params = current_state
+    session_started_at = time.time()
+
+  profile_id = f"{report_id}:custom"
+  now = time.time()
+  snapshot = {
+    "reportId": report_id,
+    "profileId": profile_id,
+    "profileLabel": "Custom",
+    "carFingerprint": report_fingerprint,
+    "pathKey": schema["pathKey"],
+    "pathLabel": schema["pathLabel"],
+    "capturedAt": session_started_at,
+    "updatedAt": now,
+    "sessionStartedAt": session_started_at,
+    "revisionCount": int(previous_display_state.get("revisionCount", 0) or 0) + 1,
+    "params": baseline_params,
+    "appliedGenericParams": generic_params,
+    "appliedFrictionThresholds": flm_overrides["baseFrictionThresholds"],
+    "appliedVehicleKnobs": flm_overrides["vehicleKnobs"],
+  }
+  _write_json(paths["snapshots"] / "active.json", snapshot)
+  _write_json(paths["snapshots"] / f"{report_id}-custom-{time.time_ns()}.json", snapshot)
+  _persist_trial_baseline(params, snapshot)
+
+  bundle = {
+    key: baseline_params[key]
+    for key in FLM_ADVANCED_LATERAL_PARAM_KEYS
+    if key in baseline_params
+  }
+  bundle.update(generic_params)
+  bundle["FLMActiveProfileId"] = profile_id
+  bundle["FLMActiveOverrides"] = flm_overrides
+  bundle["FLMTrialApplied"] = True
+  _apply_param_bundle(params, bundle)
+  if schema["pathKey"] == "cleanup_pass" and report_fingerprint:
+    _record_cleanup_progress(report_fingerprint, report_id)
+  return {
+    "message": f"Applied custom FLM trial with {schema['vehicleKnobCount']} vehicle knobs.",
+    "profile": {
+      "id": profile_id,
+      "label": "Custom",
+      "pathKey": schema["pathKey"],
+      "pathLabel": schema["pathLabel"],
+      "genericParams": generic_params,
+      "flmOverrides": flm_overrides,
+    },
+    "workspace": list_workspace(),
   }
 
 

--- a/starpilot/system/the_galaxy/tests/test_device_settings_layout.py
+++ b/starpilot/system/the_galaxy/tests/test_device_settings_layout.py
@@ -68,7 +68,7 @@ def test_galaxy_layout_contains_basic_mode_controls():
   } <= sections["Longitudinal (Speed & Following)"].keys()
   assert "RedneckCruise" not in sections["Longitudinal (Speed & Following)"].keys()
   assert sections["Developer"]["RedneckCruise"]["parent_key"] == "GalaxyDeveloperMode"
-  assert {"AlphaLongitudinalEnabled", "ForceOffroad", "GalaxyDeveloperMode", "UseOldUI"} <= sections["Developer"].keys()
+  assert {"AlphaLongitudinalEnabled", "FLMCustomValuesEnabled", "ForceOffroad", "GalaxyDeveloperMode", "UseOldUI"} <= sections["Developer"].keys()
 
 
 def test_device_shutdown_uses_literal_hours():
@@ -155,6 +155,8 @@ def test_requested_simple_and_advanced_settings_tiers():
     assert longitudinal[key]["settings_tier"] == "advanced"
 
   assert developer["GalaxyDeveloperMode"]["settings_tier"] == "simple"
+  assert developer["FLMCustomValuesEnabled"]["parent_key"] == "GalaxyDeveloperMode"
+  assert developer["FLMCustomValuesEnabled"]["settings_tier"] == "advanced"
   assert developer["AlphaLongitudinalEnabled"]["parent_key"] == "GalaxyDeveloperMode"
   assert developer["AlphaLongitudinalEnabled"]["requires_offroad"] is True
   assert developer["AlphaLongitudinalEnabled"]["settings_tier"] == "advanced"
@@ -169,6 +171,7 @@ def test_requested_simple_and_advanced_settings_tiers():
 
 def test_hidden_feature_defaults_remain_enabled():
   assert _declared_default("GalaxyDeveloperMode") == "0"
+  assert _declared_default("FLMCustomValuesEnabled") == "0"
   assert _declared_default("NavDesiresAllowed") == "1"
   assert _declared_default("NavLanePositioningAllowed") == "0"
   assert _declared_default("NavLongitudinalAllowed") == "1"

--- a/starpilot/system/the_galaxy/tests/test_flm_workspace.py
+++ b/starpilot/system/the_galaxy/tests/test_flm_workspace.py
@@ -147,10 +147,21 @@ def _install_flm_import_stubs(tmp_path):
     Paths=SimpleNamespace(comma_home=lambda: str(tmp_path), log_root=lambda **kwargs: str(tmp_path / "logs")),
   )
   sys.modules["openpilot.tools.lib.logreader"] = _simple_module("openpilot.tools.lib.logreader", LogReader=lambda *args, **kwargs: [])
-  sys.modules["openpilot.starpilot.system.the_galaxy.utilities"] = _simple_module(
+  sys.modules["openpilot.starpilot.common.lateral_delay"] = _simple_module(
+    "openpilot.starpilot.common.lateral_delay",
+    full_lateral_delay=lambda value: float(value) + 0.2,
+  )
+  galaxy_utilities = _simple_module(
     "openpilot.starpilot.system.the_galaxy.utilities",
     get_segments_in_route=lambda route, footage_path: [],
   )
+  galaxy_package = _simple_module(
+    "openpilot.starpilot.system.the_galaxy",
+    utilities=galaxy_utilities,
+  )
+  galaxy_package.__path__ = []
+  sys.modules["openpilot.starpilot.system.the_galaxy"] = galaxy_package
+  sys.modules["openpilot.starpilot.system.the_galaxy.utilities"] = galaxy_utilities
 
   return FakeParams
 
@@ -193,6 +204,98 @@ def _sample(module, **kwargs):
   )
   base.update(kwargs)
   return module.FLMSample(**base)
+
+
+def _write_custom_trial_report(module, report_id="report-custom"):
+  workspace = module.ensure_flm_workspace()
+  supported = {
+    symbol: metadata
+    for symbol, metadata in module.get_flm_supported_vehicle_knobs().items()
+    if metadata["profile"] == "hyundai_ioniq_6"
+  }
+  stock_knobs = {symbol: metadata["defaultValue"] for symbol, metadata in supported.items()}
+  first_symbol = next(iter(stock_knobs))
+  recommended_value = min(float(supported[first_symbol]["max"]), float(stock_knobs[first_symbol]) + 0.02)
+  profile = {
+    "id": f"{report_id}:cleanup_pass:recommended",
+    "reportId": report_id,
+    "label": "Recommended",
+    "pathKey": "cleanup_pass",
+    "pathLabel": "Cleanup Pass",
+    "genericParams": {"AdvancedLateralTune": True, "SteerLatAccel": 1.8},
+    "flmOverrides": {
+      "schemaVersion": 1,
+      "baseFrictionThresholds": {},
+      "vehicleKnobs": {first_symbol: recommended_value},
+    },
+  }
+  suggestion = {
+    "currentVsSuggested": {
+      "type": "vehicle_knob",
+      "symbol": first_symbol,
+      "current": stock_knobs[first_symbol],
+      "suggested": recommended_value,
+    },
+    "observedBehavior": "The analyzed route entered left curves late.",
+    "likelyInterpretation": "The left-side feedforward layer needs more authority.",
+    "primaryAdjustment": f"Move {first_symbol} to {recommended_value}.",
+    "whyThisKnob": "This corrects the affected side without moving global authority.",
+    "logSupport": "Matched in three events.",
+  }
+  report = {
+    "reportId": report_id,
+    "createdAt": 1.0,
+    "routeNames": ["route"],
+    "car": {"carFingerprint": "TEST_CAR", "brand": "hyundai", "controlPath": "torque"},
+    "capabilities": {
+      "frictionFamily": "hkg_canfd",
+      "richProfileKey": "hyundai_ioniq_6",
+      "richProfileLabel": "Ioniq 6",
+    },
+    "stockParams": {
+      "UseAutoSteerDelay": True,
+      "SteerDelay": 0.25,
+      "SteerFriction": 0.1,
+      "SteerKP": 1.0,
+      "SteerLatAccel": 1.5,
+      "SteerRatio": 15.0,
+      "FLMBaseFrictionThresholds": {
+        "hkg_canfd": {
+          "speedKnots": [0.0, 5.0, 10.0, 15.0, 25.0],
+          "values": [0.39, 0.395, 0.4, 0.405, 0.415],
+        },
+      },
+      "FLMVehicleKnobs": stock_knobs,
+    },
+    "currentParams": {
+      "AdvancedLateralTune": False,
+      "ForceAutoTune": True,
+      "ForceAutoTuneOff": False,
+      "UseAutoSteerDelay": True,
+      "SteerDelay": 0.25,
+      "SteerFriction": 0.1,
+      "SteerKP": 1.0,
+      "SteerLatAccel": 1.5,
+      "SteerRatio": 15.0,
+      "FLMActiveProfileId": "",
+      "FLMActiveOverrides": {},
+      "FLMTrialApplied": False,
+    },
+    "primaryPathKey": "cleanup_pass",
+    "selectedPathKey": "cleanup_pass",
+    "paths": [{
+      "key": "cleanup_pass",
+      "title": "Cleanup Pass",
+      "isPrimary": True,
+      "profiles": [profile],
+      "suggestions": [suggestion],
+    }],
+    "profiles": [profile],
+  }
+  (workspace["reports"] / f"{report_id}.json").write_text(json.dumps(report), encoding="utf-8")
+  (workspace["profiles"] / f"{report_id}.json").write_text(json.dumps([profile]), encoding="utf-8")
+  module.Params().put_bool(module.FLM_CUSTOM_VALUES_PARAM, True)
+  return report, supported, first_symbol, recommended_value
 
 
 def test_effective_control_path_prefers_logged_controller_state(tmp_path):
@@ -970,6 +1073,244 @@ def test_merge_primary_adjustments_disables_auto_delay_for_manual_delay_trial(tm
   assert params_delta["SteerDelay"] == pytest.approx(0.33)
   assert params_delta["UseAutoSteerDelay"] is False
   assert overrides == {}
+
+
+def test_custom_values_toggle_migrates_existing_custom_state_without_deleting_it(tmp_path):
+  module, fake_params_cls = _load_flm_workspace_module(tmp_path)
+  report, _, _, _ = _write_custom_trial_report(module)
+  workspace = module.ensure_flm_workspace()
+
+  fake_params_cls._store[module.FLM_CUSTOM_VALUES_PARAM] = False
+  with pytest.raises(RuntimeError, match="Galaxy Developer settings"):
+    module.build_custom_trial_schema(report["reportId"])
+
+  active_path = workspace["snapshots"] / "active.json"
+  active_payload = {
+    "reportId": report["reportId"],
+    "profileId": f"{report['reportId']}:custom",
+    "profileLabel": "Custom",
+    "appliedVehicleKnobs": {"example": 0.1},
+  }
+  active_path.write_text(json.dumps(active_payload), encoding="utf-8")
+  fake_params_cls._store.pop(module.FLM_CUSTOM_VALUES_PARAM)
+
+  assert module.custom_values_enabled() is True
+  assert fake_params_cls._store[module.FLM_CUSTOM_VALUES_PARAM] is True
+
+  fake_params_cls._store[module.FLM_CUSTOM_VALUES_PARAM] = False
+  assert module.list_workspace()["customValuesEnabled"] is False
+  assert json.loads(active_path.read_text(encoding="utf-8")) == active_payload
+
+
+def test_custom_trial_limits_stay_anchored_until_a_new_analysis(tmp_path):
+  module, fake_params_cls = _load_flm_workspace_module(tmp_path)
+  report, _, first_symbol, _ = _write_custom_trial_report(module)
+  schema = module.build_custom_trial_schema(report["reportId"])
+  first_control = next(control for control in schema["controls"]["vehicleKnobs"] if control["key"] == first_symbol)
+  zero_control = next(
+    control for control in schema["controls"]["vehicleKnobs"]
+    if control["key"].endswith(".center_deadband_low_deg")
+  )
+
+  assert schema["changeLimitPercent"] == 20
+  assert first_control["analysisBaseline"] == pytest.approx(0.1)
+  assert first_control["min"] == pytest.approx(0.08)
+  assert first_control["max"] == pytest.approx(0.12)
+  assert zero_control["analysisBaseline"] == pytest.approx(0.0)
+  assert zero_control["min"] == pytest.approx(0.0)
+  assert zero_control["max"] == pytest.approx(zero_control["precision"])
+
+  values = json.loads(json.dumps(schema["presets"]["current"]["values"]))
+  values["flmOverrides"]["vehicleKnobs"][first_symbol] = first_control["max"]
+  module.validate_custom_trial_values(report["reportId"], values)
+  fake_params_cls._store["IsOnroad"] = False
+  module.apply_custom_trial(report["reportId"], values)
+
+  same_analysis = module.build_custom_trial_schema(report["reportId"])
+  same_control = next(control for control in same_analysis["controls"]["vehicleKnobs"] if control["key"] == first_symbol)
+  assert same_control["analysisBaseline"] == pytest.approx(0.1)
+  assert same_control["max"] == pytest.approx(0.12)
+
+  too_far = json.loads(json.dumps(same_analysis["presets"]["current"]["values"]))
+  too_far["flmOverrides"]["vehicleKnobs"][first_symbol] = same_control["max"] + same_control["precision"]
+  with pytest.raises(ValueError, match="must be between"):
+    module.validate_custom_trial_values(report["reportId"], too_far)
+
+  next_report, _, next_symbol, _ = _write_custom_trial_report(module, "report-next-analysis")
+  next_report["currentParams"]["FLMActiveOverrides"] = {
+    "schemaVersion": 1,
+    "baseFrictionThresholds": {},
+    "vehicleKnobs": {next_symbol: 0.12},
+  }
+  workspace = module.ensure_flm_workspace()
+  (workspace["reports"] / f"{next_report['reportId']}.json").write_text(json.dumps(next_report), encoding="utf-8")
+  next_schema = module.build_custom_trial_schema(next_report["reportId"])
+  next_control = next(control for control in next_schema["controls"]["vehicleKnobs"] if control["key"] == next_symbol)
+  assert next_control["analysisBaseline"] == pytest.approx(0.12)
+  assert next_control["max"] == pytest.approx(0.144)
+
+
+def test_custom_trial_fill_presets_are_clipped_to_analysis_limits(tmp_path):
+  module, _ = _load_flm_workspace_module(tmp_path)
+  report, _, first_symbol, _ = _write_custom_trial_report(module)
+  profile = report["paths"][0]["profiles"][0]
+  profile["genericParams"]["SteerLatAccel"] = 3.0
+  profile["flmOverrides"]["vehicleKnobs"][first_symbol] = 0.4
+  workspace = module.ensure_flm_workspace()
+  (workspace["reports"] / f"{report['reportId']}.json").write_text(json.dumps(report), encoding="utf-8")
+
+  schema = module.build_custom_trial_schema(report["reportId"])
+  preset = schema["presets"]["recommended"]
+  first_control = next(control for control in schema["controls"]["vehicleKnobs"] if control["key"] == first_symbol)
+
+  assert preset["clippedToAnalysisLimits"] is True
+  assert preset["values"]["genericParams"]["SteerLatAccel"] == pytest.approx(1.8)
+  assert preset["values"]["flmOverrides"]["vehicleKnobs"][first_symbol] == pytest.approx(first_control["max"])
+
+
+def test_custom_trial_schema_exposes_every_supported_knob_and_analysis_seed(tmp_path):
+  module, _ = _load_flm_workspace_module(tmp_path)
+  report, supported, first_symbol, recommended_value = _write_custom_trial_report(module)
+
+  schema = module.build_custom_trial_schema(report["reportId"])
+  recommended = schema["presets"]["recommended"]["values"]
+
+  assert schema["vehicleKnobCount"] == len(supported)
+  assert {control["key"] for control in schema["controls"]["vehicleKnobs"]} == set(supported)
+  assert set(recommended["flmOverrides"]["vehicleKnobs"]) == set(supported)
+  assert recommended["flmOverrides"]["vehicleKnobs"][first_symbol] == pytest.approx(recommended_value)
+  assert recommended["genericParams"]["SteerLatAccel"] == pytest.approx(1.8)
+  assert all(control["help"]["summary"] for control in schema["controls"]["genericParams"])
+  assert all(control["help"]["summary"] for control in schema["controls"]["vehicleKnobs"])
+  first_help = next(control["help"] for control in schema["controls"]["vehicleKnobs"] if control["key"] == first_symbol)
+  assert first_help["analysis"][0]["whyThisKnob"] == "This corrects the affected side without moving global authority."
+  assert schema["controls"]["frictionCurve"]["help"]["summary"]
+  assert schema["forcedSettings"] == {
+    "AdvancedLateralTune": True,
+    "ForceAutoTune": False,
+    "ForceAutoTuneOff": True,
+  }
+
+
+def test_custom_trial_schema_refills_from_active_saved_tune(tmp_path):
+  module, fake_params_cls = _load_flm_workspace_module(tmp_path)
+  report, supported, first_symbol, _ = _write_custom_trial_report(module)
+  schema = module.build_custom_trial_schema(report["reportId"])
+  values = json.loads(json.dumps(schema["presets"]["recommended"]["values"]))
+  first_control = next(control for control in schema["controls"]["vehicleKnobs"] if control["key"] == first_symbol)
+  values["genericParams"]["SteerLatAccel"] = 1.7
+  values["flmOverrides"]["vehicleKnobs"][first_symbol] = max(
+    float(first_control["min"]),
+    float(values["flmOverrides"]["vehicleKnobs"][first_symbol]) - 0.005,
+  )
+  family = schema["controls"]["frictionCurve"]["family"]
+  values["flmOverrides"]["baseFrictionThresholds"][family]["values"][2] = 0.433
+  fake_params_cls._store = {
+    module.FLM_CUSTOM_VALUES_PARAM: True,
+    "IsOnroad": False,
+    "AdvancedLateralTune": False,
+    "ForceAutoTune": True,
+    "ForceAutoTuneOff": False,
+    "UseAutoSteerDelay": True,
+    "SteerDelay": 0.25,
+    "SteerFriction": 0.1,
+    "SteerKP": 1.0,
+    "SteerLatAccel": 1.5,
+    "SteerRatio": 15.0,
+    "FLMActiveProfileId": "",
+    "FLMActiveOverrides": {},
+    "FLMTrialApplied": False,
+  }
+
+  module.apply_custom_trial(report["reportId"], values)
+  module.save_active_trial_as_tune("My road tune")
+  reloaded_schema = module.build_custom_trial_schema(report["reportId"])
+  current = reloaded_schema["presets"]["current"]
+
+  assert reloaded_schema["currentPresetSource"] == "active_trial"
+  assert reloaded_schema["currentTrialActive"] is True
+  assert reloaded_schema["defaultPreset"] == "current"
+  assert current["label"] == "Current (Active Tune)"
+  assert current["values"]["genericParams"] == values["genericParams"]
+  assert set(current["values"]["flmOverrides"]["vehicleKnobs"]) == set(supported)
+  assert current["values"]["flmOverrides"]["vehicleKnobs"][first_symbol] == pytest.approx(
+    values["flmOverrides"]["vehicleKnobs"][first_symbol]
+  )
+  assert current["values"]["flmOverrides"]["baseFrictionThresholds"][family]["values"][2] == pytest.approx(0.433)
+
+
+def test_custom_trial_validation_requires_all_knobs_and_enforces_bounds(tmp_path):
+  module, _ = _load_flm_workspace_module(tmp_path)
+  report, _, _, _ = _write_custom_trial_report(module)
+  schema = module.build_custom_trial_schema(report["reportId"])
+  values = json.loads(json.dumps(schema["presets"][schema["defaultPreset"]]["values"]))
+  first_control = schema["controls"]["vehicleKnobs"][0]
+
+  values["flmOverrides"]["vehicleKnobs"].pop(first_control["key"])
+  with pytest.raises(ValueError, match="Missing custom vehicle knob"):
+    module.validate_custom_trial_values(report["reportId"], values)
+
+  values = json.loads(json.dumps(schema["presets"][schema["defaultPreset"]]["values"]))
+  values["flmOverrides"]["vehicleKnobs"][first_control["key"]] = first_control["max"] + 1
+  with pytest.raises(ValueError, match="must be between"):
+    module.validate_custom_trial_values(report["reportId"], values)
+
+  values = json.loads(json.dumps(schema["presets"][schema["defaultPreset"]]["values"]))
+  family = schema["controls"]["frictionCurve"]["family"]
+  values["flmOverrides"]["baseFrictionThresholds"][family]["speedKnots"][0] = 1.0
+  with pytest.raises(ValueError, match="speed knots cannot be changed"):
+    module.validate_custom_trial_values(report["reportId"], values)
+
+  values = json.loads(json.dumps(schema["presets"][schema["defaultPreset"]]["values"]))
+  values["flmOverrides"]["hiddenField"] = True
+  with pytest.raises(ValueError, match="Unknown custom FLM override"):
+    module.validate_custom_trial_values(report["reportId"], values)
+
+
+def test_apply_custom_trial_uses_exact_full_set_and_reverts_original_baseline(tmp_path):
+  module, fake_params_cls = _load_flm_workspace_module(tmp_path)
+  report, supported, first_symbol, _ = _write_custom_trial_report(module)
+  schema = module.build_custom_trial_schema(report["reportId"])
+  values = json.loads(json.dumps(schema["presets"][schema["defaultPreset"]]["values"]))
+  first_control = next(control for control in schema["controls"]["vehicleKnobs"] if control["key"] == first_symbol)
+  custom_value = min(float(first_control["max"]), max(float(first_control["min"]), float(values["flmOverrides"]["vehicleKnobs"][first_symbol]) + 0.01))
+  values["flmOverrides"]["vehicleKnobs"][first_symbol] = custom_value
+  baseline_overrides = {"vehicleKnobs": {"legacy.extra": 0.4}}
+  fake_params_cls._store = {
+    module.FLM_CUSTOM_VALUES_PARAM: True,
+    "IsOnroad": False,
+    "AdvancedLateralTune": False,
+    "ForceAutoTune": True,
+    "ForceAutoTuneOff": False,
+    "UseAutoSteerDelay": True,
+    "SteerDelay": 0.25,
+    "SteerFriction": 0.1,
+    "SteerKP": 1.0,
+    "SteerLatAccel": 1.5,
+    "SteerRatio": 15.0,
+    "FLMActiveProfileId": "",
+    "FLMActiveOverrides": baseline_overrides,
+    "FLMTrialApplied": False,
+  }
+
+  result = module.apply_custom_trial(report["reportId"], values)
+
+  assert result["profile"]["label"] == "Custom"
+  assert fake_params_cls._store["AdvancedLateralTune"] is True
+  assert fake_params_cls._store["ForceAutoTune"] is False
+  assert fake_params_cls._store["ForceAutoTuneOff"] is True
+  assert fake_params_cls._store["FLMActiveProfileId"] == f"{report['reportId']}:custom"
+  assert fake_params_cls._store["FLMTrialApplied"] is True
+  assert set(fake_params_cls._store["FLMActiveOverrides"]["vehicleKnobs"]) == set(supported)
+  assert fake_params_cls._store["FLMActiveOverrides"]["vehicleKnobs"][first_symbol] == pytest.approx(custom_value)
+  assert "legacy.extra" not in fake_params_cls._store["FLMActiveOverrides"]["vehicleKnobs"]
+
+  module.revert_trial_profile()
+  assert fake_params_cls._store["AdvancedLateralTune"] is False
+  assert fake_params_cls._store["ForceAutoTune"] is True
+  assert fake_params_cls._store["ForceAutoTuneOff"] is False
+  assert fake_params_cls._store["FLMActiveOverrides"]["vehicleKnobs"] == {"legacy.extra": pytest.approx(0.4)}
+  assert fake_params_cls._store["FLMTrialApplied"] is False
 
 
 def test_apply_and_revert_trial_profile_round_trip(tmp_path):

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -6229,6 +6229,7 @@ def setup(app):
       "activeTrial": workspace.get("activeTrial"),
       "reports": workspace.get("reports", [])[:10],
       "savedTunes": workspace.get("savedTunes", []),
+      "customValuesEnabled": workspace.get("customValuesEnabled", False),
     }), 200
 
   @app.route(f"{LEGACY_LATERAL_METHOD_API_PREFIX}/analyze", methods=["POST"])
@@ -6298,6 +6299,27 @@ def setup(app):
       return jsonify({"error": "FLM report not found."}), 404
     except ValueError as error:
       return jsonify({"error": str(error)}), 400
+
+  @app.route("/api/flm/report/<report_id>/custom-trial", methods=["GET"])
+  def get_flm_custom_trial(report_id):
+    try:
+      return jsonify(flm_workspace.build_custom_trial_schema(report_id)), 200
+    except FileNotFoundError:
+      return jsonify({"error": "FLM report not found."}), 404
+    except RuntimeError as error:
+      return jsonify({"error": str(error)}), 409
+
+  @app.route("/api/flm/report/<report_id>/custom-trial", methods=["POST"])
+  def apply_flm_custom_trial(report_id):
+    data = request.get_json(silent=True) or {}
+    try:
+      return jsonify(flm_workspace.apply_custom_trial(report_id, data)), 200
+    except FileNotFoundError:
+      return jsonify({"error": "FLM report not found."}), 404
+    except ValueError as error:
+      return jsonify({"error": str(error)}), 400
+    except (RuntimeError, flm_workspace.FLMAnalysisCancelled) as error:
+      return jsonify({"error": str(error)}), 409
 
   @app.route(f"{LEGACY_LATERAL_METHOD_API_PREFIX}/workspace", methods=["GET"])
   @app.route("/api/flm/workspace", methods=["GET"])


### PR DESCRIPTION
## Summary
- add a complete custom FLM trial editor for generic lateral settings, friction curves, and every supported vehicle knob
- expose per-control help plus analysis rationales and keep Stock vs Current limited to values that actually changed
- gate custom values behind `Custom FLM Values` in Galaxy Developer settings
- enforce server-side numeric limits of +/-20% from the Current values captured by the analysis; only a new analysis resets the range
- preserve existing custom trials and saved values, with a one-time migration that leaves existing users enabled

Manual rlog upload is intentionally not included in this PR.

## Safety
- retain the existing off-road requirement and exact rollback baseline
- validate the full submitted control set on the server
- allow one control step from a zero baseline so zero-valued knobs are not permanently locked
- clip fill presets to the analysis window and label them when clipping occurs
- disabling the toggle hides/blocks custom editing without deleting active or saved tune data

## Validation
- custom trial and migration tests: 7 passed
- Galaxy settings layout tests: 11 passed
- full Windows regression: 66 passed; the same 3 pre-existing POSIX process/signal tests are not runnable on Windows
- JavaScript syntax, Python compilation, and diff checks passed