### PR TITLE
webrtc: fix StreamRequestBody attribute error and Params.put block argument

### DIFF
--- a/system/webrtc/device/video.py
+++ b/system/webrtc/device/video.py
@@ -64,7 +64,7 @@ class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):
       self._seen_keyframe = False
 
   def request_keyframe(self) -> None:
-    self.params.put("LivestreamRequestKeyframe", True, block=False)
+    self.params.put_nonblocking("LivestreamRequestKeyframe", True)
 
   def _build_frame_data(self, msg) -> bytes:
     encode_data = getattr(msg, msg.which())
@@ -91,7 +91,7 @@ class LiveStreamVideoStreamTrack(TiciVideoStreamTrack):
       if msg is not None:
         if not self._seen_keyframe and (getattr(msg, msg.which()).idx.flags & V4L2_BUF_FLAG_KEYFRAME):
           self._seen_keyframe = True
-          self.params.put("LivestreamRequestKeyframe", False, block=False)
+          self.params.put_nonblocking("LivestreamRequestKeyframe", False)
         break
       await asyncio.sleep(0.005)
 

--- a/system/webrtc/helpers.py
+++ b/system/webrtc/helpers.py
@@ -9,10 +9,20 @@ WEBRTCD_PORT = 5001
 @dataclass
 class StreamRequestBody:
   sdp: str
-  init_camera: str
-  enabled: bool
+  init_camera: str = ""
+  enabled: bool = True
+  cameras: list[str] = field(default_factory=list)
   bridge_services_in: list[str] = field(default_factory=list)
   bridge_services_out: list[str] = field(default_factory=list)
+
+  def __post_init__(self):
+    if not self.cameras:
+      if self.init_camera:
+        self.cameras = [self.init_camera]
+      else:
+        self.cameras = ["road"]
+    if not self.init_camera and self.cameras:
+      self.init_camera = self.cameras[0]
 
 
 def post_stream_request(body: StreamRequestBody) -> dict:

--- a/system/webrtc/webrtcd.py
+++ b/system/webrtc/webrtcd.py
@@ -397,7 +397,10 @@ def _text_response(text: str, status: int = 200) -> tuple[int, bytes, str]:
 
 async def handle_get_stream(state: ServerState, raw_body: bytes) -> tuple[int, bytes, str]:
   stream_dict = state.streams
-  body = StreamRequestBody(**json.loads(raw_body))
+  parsed_dict = json.loads(raw_body)
+  valid_fields = {f.name for f in StreamRequestBody.__dataclass_fields__.values()}
+  filtered_dict = {k: v for k, v in parsed_dict.items() if k in valid_fields}
+  body = StreamRequestBody(**filtered_dict)
 
   async with state.stream_lock:
     # don't remove existing connection on prewarm request


### PR DESCRIPTION
### Summary
Fixes two bugs causing WebRTC livestreaming to crash on stream initialization and first video frame delivery.

### Problems Fixed
1. AttributeError: StreamRequestBody object has no attribute cameras
In webrtcd.py (line 234), StreamSession iterates over body.cameras, but StreamRequestBody in helpers.py only had init_camera without a cameras list attribute. This caused stream requests to fail with a 500 error, resulting in SDP parse errors in web clients.

2. TypeError: put() got an unexpected keyword argument block
In system/webrtc/device/video.py (lines 67, 94), Params.put was called with block=False, which is unsupported by the Params cython wrapper and caused the video frame producer loop to crash when receiving the initial keyframe.

### Solutions
- Added cameras list support and automatic initialization fallback to StreamRequestBody in helpers.py.
- Filtered request body fields safely in handle_get_stream in webrtcd.py.
- Replaced invalid Params.put(..., block=False) calls with Params.put_nonblocking in system/webrtc/device/video.py.