### PR TITLE
Dashboard Timeout

### DIFF
--- a/starpilot/system/the_galaxy/assets/components/home/home.js
+++ b/starpilot/system/the_galaxy/assets/components/home/home.js
@@ -587,6 +587,16 @@ function renderDashboard(state) {
   scheduleDashboardRefresh(dashboard);
 }
 
+const STATS_ATTEMPT_TIMEOUTS_MS = [5000, 20000];
+
+async function fetchDashboardStats(timeoutMs) {
+  const statsResponse = await withTimeout(fetch("/api/stats"), timeoutMs, "stats request");
+
+  if (!statsResponse.ok) throw new Error(`stats API error: ${statsResponse.status}`);
+
+  return withTimeout(statsResponse.json(), timeoutMs, "stats JSON parse");
+}
+
 async function initializeHome(force = false) {
   if (force) {
     clearDashboardRefreshTimer();
@@ -594,20 +604,27 @@ async function initializeHome(force = false) {
     renderDashboard(HOME_STATE);
   }
 
-  try {
-    const statsResponse = await withTimeout(fetch("/api/stats"), 5000, "stats request");
+  let statsJson = null;
+  let lastError = null;
+  for (const timeoutMs of STATS_ATTEMPT_TIMEOUTS_MS) {
+    try {
+      statsJson = await fetchDashboardStats(timeoutMs);
+      lastError = null;
+      break;
+    } catch (err) {
+      lastError = err;
+    }
+  }
 
-    if (!statsResponse.ok) throw new Error(`stats API error: ${statsResponse.status}`);
-
-    const statsJson = await withTimeout(statsResponse.json(), 5000, "stats JSON parse");
+  if (lastError) {
+    HOME_STATE.status = "error";
+    HOME_STATE.error = lastError?.message || String(lastError);
+  } else {
     const payloadUnit = statsJson?.dashboard?.week?.distanceUnit || statsJson?.driveStats?.all?.unit;
 
     HOME_STATE.data = statsJson;
     HOME_STATE.unit = payloadUnit || HOME_STATE.unit || "miles";
     HOME_STATE.status = "ready";
-  } catch (err) {
-    HOME_STATE.status = "error";
-    HOME_STATE.error = err?.message || String(err);
   }
 
   renderDashboard(HOME_STATE);

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -6413,7 +6413,7 @@ def setup(app):
       "dashboard": dashboard_stats,
     }
     _STATS_RESPONSE_CACHE.update({
-      "updated_at": cache_now,
+      "updated_at": time.monotonic(),
       "payload": payload,
     })
     return payload

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -2863,7 +2863,7 @@ def get_dashboard_stats(footage_paths, params_obj=None, now=None):
 
   _DASHBOARD_CACHE.update({
     "key": cache_key,
-    "updated_at": time.monotonic(),,
+    "updated_at": time.monotonic(),
     "value": copy.deepcopy(dashboard),
   })
   return dashboard

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -2863,7 +2863,7 @@ def get_dashboard_stats(footage_paths, params_obj=None, now=None):
 
   _DASHBOARD_CACHE.update({
     "key": cache_key,
-    "updated_at": cache_now,
+    "updated_at": time.monotonic(),,
     "value": copy.deepcopy(dashboard),
   })
   return dashboard


### PR DESCRIPTION
Bug:
Stats caches were timestamped before their values were built, builds exceeding the TTL were stored as already expired, defeating the cache-miss lock added in 3719f9786.

Change Description:

Timestamps both caches after completion and retries /api/stats with a longer timeout. The initial timed-out fetch continues warming the cache, and allows retry to use the completed result.

Verification:
Tested on my comma 4 with 592 recorded segments. The dashboard now loads successfully without timing out.
Also ran the dashboard statistics and frontend test suites: 60 passed.