### PR TITLE
galaxy: enable threaded mode in Flask to prevent request blocking

### DIFF
--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -8745,7 +8745,7 @@ def main():
     print("\"The Galaxy\" is not running on a comma device, enabling debug mode")
 
   app.secret_key = secrets.token_hex(32)
-  app.run(host=host, port=port, debug=debug, use_reloader=use_reloader)
+  app.run(host=host, port=port, debug=debug, use_reloader=use_reloader, threaded=True)
 
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
### Summary
Enable threaded=True in Flask app.run() in the_galaxy.py.

### Problem
In Werkzeug / Flask, app.run() without threaded=True runs as a single-threaded server. When a client (e.g. mobile browser or streaming consumer) opens long-lived requests or streaming endpoints (like live tmux log snapshots, video streaming, or status polling), the single worker thread is blocked. Concurrent HTTP requests from other devices on the LAN hang and time out.

### Solution
Set threaded=True in app.run() so incoming requests are handled concurrently across worker threads.