### PR TITLE
Dashcam Routes Page Rework

### DIFF
--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -244,45 +244,164 @@
   transform: var(--hover-scale-sm);
 }
 
-.route-logs {
-  margin-top: var(--padding-base);
-  max-height: 40vh;
-  overflow-y: auto;
+.dialog-box.route-logs-dialog {
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.55);
+  display: flex;
+  flex-direction: column;
+  max-height: min(42rem, calc(100vh - 2rem));
+  max-width: none;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
   text-align: left;
+  width: min(36rem, calc(100vw - 2rem));
+}
+
+.route-logs-toolbar {
+  align-items: center;
+  background: var(--input-bg);
+  border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
+  display: flex;
+  flex-shrink: 0;
+  justify-content: space-between;
+  padding: var(--padding-base) var(--padding-lg);
+}
+
+.route-logs-toolbar h2,
+.route-logs-eyebrow {
+  margin: 0;
+}
+
+.route-logs-toolbar h2 {
+  color: var(--text-color);
+  font-size: var(--font-size-xl);
+  line-height: 1.2;
+}
+
+.route-logs-eyebrow {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.08em;
+  margin-bottom: var(--margin-xs);
+  text-transform: uppercase;
+}
+
+.route-logs-close {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  font-size: 2rem;
+  height: 2.5rem;
+  justify-content: center;
+  line-height: 1;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+  width: 2.5rem;
+}
+
+.route-logs-close:hover,
+.route-logs-close:focus-visible {
+  background: var(--sidebar-active-bg);
+  color: var(--text-color);
+  outline: none;
+}
+
+.route-logs-content {
+  overflow-y: auto;
+  padding: var(--padding-lg);
 }
 
 .route-logs-message {
+  color: var(--text-color);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
   margin: 0;
-  padding: var(--padding-sm) 0;
-  font-size: var(--font-size-sm);
+  padding: var(--padding-lg) var(--padding-sm);
+  text-align: center;
 }
 
-.route-logs-header {
-  display: flex;
+.route-logs-error {
+  color: var(--danger-fg);
+}
+
+.route-logs-summary {
   align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  display: flex;
   justify-content: space-between;
-  gap: var(--padding-sm);
-  padding-bottom: var(--padding-sm);
-  font-size: var(--font-size-sm);
+  gap: var(--gap-md);
+  padding: var(--padding-base);
+}
+
+.route-logs-summary > div,
+.route-log-details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  min-width: 0;
+}
+
+.route-logs-summary strong,
+.route-log-details strong {
+  color: var(--text-color);
+  font-size: var(--font-size-base);
+}
+
+.route-logs-summary div span,
+.route-log-details span {
+  color: var(--text-muted);
+  font-size: var(--font-size-base);
+  line-height: 1.4;
+}
+
+.route-logs-download-all,
+.route-log-download {
+  background: var(--main-fg);
+  border-radius: var(--border-radius-md);
+  color: var(--text-on-primary);
+  flex-shrink: 0;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-demi-bold);
+  padding: var(--padding-sm) var(--padding-base);
+  text-decoration: none;
+  transition: filter var(--transition-fast), transform var(--transition-fast);
+}
+
+.route-logs-download-all span {
+  opacity: 0.75;
+}
+
+.route-logs-download-all:hover,
+.route-log-download:hover,
+.route-logs-download-all:focus-visible,
+.route-log-download:focus-visible {
+  filter: brightness(1.15);
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .route-logs-list {
+  display: grid;
+  gap: var(--gap-sm);
   list-style: none;
-  margin: 0;
+  margin: var(--margin-base) 0 0;
   padding: 0;
 }
 
 .route-logs-list li {
-  display: flex;
   align-items: center;
+  border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
+  display: flex;
   justify-content: space-between;
-  gap: var(--padding-sm);
-  padding: var(--padding-sm) 0;
-  font-size: var(--font-size-sm);
-}
-
-.route-logs a {
-  text-decoration: underline;
+  gap: var(--gap-md);
+  padding: var(--padding-sm) var(--padding-xs) var(--padding-base);
 }
 
 @media only screen and (max-width: 768px) and (orientation: portrait) {
@@ -308,10 +427,19 @@
     width: 100%;
   }
 
-  .route-logs-header,
+  .route-logs-toolbar,
+  .route-logs-content {
+    padding: var(--padding-base);
+  }
+
+  .route-logs-summary,
   .route-logs-list li {
     flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
+    align-items: stretch;
+  }
+
+  .route-logs-download-all,
+  .route-log-download {
+    text-align: center;
   }
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -445,7 +445,15 @@
 
 .dashcam-library-header {
   justify-content: space-between;
+  align-items: flex-start;
   gap: var(--gap-md);
+  flex-wrap: wrap;
+}
+
+.dashcam-header-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .dashcam-library-header h1,
@@ -471,89 +479,230 @@
   text-transform: uppercase;
 }
 
-.dashcam-refresh-button,
-.dashcam-preserved-filter,
-.dashcam-sort,
-.dashcam-search {
+/* Stats Chips in Header */
+.dashcam-stats-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  margin-top: 0.4rem;
+}
+
+.dashcam-stat-chip {
+  align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-xl);
+  color: var(--text-muted);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  gap: 0.35rem;
+  padding: 0.3rem 0.75rem;
+}
+
+.dashcam-stat-chip strong {
+  color: var(--text-color);
+  font-weight: var(--font-weight-demi-bold);
+}
+
+.dashcam-stat-chip i {
+  color: var(--main-fg);
+  font-size: 0.85rem;
+}
+
+.dashcam-stat-chip.stat-chip-preserved i {
+  color: #ef6078;
+}
+
+.dashcam-header-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+}
+
+.dashcam-refresh-button {
   background: var(--input-bg);
   border: var(--border-width-thin) solid var(--sidebar-border-color);
   border-radius: var(--border-radius-md);
   color: var(--text-color);
-}
-
-.dashcam-refresh-button,
-.dashcam-preserved-filter {
   cursor: pointer;
-  font-size: var(--font-size-base);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: var(--font-size-sm);
   font-weight: var(--font-weight-demi-bold);
-  padding: 0.7rem 1rem;
+  padding: 0.6rem 0.95rem;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
 }
 
-.dashcam-refresh-button:disabled,
-.dashcam-player-actions button:disabled {
+.dashcam-refresh-button:hover {
+  background: var(--sidebar-active-bg);
+  border-color: var(--main-fg);
+  transform: translateY(-1px);
+}
+
+.dashcam-refresh-button:disabled {
   cursor: not-allowed;
   opacity: var(--disabled-opacity);
 }
 
+/* Modern Toolbar */
 .dashcam-toolbar {
   flex-wrap: wrap;
   gap: var(--gap-sm);
   margin-top: var(--margin-lg);
 }
 
-.dashcam-search {
+.dashcam-search-box {
   align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
   display: flex;
-  flex: 1 1 22rem;
+  flex: 1 1 18rem;
   gap: var(--gap-sm);
-  padding: 0 0.9rem;
+  padding: 0 0.8rem;
+  position: relative;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
-.dashcam-search input,
-.dashcam-sort select {
+.dashcam-search-box:focus-within {
+  border-color: var(--main-fg);
+  box-shadow: 0 0 0 2px rgba(139, 108, 197, 0.2);
+}
+
+.dashcam-search-icon {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.dashcam-search-box input {
   background: transparent;
   border: 0;
   color: var(--text-color);
   font: inherit;
-  outline: 0;
-}
-
-.dashcam-search input {
+  font-size: var(--font-size-sm);
   min-width: 0;
-  padding: 0.75rem 0;
+  outline: 0;
+  padding: 0.65rem 0;
   width: 100%;
 }
 
+.dashcam-search-clear {
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem;
+  border-radius: 50%;
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.dashcam-search-clear:hover {
+  color: var(--text-color);
+  background: var(--sidebar-active-bg);
+}
+
+.dashcam-filter-group {
+  display: inline-flex;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  padding: 2px;
+  gap: 2px;
+}
+
+.dashcam-filter-pill {
+  background: transparent;
+  border: 0;
+  border-radius: calc(var(--border-radius-md) - 2px);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-demi-bold);
+  padding: 0.5rem 0.85rem;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.dashcam-filter-pill.active {
+  background: var(--sidebar-active-bg);
+  color: var(--text-color);
+  box-shadow: inset 0 0 0 1px var(--main-fg);
+}
+
+.dashcam-filter-pill .bi-heart-fill {
+  color: #ef6078;
+  margin-right: 0.25rem;
+}
+
 .dashcam-sort {
+  align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  display: flex;
   gap: var(--gap-sm);
-  padding: 0.65rem 0.85rem;
+  padding: 0.5rem 0.85rem;
 }
 
 .dashcam-sort span {
   color: var(--text-muted);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .dashcam-sort select {
+  background: transparent;
+  border: 0;
+  color: var(--text-color);
   cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  outline: 0;
 }
 
-.dashcam-preserved-filter[aria-pressed="true"] {
-  background: rgba(230, 78, 102, 0.16);
-  border-color: rgba(230, 78, 102, 0.65);
+.dashcam-view-toggle {
+  display: inline-flex;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  padding: 2px;
+  gap: 2px;
 }
 
-.dashcam-preserved-filter .bi-heart-fill {
-  color: #ef6078;
-  margin-right: 0.35rem;
+.dashcam-view-btn {
+  background: transparent;
+  border: 0;
+  border-radius: calc(var(--border-radius-md) - 2px);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+  padding: 0.4rem 0.65rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.dashcam-view-btn.active {
+  background: var(--sidebar-active-bg);
+  color: var(--main-fg);
+  box-shadow: inset 0 0 0 1px var(--main-fg);
 }
 
 .dashcam-results-summary {
   color: var(--text-muted);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   justify-content: space-between;
   margin-top: var(--margin-base);
   min-height: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .dashcam-date-groups,
@@ -565,51 +714,332 @@
   margin-top: var(--margin-lg);
 }
 
-.dashcam-date-group > h2 {
+.dashcam-date-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
-  color: var(--text-color);
-  font-size: var(--font-size-lg);
-  margin: 0;
-  padding-bottom: var(--padding-sm);
+  padding-bottom: var(--padding-xs);
+  margin-bottom: var(--margin-sm);
 }
 
+.dashcam-date-group-header h2 {
+  color: var(--text-color);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  margin: 0;
+}
+
+.dashcam-date-group-count {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+/* ============================================================
+   Modernized List View (Data & Telemetry Focused)
+   ============================================================ */
+.dashcam-routes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.dashcam-route-row {
+  align-items: center;
+  background: var(--card-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  box-shadow: var(--shadow-xs);
+  cursor: pointer;
+  display: flex;
+  gap: var(--gap-md);
+  padding: 0.75rem 1rem;
+  position: relative;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.dashcam-route-row:hover {
+  background: rgba(18, 18, 36, 0.95);
+  border-color: rgba(139, 108, 197, 0.4);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.dashcam-route-row.is-preserved {
+  border-left: 3px solid #ef6078;
+}
+
+/* Compact Mini Preview (Non-dominant) */
+.dashcam-mini-preview {
+  aspect-ratio: 16 / 9;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-sm);
+  flex-shrink: 0;
+  height: 52px;
+  overflow: hidden;
+  position: relative;
+  width: 92px;
+}
+
+.dashcam-mini-fallback {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: absolute;
+  font-size: 1.25rem;
+}
+
+.dashcam-mini-preview:not(.thumbnail-failed) .dashcam-mini-fallback {
+  visibility: hidden;
+}
+
+.dashcam-mini-img {
+  background: var(--sidebar-bg);
+  height: 100%;
+  object-fit: cover;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.dashcam-mini-play-overlay {
+  align-items: center;
+  background: rgba(10, 10, 22, 0.6);
+  color: white;
+  display: flex;
+  font-size: 1.2rem;
+  inset: 0;
+  justify-content: center;
+  opacity: 0;
+  position: absolute;
+  transition: opacity var(--transition-fast);
+  z-index: 2;
+}
+
+.dashcam-route-row:hover .dashcam-mini-play-overlay {
+  opacity: 1;
+}
+
+/* Route Info & Telemetry */
+.dashcam-route-info {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.dashcam-route-title-row {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.dashcam-route-title {
+  color: var(--text-color);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-demi-bold);
+  line-height: 1.3;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashcam-custom-badge {
+  align-items: center;
+  background: rgba(139, 108, 197, 0.15);
+  border: 1px solid rgba(139, 108, 197, 0.35);
+  border-radius: var(--border-radius-sm);
+  color: var(--main-fg);
+  display: inline-flex;
+  font-size: 0.7rem;
+  font-weight: var(--font-weight-bold);
+  gap: 0.25rem;
+  padding: 0.1rem 0.4rem;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.dashcam-route-subdate {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dashcam-route-meta-pills {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.15rem;
+}
+
+.meta-pill {
+  align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-sm);
+  color: var(--text-muted);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+
+.meta-pill.duration-pill {
+  color: var(--text-color);
+}
+
+.meta-pill.duration-pill i {
+  color: var(--main-fg);
+}
+
+.meta-pill.segments-pill i {
+  color: var(--text-muted);
+}
+
+.meta-pill.preserved-pill {
+  background: rgba(239, 96, 120, 0.12);
+  border-color: rgba(239, 96, 120, 0.35);
+  color: #ef6078;
+}
+
+.meta-pill.id-pill {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  opacity: 0.85;
+}
+
+/* Route Action Buttons */
+.dashcam-route-actions {
+  align-items: center;
+  display: flex;
+  flex-shrink: 0;
+  gap: 0.4rem;
+}
+
+.btn-route-action {
+  align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  color: var(--text-color);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-demi-bold);
+  gap: 0.35rem;
+  justify-content: center;
+  padding: 0.45rem 0.75rem;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.btn-route-action:hover {
+  background: var(--sidebar-active-bg);
+  border-color: var(--main-fg);
+  transform: translateY(-1px);
+}
+
+.btn-route-action.btn-play {
+  background: var(--main-fg);
+  border-color: var(--main-fg);
+  color: var(--text-on-primary);
+}
+
+.btn-route-action.btn-play:hover {
+  filter: brightness(1.12);
+}
+
+.btn-route-action.btn-preserve {
+  padding: 0.45rem 0.6rem;
+  color: var(--text-muted);
+}
+
+.btn-route-action.btn-preserve.active {
+  background: rgba(239, 96, 120, 0.15);
+  border-color: rgba(239, 96, 120, 0.45);
+  color: #ef6078;
+}
+
+.btn-route-action.btn-preserve:hover {
+  color: #ef6078;
+}
+
+.btn-route-action.btn-icon {
+  color: var(--text-muted);
+  padding: 0.45rem 0.6rem;
+}
+
+.btn-route-action.btn-icon:hover {
+  color: var(--text-color);
+}
+
+.btn-route-action.btn-danger-action:hover {
+  background: rgba(224, 85, 119, 0.15);
+  border-color: var(--danger-bg);
+  color: var(--danger-bg);
+}
+
+/* ============================================================
+   Compact Grid View Mode
+   ============================================================ */
 .dashcam-library .screen-recordings-grid.dashcam-routes-grid {
-  gap: clamp(0.8rem, 1.5vw, 1.25rem);
-  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
-  margin-top: var(--margin-base);
+  gap: clamp(0.8rem, 1.5vw, 1.1rem);
+  grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+  margin-top: var(--margin-sm);
 }
 
 .dashcam-library .recording-card.dashcam-route-card {
+  background: var(--card-bg);
   border: var(--border-width-thin) solid var(--sidebar-border-color);
-  border-radius: var(--border-radius-lg);
-  box-shadow: var(--shadow-sm);
+  border-radius: var(--border-radius-md);
+  box-shadow: var(--shadow-xs);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   position: relative;
   text-align: left;
+  transition: border-color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .dashcam-library .recording-card.dashcam-route-card:hover {
-  box-shadow: var(--shadow-md);
+  border-color: rgba(139, 108, 197, 0.45);
+  box-shadow: var(--shadow-sm);
   transform: translateY(-2px);
 }
 
-.dashcam-route-card .preserved-icon {
+.dashcam-card-top-bar {
   align-items: center;
-  background: rgba(10, 12, 18, 0.7);
-  border: 0;
-  border-radius: 50%;
-  color: white;
+  background: var(--secondary-bg);
+  border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
   display: flex;
-  height: 2.6rem;
-  justify-content: center;
-  right: 0.7rem;
-  top: 0.7rem;
-  width: 2.6rem;
+  justify-content: space-between;
+  padding: 0.35rem 0.6rem;
+}
+
+.dashcam-card-top-bar .btn-preserve {
+  background: transparent;
+  border: 0;
+  padding: 0.15rem 0.3rem;
 }
 
 .dashcam-route-card .dashcam-preview {
+  aspect-ratio: 16 / 9;
   background: linear-gradient(135deg, var(--sidebar-bg), var(--input-bg));
+  max-height: 120px;
   overflow: hidden;
+  position: relative;
+  width: 100%;
 }
 
 .dashcam-preview-fallback {
@@ -624,7 +1054,7 @@
 }
 
 .dashcam-preview-fallback i {
-  font-size: 2rem;
+  font-size: 1.6rem;
 }
 
 .dashcam-preview:not(.thumbnail-failed) .dashcam-preview-fallback {
@@ -633,16 +1063,42 @@
 
 .dashcam-preview img {
   background: var(--sidebar-bg);
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
   z-index: 1;
 }
 
+.dashcam-grid-play-overlay {
+  align-items: center;
+  background: rgba(10, 10, 22, 0.55);
+  color: white;
+  display: flex;
+  font-size: 1.8rem;
+  inset: 0;
+  justify-content: center;
+  opacity: 0;
+  position: absolute;
+  transition: opacity var(--transition-fast);
+  z-index: 2;
+}
+
+.dashcam-route-card:hover .dashcam-grid-play-overlay {
+  opacity: 1;
+}
+
 .dashcam-card-body {
-  padding: var(--padding-base);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.75rem;
 }
 
 .dashcam-card-body h3 {
   color: var(--text-color);
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-demi-bold);
   line-height: 1.3;
   margin: 0;
   overflow: hidden;
@@ -650,34 +1106,26 @@
   white-space: nowrap;
 }
 
-.dashcam-card-date,
-.dashcam-card-details,
-.dashcam-preserve-status {
+.dashcam-card-date {
   color: var(--text-muted);
-  font-size: var(--font-size-sm);
-  margin: var(--margin-xs) 0 0;
-}
-
-.dashcam-card-details {
-  display: flex;
-  gap: var(--gap-sm);
-}
-
-.dashcam-card-details span + span::before {
-  content: "·";
-  margin-right: var(--gap-sm);
-}
-
-.dashcam-preserve-status {
   font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-demi-bold);
-  text-transform: uppercase;
+  margin: 0;
 }
 
-.dashcam-preserve-status.preserved {
-  color: #ef6078;
+.dashcam-card-actions {
+  align-items: center;
+  border-top: var(--border-width-thin) solid var(--sidebar-border-color);
+  display: flex;
+  gap: 0.3rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
 }
 
+.dashcam-card-actions .btn-play {
+  flex: 1;
+}
+
+/* Empty & Loading States */
 .dashcam-loading,
 .dashcam-empty-state {
   align-items: center;
@@ -840,6 +1288,7 @@
   margin-left: auto;
 }
 
+/* Responsive Adaptations */
 @media only screen and (max-width: 768px) {
   .screen-recordings-wrapper.dashcam-routes-wrapper {
     padding: 0 var(--padding-sm) var(--padding-lg);
@@ -856,15 +1305,43 @@
     flex-direction: column;
   }
 
-  .dashcam-refresh-button,
-  .dashcam-preserved-filter,
-  .dashcam-sort {
+  .dashcam-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dashcam-search-box {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .dashcam-filter-group,
+  .dashcam-sort,
+  .dashcam-view-toggle {
     justify-content: center;
   }
 
   .dashcam-sort {
     display: flex;
     flex: 1;
+  }
+
+  .dashcam-route-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--gap-sm);
+  }
+
+  .dashcam-mini-preview {
+    width: 100%;
+    height: auto;
+    max-height: 140px;
+  }
+
+  .dashcam-route-actions {
+    border-top: var(--border-width-thin) solid var(--sidebar-border-color);
+    padding-top: var(--padding-xs);
+    justify-content: space-between;
   }
 
   .dashcam-library .screen-recordings-grid.dashcam-routes-grid {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1212,6 +1212,7 @@
 .dashcam-video-shell {
   aspect-ratio: 16 / 9;
   background: #07080b;
+  overflow: hidden;
   position: relative;
   width: 100%;
 }
@@ -1219,23 +1220,22 @@
 .dashcam-player-overlay .dashcam-player .dashcam-video-shell video {
   border-radius: 0;
   height: 100%;
+  inset: 0;
   object-fit: contain;
+  position: absolute;
   width: 100%;
 }
 
-.dashcam-transition-frame {
-  background: #07080b;
-  height: 100%;
-  inset: 0;
-  object-fit: contain;
-  pointer-events: none;
-  position: absolute;
-  width: 100%;
+.dashcam-player-overlay .dashcam-player .dashcam-video-shell video.active {
+  opacity: 1;
+  pointer-events: auto;
   z-index: 1;
 }
 
-.dashcam-transition-frame[hidden] {
-  display: none;
+.dashcam-player-overlay .dashcam-player .dashcam-video-shell video.staging {
+  opacity: 0;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .dashcam-player-state {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1223,6 +1223,21 @@
   width: 100%;
 }
 
+.dashcam-transition-frame {
+  background: #07080b;
+  height: 100%;
+  inset: 0;
+  object-fit: contain;
+  pointer-events: none;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.dashcam-transition-frame[hidden] {
+  display: none;
+}
+
 .dashcam-player-state {
   align-items: center;
   background: rgba(7, 8, 11, 0.78);
@@ -1232,6 +1247,7 @@
   justify-content: center;
   position: absolute;
   text-align: center;
+  z-index: 2;
 }
 
 .dashcam-player-state.error {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1239,18 +1239,48 @@
 }
 
 .dashcam-player-state[hidden],
-.dashcam-segment-status[hidden],
+.dashcam-segment-bar[hidden],
 .dashcam-camera-selector button[hidden] {
   display: none;
 }
 
-.dashcam-segment-status {
+.dashcam-segment-bar {
+  align-items: center;
   background: var(--sidebar-bg);
   border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
-  color: var(--text-muted);
-  font-size: var(--font-size-sm);
+  display: flex;
+  gap: var(--gap-xs);
   padding: 0.65rem var(--padding-lg);
 }
+
+.dashcam-segment-bar .segment-step {
+  align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  color: var(--text-color);
+  cursor: pointer;
+  display: flex;
+  font-size: var(--font-size-base);
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+}
+
+.dashcam-segment-bar .segment-step:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.dashcam-segment-bar .segment-select {
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  padding: 0.35rem 0.6rem;
+}
+
 
 .dashcam-camera-selector {
   gap: var(--gap-xs);
@@ -1355,7 +1385,7 @@
   }
 
   .dashcam-player-header,
-  .dashcam-segment-status,
+  .dashcam-segment-bar,
   .dashcam-camera-selector,
   .dashcam-player-actions {
     padding-left: var(--padding-base);

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1225,12 +1225,32 @@
   line-height: 1.25;
 }
 
+.dashcam-player-overlay .dashcam-player-close,
 .dashcam-player-close {
+  align-items: center;
   background: transparent;
   border: 0;
-  color: var(--text-muted);
+  box-shadow: none;
+  color: var(--danger-fg, #e05577);
   cursor: pointer;
-  font-size: 2rem;
+  display: inline-flex;
+  font-size: 2.75rem;
+  font-weight: 300;
+  justify-content: center;
+  line-height: 0.8;
+  margin: 0;
+  padding: 0 0.25rem;
+  transition: color var(--transition-fast, 0.15s ease), transform var(--transition-fast, 0.15s ease), opacity var(--transition-fast, 0.15s ease);
+}
+
+.dashcam-player-overlay .dashcam-player-close:hover,
+.dashcam-player-overlay .dashcam-player-close:focus-visible,
+.dashcam-player-close:hover,
+.dashcam-player-close:focus-visible {
+  background: transparent;
+  color: var(--danger-hover-bg, #ff6b8b);
+  outline: none;
+  transform: scale(1.15);
 }
 
 .dashcam-video-shell {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -159,34 +159,6 @@
   color: white;
 }
 
-.show-preserved-button {
-  background-color: var(--input-bg);
-  border: none;
-  border-radius: var(--border-radius-lg);
-  color: var(--text-color);
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-demi-bold);
-  margin-top: var(--margin-sm);
-  padding: var(--padding-sm) var(--padding-base);
-  text-align: center;
-  transition:
-    background-color var(--transition-fast),
-    box-shadow var(--transition-fast),
-    transform var(--transition-fast);
-  width: auto;
-}
-
-.show-preserved-button:hover {
-  background-color: var(--success-hover-bg);
-  box-shadow: var(--shadow-md);
-  transform: var(--hover-scale-sm);
-}
-
-.show-preserved-button[disabled] {
-  cursor: not-allowed;
-  opacity: var(--disabled-opacity);
-}
-
 .delete-all-button {
   background-color: var(--danger-bg);
   border: none;
@@ -441,5 +413,485 @@
   .route-logs-download-all,
   .route-log-download {
     text-align: center;
+  }
+}
+
+/* Date-organized route library */
+.screen-recordings-wrapper.dashcam-routes-wrapper {
+  padding: 0 var(--padding-base) var(--padding-xl);
+  width: 100%;
+}
+
+.screen-recordings-widget.dashcam-library {
+  align-items: stretch;
+  max-width: 92rem;
+  padding: clamp(1rem, 2vw, 2rem);
+}
+
+.screen-recordings-widget.dashcam-library:hover {
+  transform: none;
+}
+
+.dashcam-library-header,
+.dashcam-toolbar,
+.dashcam-results-summary,
+.dashcam-danger-zone,
+.dashcam-player-header,
+.dashcam-player-actions,
+.dashcam-camera-selector {
+  align-items: center;
+  display: flex;
+}
+
+.dashcam-library-header {
+  justify-content: space-between;
+  gap: var(--gap-md);
+}
+
+.dashcam-library-header h1,
+.dashcam-library-eyebrow,
+.dashcam-player-header h2,
+.dashcam-player-eyebrow {
+  margin: 0;
+}
+
+.dashcam-library-header h1 {
+  color: var(--text-color);
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  line-height: 1.15;
+}
+
+.dashcam-library-eyebrow,
+.dashcam-player-eyebrow {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.08em;
+  margin-bottom: var(--margin-xs);
+  text-transform: uppercase;
+}
+
+.dashcam-refresh-button,
+.dashcam-preserved-filter,
+.dashcam-sort,
+.dashcam-search {
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  color: var(--text-color);
+}
+
+.dashcam-refresh-button,
+.dashcam-preserved-filter {
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-demi-bold);
+  padding: 0.7rem 1rem;
+}
+
+.dashcam-refresh-button:disabled,
+.dashcam-player-actions button:disabled {
+  cursor: not-allowed;
+  opacity: var(--disabled-opacity);
+}
+
+.dashcam-toolbar {
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  margin-top: var(--margin-lg);
+}
+
+.dashcam-search {
+  align-items: center;
+  display: flex;
+  flex: 1 1 22rem;
+  gap: var(--gap-sm);
+  padding: 0 0.9rem;
+}
+
+.dashcam-search input,
+.dashcam-sort select {
+  background: transparent;
+  border: 0;
+  color: var(--text-color);
+  font: inherit;
+  outline: 0;
+}
+
+.dashcam-search input {
+  min-width: 0;
+  padding: 0.75rem 0;
+  width: 100%;
+}
+
+.dashcam-sort {
+  gap: var(--gap-sm);
+  padding: 0.65rem 0.85rem;
+}
+
+.dashcam-sort span {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.dashcam-sort select {
+  cursor: pointer;
+}
+
+.dashcam-preserved-filter[aria-pressed="true"] {
+  background: rgba(230, 78, 102, 0.16);
+  border-color: rgba(230, 78, 102, 0.65);
+}
+
+.dashcam-preserved-filter .bi-heart-fill {
+  color: #ef6078;
+  margin-right: 0.35rem;
+}
+
+.dashcam-results-summary {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  justify-content: space-between;
+  margin-top: var(--margin-base);
+  min-height: 1.5rem;
+}
+
+.dashcam-date-groups,
+.dashcam-date-group {
+  width: 100%;
+}
+
+.dashcam-date-group {
+  margin-top: var(--margin-lg);
+}
+
+.dashcam-date-group > h2 {
+  border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
+  color: var(--text-color);
+  font-size: var(--font-size-lg);
+  margin: 0;
+  padding-bottom: var(--padding-sm);
+}
+
+.dashcam-library .screen-recordings-grid.dashcam-routes-grid {
+  gap: clamp(0.8rem, 1.5vw, 1.25rem);
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  margin-top: var(--margin-base);
+}
+
+.dashcam-library .recording-card.dashcam-route-card {
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  position: relative;
+  text-align: left;
+}
+
+.dashcam-library .recording-card.dashcam-route-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+
+.dashcam-route-card .preserved-icon {
+  align-items: center;
+  background: rgba(10, 12, 18, 0.7);
+  border: 0;
+  border-radius: 50%;
+  color: white;
+  display: flex;
+  height: 2.6rem;
+  justify-content: center;
+  right: 0.7rem;
+  top: 0.7rem;
+  width: 2.6rem;
+}
+
+.dashcam-route-card .dashcam-preview {
+  background: linear-gradient(135deg, var(--sidebar-bg), var(--input-bg));
+  overflow: hidden;
+}
+
+.dashcam-preview-fallback {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  inset: 0;
+  justify-content: center;
+  position: absolute;
+}
+
+.dashcam-preview-fallback i {
+  font-size: 2rem;
+}
+
+.dashcam-preview:not(.thumbnail-failed) .dashcam-preview-fallback {
+  visibility: hidden;
+}
+
+.dashcam-preview img {
+  background: var(--sidebar-bg);
+  z-index: 1;
+}
+
+.dashcam-card-body {
+  padding: var(--padding-base);
+}
+
+.dashcam-card-body h3 {
+  color: var(--text-color);
+  font-size: var(--font-size-lg);
+  line-height: 1.3;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashcam-card-date,
+.dashcam-card-details,
+.dashcam-preserve-status {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  margin: var(--margin-xs) 0 0;
+}
+
+.dashcam-card-details {
+  display: flex;
+  gap: var(--gap-sm);
+}
+
+.dashcam-card-details span + span::before {
+  content: "·";
+  margin-right: var(--gap-sm);
+}
+
+.dashcam-preserve-status {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-demi-bold);
+  text-transform: uppercase;
+}
+
+.dashcam-preserve-status.preserved {
+  color: #ef6078;
+}
+
+.dashcam-loading,
+.dashcam-empty-state {
+  align-items: center;
+  color: var(--text-muted);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 15rem;
+  width: 100%;
+}
+
+.dashcam-loading span {
+  animation: dashcam-spin 0.8s linear infinite;
+  border: 3px solid var(--sidebar-border-color);
+  border-radius: 50%;
+  border-top-color: var(--main-fg);
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.dashcam-empty-state i {
+  font-size: 3rem;
+}
+
+.dashcam-error {
+  color: var(--danger-fg);
+}
+
+@keyframes dashcam-spin {
+  to { transform: rotate(360deg); }
+}
+
+.dashcam-danger-zone {
+  border-top: var(--border-width-thin) solid var(--sidebar-border-color);
+  gap: var(--gap-md);
+  justify-content: space-between;
+  margin-top: 2.5rem;
+  padding-top: var(--padding-lg);
+}
+
+.dashcam-danger-zone > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+}
+
+.dashcam-danger-zone span {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+/* Focused route player */
+.dashcam-player-overlay .media-player-content.dashcam-player {
+  background: var(--secondary-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.55);
+  max-height: calc(100vh - 2rem);
+  max-width: calc(100vw - 2rem);
+  overflow-y: auto;
+  padding: 0;
+  text-align: left;
+  width: min(62rem, calc(100vw - 2rem));
+}
+
+.dashcam-player-header {
+  justify-content: space-between;
+  padding: var(--padding-base) var(--padding-lg);
+}
+
+.dashcam-player-header h2 {
+  color: var(--text-color);
+  font-size: var(--font-size-xl);
+  line-height: 1.25;
+}
+
+.dashcam-player-close {
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 2rem;
+}
+
+.dashcam-video-shell {
+  aspect-ratio: 16 / 9;
+  background: #07080b;
+  position: relative;
+  width: 100%;
+}
+
+.dashcam-player-overlay .dashcam-player .dashcam-video-shell video {
+  border-radius: 0;
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.dashcam-player-state {
+  align-items: center;
+  background: rgba(7, 8, 11, 0.78);
+  color: white;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: absolute;
+  text-align: center;
+}
+
+.dashcam-player-state.error {
+  color: #ff9aaa;
+}
+
+.dashcam-player-state[hidden],
+.dashcam-segment-status[hidden],
+.dashcam-camera-selector button[hidden] {
+  display: none;
+}
+
+.dashcam-segment-status {
+  background: var(--sidebar-bg);
+  border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  padding: 0.65rem var(--padding-lg);
+}
+
+.dashcam-camera-selector {
+  gap: var(--gap-xs);
+  padding: var(--padding-base) var(--padding-lg) 0;
+}
+
+.dashcam-camera-selector button,
+.dashcam-player-actions button {
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  padding: 0.65rem 1rem;
+}
+
+.dashcam-camera-selector button.active {
+  background: var(--sidebar-active-bg);
+  box-shadow: inset 0 0 0 1px var(--main-fg);
+}
+
+.dashcam-player-actions {
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  padding: var(--padding-base) var(--padding-lg) var(--padding-lg);
+}
+
+.dashcam-player-actions .action-download {
+  background: var(--color-confirm);
+}
+
+.dashcam-player-actions .action-delete {
+  background: var(--danger-bg);
+  margin-left: auto;
+}
+
+@media only screen and (max-width: 768px) {
+  .screen-recordings-wrapper.dashcam-routes-wrapper {
+    padding: 0 var(--padding-sm) var(--padding-lg);
+  }
+
+  .screen-recordings-widget.dashcam-library {
+    margin-top: var(--padding-base);
+    padding: var(--padding-base);
+  }
+
+  .dashcam-library-header,
+  .dashcam-danger-zone {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dashcam-refresh-button,
+  .dashcam-preserved-filter,
+  .dashcam-sort {
+    justify-content: center;
+  }
+
+  .dashcam-sort {
+    display: flex;
+    flex: 1;
+  }
+
+  .dashcam-library .screen-recordings-grid.dashcam-routes-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dashcam-player-overlay .media-player-content.dashcam-player {
+    max-height: calc(100vh - 1rem);
+    max-width: calc(100vw - 1rem);
+    width: calc(100vw - 1rem);
+  }
+
+  .dashcam-player-header,
+  .dashcam-segment-status,
+  .dashcam-camera-selector,
+  .dashcam-player-actions {
+    padding-left: var(--padding-base);
+    padding-right: var(--padding-base);
+  }
+
+  .dashcam-camera-selector,
+  .dashcam-player-actions {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .dashcam-player-actions .action-delete {
+    margin-left: 0;
   }
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1257,6 +1257,7 @@
   /* Match qcamera.ts so the visible frame does not widen during the full-quality swap. */
   aspect-ratio: 526 / 330;
   background: #07080b;
+  contain: layout paint;
   overflow: hidden;
   position: relative;
   width: 100%;
@@ -1264,12 +1265,16 @@
 
 .dashcam-player-overlay .dashcam-player .dashcam-video-shell video {
   border-radius: 0;
-  height: 100%;
+  display: block;
+  height: 100% !important;
   inset: 0;
-  /* Keep the visible frame size fixed when qcamera swaps to a wider full stream. */
+  max-height: none;
+  max-width: none;
+  /* Crop both encodes into the same viewport instead of letting intrinsic media sizing win. */
   object-fit: cover;
+  object-position: center center;
   position: absolute;
-  width: 100%;
+  width: 100% !important;
 }
 
 .dashcam-player-overlay .dashcam-player .dashcam-video-shell video.active {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1277,6 +1277,11 @@
   width: 100% !important;
 }
 
+.dashcam-player-overlay .dashcam-player .dashcam-video-shell.qcamera-framing video {
+  /* qcamera.ts is a full-frame, non-uniform scale; mirror it to prevent a crop/FOV jump. */
+  object-fit: fill;
+}
+
 .dashcam-player-overlay .dashcam-player .dashcam-video-shell video.active {
   opacity: 1;
   pointer-events: auto;

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1266,7 +1266,8 @@
   border-radius: 0;
   height: 100%;
   inset: 0;
-  object-fit: contain;
+  /* Keep the visible frame size fixed when qcamera swaps to a wider full stream. */
+  object-fit: cover;
   position: absolute;
   width: 100%;
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1168,8 +1168,32 @@
 
 .dashcam-danger-zone > div {
   display: flex;
+}
+
+.dashcam-danger-copy {
   flex-direction: column;
   gap: var(--gap-xs);
+}
+
+.dashcam-danger-actions {
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--gap-sm);
+  justify-content: flex-end;
+}
+
+.dashcam-danger-actions .delete-all-button {
+  margin: 0;
+}
+
+.delete-all-button.delete-non-preserved-button {
+  background: transparent;
+  border: var(--border-width-thin) solid var(--danger-bg);
+  color: var(--danger-bg);
+}
+
+.delete-all-button.delete-non-preserved-button:hover {
+  background: rgba(224, 85, 119, 0.15);
 }
 
 .dashcam-danger-zone span {
@@ -1392,6 +1416,11 @@
 
   .dashcam-library-header,
   .dashcam-danger-zone {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .dashcam-danger-actions {
     align-items: stretch;
     flex-direction: column;
   }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1254,7 +1254,8 @@
 }
 
 .dashcam-video-shell {
-  aspect-ratio: 16 / 9;
+  /* Match qcamera.ts so the visible frame does not widen during the full-quality swap. */
+  aspect-ratio: 526 / 330;
   background: #07080b;
   overflow: hidden;
   position: relative;

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -244,6 +244,47 @@
   transform: var(--hover-scale-sm);
 }
 
+.route-logs {
+  margin-top: var(--padding-base);
+  max-height: 40vh;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.route-logs-message {
+  margin: 0;
+  padding: var(--padding-sm) 0;
+  font-size: var(--font-size-sm);
+}
+
+.route-logs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--padding-sm);
+  padding-bottom: var(--padding-sm);
+  font-size: var(--font-size-sm);
+}
+
+.route-logs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.route-logs-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--padding-sm);
+  padding: var(--padding-sm) 0;
+  font-size: var(--font-size-sm);
+}
+
+.route-logs a {
+  text-decoration: underline;
+}
+
 @media only screen and (max-width: 768px) and (orientation: portrait) {
   .media-player-content {
     width: 90%;
@@ -265,5 +306,12 @@
     font-size: var(--font-size-sm);
     text-align: center;
     width: 100%;
+  }
+
+  .route-logs-header,
+  .route-logs-list li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
   }
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.css
@@ -1244,13 +1244,43 @@
   display: none;
 }
 
-.dashcam-segment-bar {
+.dashcam-player-title-row {
+  align-items: center;
+  display: flex;
+  gap: var(--gap-xs);
+}
+
+.dashcam-title-rename {
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-base);
+  line-height: 1;
+  padding: 0.25rem;
+}
+
+.dashcam-title-rename:hover {
+  color: var(--text-color);
+}
+
+/* Cameras left, segments centred, actions right - the side columns stay equal so the
+   segment controls sit in the true centre regardless of how wide either side is. */
+.dashcam-player-toolbar {
   align-items: center;
   background: var(--sidebar-bg);
   border-bottom: var(--border-width-thin) solid var(--sidebar-border-color);
+  display: grid;
+  gap: var(--gap-sm);
+  grid-template-columns: 1fr auto 1fr;
+  padding: 0.65rem var(--padding-lg);
+}
+
+.dashcam-segment-bar {
+  align-items: center;
   display: flex;
   gap: var(--gap-xs);
-  padding: 0.65rem var(--padding-lg);
+  justify-self: center;
 }
 
 .dashcam-segment-bar .segment-step {
@@ -1284,18 +1314,30 @@
 
 .dashcam-camera-selector {
   gap: var(--gap-xs);
-  padding: var(--padding-base) var(--padding-lg) 0;
+  justify-self: start;
 }
 
-.dashcam-camera-selector button,
-.dashcam-player-actions button {
+.dashcam-camera-selector button {
   background: var(--input-bg);
   border: var(--border-width-thin) solid var(--sidebar-border-color);
   border-radius: var(--border-radius-md);
   color: var(--text-color);
   cursor: pointer;
+  font-size: var(--font-size-sm);
+  padding: 0.35rem 0.7rem;
+}
+
+.dashcam-player-actions button {
+  align-items: center;
+  background: var(--input-bg);
+  border: var(--border-width-thin) solid var(--sidebar-border-color);
+  border-radius: var(--border-radius-md);
+  color: var(--text-color);
+  cursor: pointer;
+  display: flex;
   font-size: var(--font-size-base);
-  padding: 0.65rem 1rem;
+  justify-content: center;
+  padding: 0.35rem 0.6rem;
 }
 
 .dashcam-camera-selector button.active {
@@ -1304,18 +1346,21 @@
 }
 
 .dashcam-player-actions {
-  flex-wrap: wrap;
-  gap: var(--gap-sm);
-  padding: var(--padding-base) var(--padding-lg) var(--padding-lg);
+  gap: var(--gap-xs);
+  justify-self: end;
 }
 
-.dashcam-player-actions .action-download {
+.dashcam-player-actions .action-download:not(:disabled) {
   background: var(--color-confirm);
+}
+
+.dashcam-player-actions button:disabled {
+  cursor: default;
+  opacity: 0.4;
 }
 
 .dashcam-player-actions .action-delete {
   background: var(--danger-bg);
-  margin-left: auto;
 }
 
 /* Responsive Adaptations */
@@ -1385,20 +1430,19 @@
   }
 
   .dashcam-player-header,
-  .dashcam-segment-bar,
-  .dashcam-camera-selector,
-  .dashcam-player-actions {
+  .dashcam-player-toolbar {
     padding-left: var(--padding-base);
     padding-right: var(--padding-base);
   }
 
-  .dashcam-camera-selector,
-  .dashcam-player-actions {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
+  /* Too narrow for three columns: stack them and centre each row. */
+  .dashcam-player-toolbar {
+    grid-template-columns: 1fr;
+    justify-items: center;
   }
 
-  .dashcam-player-actions .action-delete {
-    margin-left: 0;
+  .dashcam-camera-selector,
+  .dashcam-player-actions {
+    justify-self: center;
   }
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -540,7 +540,7 @@ async function openOverlay(route) {
     cancelUpgrade()
     wantsPlayback = autoplay
     showingPreview = preview === undefined ? supportsLowQuality(camera) : preview
-    setPlayerMessage(message || "Loading video…")
+    if (message) setPlayerMessage(message)
 
     stagingVideo.pause()
     stagingVideo.removeAttribute("src")
@@ -623,9 +623,7 @@ async function openOverlay(route) {
   const handlePlaying = event => {
     if (event.target === activeVideo) setPlayerMessage("")
   }
-  const handleWaiting = event => {
-    if (event.target === activeVideo && !isUpgrading) setPlayerMessage("Loading video…")
-  }
+  const handleWaiting = () => {}
   const handleError = event => {
     if (event.target !== activeVideo) return
     // A dead preview drops through to the real stream rather than showing an error.

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -4,6 +4,7 @@ import { Modal } from "/assets/components/modal.js"
 import {
   buildRouteView,
   cameraVideoUrl,
+  computeRouteStats,
   formatApproxDuration,
   getSegmentStatus,
   groupRoutesByDate,
@@ -19,6 +20,7 @@ const state = reactive({
   searchQuery: "",
   sortOrder: "newest",
   showPreservedOnly: false,
+  viewMode: "list",
   progress: 0,
   total: 0,
   showDeleteAllModal: false,
@@ -29,6 +31,7 @@ let routesAbortController = null
 let routesRequestToken = 0
 let seenRouteNames = new Set()
 let overlay = null
+const routeLogsCache = new Map()
 
 function routeLabel(route) {
   return route.displayName || route.displayDate || route.name
@@ -218,7 +221,7 @@ function openLogsDialog(route, logsButton, getCachedLogs, setCachedLogs) {
   const closeLogsDialog = () => {
     document.removeEventListener("keydown", handleKeydown)
     closeDialog(logsDialog)
-    logsButton.focus()
+    logsButton?.focus()
   }
   const handleKeydown = event => { if (event.key === "Escape") closeLogsDialog() }
   closeButton.onclick = closeLogsDialog
@@ -240,7 +243,7 @@ function openLogsDialog(route, logsButton, getCachedLogs, setCachedLogs) {
       </ul>`
   }
 
-  const cachedLogs = getCachedLogs()
+  const cachedLogs = getCachedLogs?.()
   if (cachedLogs) {
     renderLogs(cachedLogs)
     return
@@ -253,12 +256,22 @@ function openLogsDialog(route, logsButton, getCachedLogs, setCachedLogs) {
         if (content.isConnected) content.innerHTML = `<p class="route-logs-message route-logs-error">${escapeHtml(data.error || "Could not read logs.")}</p>`
         return
       }
-      setCachedLogs(data)
+      setCachedLogs?.(data)
       if (content.isConnected) renderLogs(data)
     })
     .catch(error => {
       if (content.isConnected) content.innerHTML = `<p class="route-logs-message route-logs-error">Could not reach the device: ${escapeHtml(error.message)}</p>`
     })
+}
+
+function openLogsFromRow(route, event) {
+  const button = event.currentTarget
+  openLogsDialog(
+    route,
+    button,
+    () => routeLogsCache.get(route.name) || null,
+    value => { routeLogsCache.set(route.name, value) },
+  )
 }
 
 async function openOverlay(route) {
@@ -369,7 +382,6 @@ async function openOverlay(route) {
       setPlayerMessage("Switching camera…")
       video.src = cameraVideoUrl(segments[current], selectedCamera)
       video.load()
-      // Switching cameras deliberately leaves current and the status strip unchanged.
     })
   }
 
@@ -406,7 +418,7 @@ function closeOverlay() {
 }
 
 async function togglePreserved(route, event) {
-  event.stopPropagation()
+  event?.stopPropagation?.()
   const isPreserved = !route.is_preserved
   try {
     const response = await fetch(`/api/routes/${route.name}/preserve`, { method: isPreserved ? "POST" : "DELETE" })
@@ -456,35 +468,71 @@ export function RouteRecordings() {
   return html`
     <div class="screen-recordings-wrapper dashcam-routes-wrapper">
       <section class="screen-recordings-widget dashcam-library">
-        <header class="dashcam-library-header">
-          <div><p class="dashcam-library-eyebrow">Local recordings</p><h1>Dashcam Routes</h1></div>
-          <button class="dashcam-refresh-button" type="button" @click="${refresh}" disabled="${() => state.loading || false}"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
-        </header>
+        ${() => {
+          const stats = computeRouteStats(state.routes)
+          return html`
+            <header class="dashcam-library-header">
+              <div class="dashcam-header-info">
+                <p class="dashcam-library-eyebrow">Local recordings</p>
+                <h1>Dashcam Routes</h1>
+                <div class="dashcam-stats-bar">
+                  <span class="dashcam-stat-chip"><i class="bi bi-car-front-fill"></i> <strong>${stats.count}</strong> ${stats.count === 1 ? "drive" : "drives"}</span>
+                  <span class="dashcam-stat-chip"><i class="bi bi-stopwatch-fill"></i> <strong>${stats.formattedDuration}</strong> total</span>
+                  ${stats.preservedCount > 0 ? html`<span class="dashcam-stat-chip stat-chip-preserved"><i class="bi bi-heart-fill"></i> <strong>${stats.preservedCount}</strong> preserved</span>` : ""}
+                </div>
+              </div>
+              <div class="dashcam-header-controls">
+                <button class="dashcam-refresh-button" type="button" @click="${refresh}" disabled="${() => state.loading || false}" title="Refresh routes">
+                  <i class="bi bi-arrow-clockwise"></i> Refresh
+                </button>
+              </div>
+            </header>`
+        }}
 
         <div class="dashcam-toolbar">
-          <label class="dashcam-search">
-            <i class="bi bi-search"></i>
-            <input type="search" placeholder="Search names, dates, or route IDs" aria-label="Search routes" value="${() => state.searchQuery}" @input="${event => { state.searchQuery = event.target.value }}">
-          </label>
+          <div class="dashcam-search-box">
+            <i class="bi bi-search dashcam-search-icon"></i>
+            <input type="search" placeholder="Search route names, dates, or hash IDs..." aria-label="Search routes" value="${() => state.searchQuery}" @input="${event => { state.searchQuery = event.target.value }}">
+            ${() => state.searchQuery ? html`
+              <button class="dashcam-search-clear" type="button" title="Clear search" @click="${() => { state.searchQuery = "" }}"><i class="bi bi-x"></i></button>
+            ` : ""}
+          </div>
+          <div class="dashcam-filter-group">
+            <button class="dashcam-filter-pill ${() => !state.showPreservedOnly ? "active" : ""}" type="button" @click="${() => { state.showPreservedOnly = false }}">
+              All Drives
+            </button>
+            <button class="dashcam-filter-pill ${() => state.showPreservedOnly ? "active" : ""}" type="button" @click="${() => { state.showPreservedOnly = true }}">
+              <i class="bi bi-heart-fill"></i> Preserved
+            </button>
+          </div>
           <label class="dashcam-sort">
             <span>Sort</span>
             <select @change="${event => { state.sortOrder = event.target.value }}">
-              <option value="newest" selected="${() => state.sortOrder === "newest" || false}">Newest</option>
-              <option value="oldest" selected="${() => state.sortOrder === "oldest" || false}">Oldest</option>
+              <option value="newest" selected="${() => state.sortOrder === "newest" || false}">Newest first</option>
+              <option value="oldest" selected="${() => state.sortOrder === "oldest" || false}">Oldest first</option>
+              <option value="longest" selected="${() => state.sortOrder === "longest" || false}">Longest duration</option>
+              <option value="shortest" selected="${() => state.sortOrder === "shortest" || false}">Shortest duration</option>
             </select>
           </label>
-          <button class="dashcam-preserved-filter" type="button" aria-pressed="${() => String(state.showPreservedOnly)}" @click="${() => { state.showPreservedOnly = !state.showPreservedOnly }}">
-            <i class="bi bi-heart-fill"></i> ${() => state.showPreservedOnly ? "Preserved only" : "All routes"}
-          </button>
+          <div class="dashcam-view-toggle" aria-label="Layout view mode">
+            <button class="dashcam-view-btn ${() => state.viewMode === "list" ? "active" : ""}" type="button" title="List View" @click="${() => { state.viewMode = "list" }}">
+              <i class="bi bi-list-ul"></i>
+            </button>
+            <button class="dashcam-view-btn ${() => state.viewMode === "grid" ? "active" : ""}" type="button" title="Grid View" @click="${() => { state.viewMode = "grid" }}">
+              <i class="bi bi-grid-fill"></i>
+            </button>
+          </div>
         </div>
 
         ${() => {
           const view = buildRouteView(state.routes, { preservedOnly: state.showPreservedOnly, searchQuery: state.searchQuery, sortOrder: state.sortOrder })
           const groups = groupRoutesByDate(view.visible)
+          const isGrid = state.viewMode === "grid"
+
           return html`
             <div class="dashcam-results-summary" aria-live="polite">
-              <span>${view.matching.length} matching route${view.matching.length === 1 ? "" : "s"}</span>
-              ${state.loading ? html`<span>Loading ${state.progress} of ${state.total}</span>` : html`<span>${state.routes.length} total</span>`}
+              <span>${view.matching.length} matching drive${view.matching.length === 1 ? "" : "s"}</span>
+              ${state.loading ? html`<span>Loading ${state.progress} of ${state.total}</span>` : html`<span>${state.routes.length} total local</span>`}
             </div>
             ${state.error ? html`<p class="screen-recordings-message dashcam-error">${state.error}</p>` : ""}
             ${state.isDeletingAll ? html`<p class="screen-recordings-message">Deleting routes&hellip;</p>` : ""}
@@ -493,25 +541,93 @@ export function RouteRecordings() {
             <div class="dashcam-date-groups">
               ${groups.map(group => html`
                 <section class="dashcam-date-group">
-                  <h2>${group.label}</h2>
-                  <div class="screen-recordings-grid dashcam-routes-grid">
-                    ${group.routes.map(route => html`
-                      <article class="recording-card dashcam-route-card" @click="${() => { state.selectedRoute = route }}">
-                        <button class="preserved-icon" type="button" aria-label="${route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${route.is_preserved ? "Preserved" : "Not preserved"}" @click="${event => togglePreserved(route, event)}">
-                          ${() => html`<i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>`}
-                        </button>
-                        <div class="recording-preview-container dashcam-preview">
-                          <span class="dashcam-preview-fallback"><i class="bi bi-camera-video"></i><small>Preview unavailable</small></span>
-                          <img src="${route.png}" class="recording-preview" loading="lazy" alt="" @error="${thumbnailFailed}">
-                        </div>
-                        <div class="dashcam-card-body">
-                          <h3>${route.displayName}</h3>
-                          ${route.isCustomName ? html`<p class="dashcam-card-date">${route.displayDate}</p>` : ""}
-                          <p class="dashcam-card-details"><span>${formatApproxDuration(route.approxDurationSeconds)}</span><span>${route.segmentCount} segment${route.segmentCount === 1 ? "" : "s"}</span></p>
-                          <p class="dashcam-preserve-status ${route.is_preserved ? "preserved" : ""}"><i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i> ${route.is_preserved ? "Preserved" : "Not preserved"}</p>
-                        </div>
-                      </article>`)}
+                  <div class="dashcam-date-group-header">
+                    <h2>${group.label}</h2>
+                    <span class="dashcam-date-group-count">${group.routes.length} ${group.routes.length === 1 ? "drive" : "drives"}</span>
                   </div>
+                  ${isGrid ? html`
+                    <div class="screen-recordings-grid dashcam-routes-grid">
+                      ${group.routes.map(route => html`
+                        <article class="recording-card dashcam-route-card ${route.is_preserved ? "is-preserved" : ""}" @click="${() => { state.selectedRoute = route }}">
+                          <div class="dashcam-card-top-bar">
+                            <button class="btn-route-action btn-preserve ${route.is_preserved ? "active" : ""}" type="button" aria-label="${route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${route.is_preserved ? "Preserved (click to unpreserve)" : "Click to preserve"}" @click="${event => togglePreserved(route, event)}">
+                              <i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>
+                            </button>
+                            <span class="meta-pill id-pill" title="Route ID: ${route.name}"><i class="bi bi-hash"></i>${route.name.split("--").slice(1).join("--") || route.name}</span>
+                          </div>
+                          <div class="recording-preview-container dashcam-preview">
+                            <span class="dashcam-preview-fallback"><i class="bi bi-camera-video"></i><small>Preview unavailable</small></span>
+                            <img src="${route.png}" class="recording-preview" loading="lazy" alt="" @error="${thumbnailFailed}">
+                            <span class="dashcam-grid-play-overlay"><i class="bi bi-play-fill"></i></span>
+                          </div>
+                          <div class="dashcam-card-body">
+                            <div class="dashcam-route-title-row">
+                              <h3 title="${route.displayName}">${route.displayName}</h3>
+                              ${route.isCustomName ? html`<span class="dashcam-custom-badge" title="Custom name"><i class="bi bi-tag-fill"></i></span>` : ""}
+                            </div>
+                            ${route.isCustomName ? html`<p class="dashcam-card-date">${route.displayDate}</p>` : ""}
+                            <div class="dashcam-route-meta-pills">
+                              <span class="meta-pill duration-pill"><i class="bi bi-clock"></i> ${formatApproxDuration(route.approxDurationSeconds)}</span>
+                              <span class="meta-pill segments-pill"><i class="bi bi-collection-play"></i> ${route.segmentCount} seg</span>
+                            </div>
+                            <div class="dashcam-card-actions" @click="${event => event.stopPropagation()}">
+                              <button class="btn-route-action btn-play" type="button" title="Play route" @click="${() => { state.selectedRoute = route }}">
+                                <i class="bi bi-play-fill"></i> Play
+                              </button>
+                              <button class="btn-route-action btn-icon" type="button" title="View logs" @click="${event => openLogsFromRow(route, event)}">
+                                <i class="bi bi-file-earmark-arrow-down"></i>
+                              </button>
+                              <button class="btn-route-action btn-icon" type="button" title="Rename" @click="${() => renameRoute(route)}">
+                                <i class="bi bi-pencil"></i>
+                              </button>
+                              <button class="btn-route-action btn-icon btn-danger-action" type="button" title="Delete" @click="${() => deleteRoute(route)}">
+                                <i class="bi bi-trash"></i>
+                              </button>
+                            </div>
+                          </div>
+                        </article>`)}
+                    </div>
+                  ` : html`
+                    <div class="dashcam-routes-list">
+                      ${group.routes.map(route => html`
+                        <article class="dashcam-route-row ${route.is_preserved ? "is-preserved" : ""}" @click="${() => { state.selectedRoute = route }}">
+                          <div class="dashcam-mini-preview">
+                            <span class="dashcam-mini-fallback"><i class="bi bi-camera-video"></i></span>
+                            <img src="${route.png}" class="dashcam-mini-img" loading="lazy" alt="" @error="${thumbnailFailed}">
+                            <span class="dashcam-mini-play-overlay"><i class="bi bi-play-fill"></i></span>
+                          </div>
+                          <div class="dashcam-route-info">
+                            <div class="dashcam-route-title-row">
+                              <h3 class="dashcam-route-title" title="${route.displayName}">${route.displayName}</h3>
+                              ${route.isCustomName ? html`<span class="dashcam-custom-badge" title="Custom name"><i class="bi bi-tag-fill"></i> Custom</span>` : ""}
+                            </div>
+                            ${route.isCustomName ? html`<p class="dashcam-route-subdate"><i class="bi bi-calendar3"></i> ${route.displayDate}</p>` : ""}
+                            <div class="dashcam-route-meta-pills">
+                              <span class="meta-pill duration-pill" title="Estimated duration"><i class="bi bi-clock"></i> ${formatApproxDuration(route.approxDurationSeconds)}</span>
+                              <span class="meta-pill segments-pill" title="Segments recorded"><i class="bi bi-collection-play"></i> ${route.segmentCount} segment${route.segmentCount === 1 ? "" : "s"}</span>
+                              ${route.is_preserved ? html`<span class="meta-pill preserved-pill" title="Preserved from deletion"><i class="bi bi-heart-fill"></i> Preserved</span>` : ""}
+                              <span class="meta-pill id-pill" title="Route ID: ${route.name}"><i class="bi bi-hash"></i>${route.name.split("--").slice(1).join("--") || route.name}</span>
+                            </div>
+                          </div>
+                          <div class="dashcam-route-actions" @click="${event => event.stopPropagation()}">
+                            <button class="btn-route-action btn-play" type="button" title="Play recording" @click="${() => { state.selectedRoute = route }}">
+                              <i class="bi bi-play-fill"></i> <span>Play</span>
+                            </button>
+                            <button class="btn-route-action btn-preserve ${route.is_preserved ? "active" : ""}" type="button" aria-label="${route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${route.is_preserved ? "Preserved (click to unpreserve)" : "Click to preserve"}" @click="${event => togglePreserved(route, event)}">
+                              <i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>
+                            </button>
+                            <button class="btn-route-action btn-icon" type="button" title="View & download logs" @click="${event => openLogsFromRow(route, event)}">
+                              <i class="bi bi-file-earmark-arrow-down"></i>
+                            </button>
+                            <button class="btn-route-action btn-icon" type="button" title="Rename route" @click="${() => renameRoute(route)}">
+                              <i class="bi bi-pencil"></i>
+                            </button>
+                            <button class="btn-route-action btn-icon btn-danger-action" type="button" title="Delete route" @click="${() => deleteRoute(route)}">
+                              <i class="bi bi-trash"></i>
+                            </button>
+                          </div>
+                        </article>`)}
+                    </div>`}
                 </section>`)}
             </div>
             ${view.truncated ? html`<p class="screen-recordings-message">Showing the first ${MAX_RENDERED_ROUTES} of ${view.matching.length} matching routes.</p>` : ""}`

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -300,8 +300,8 @@ async function openOverlay(route) {
         <button class="dashcam-player-close action-close" type="button" aria-label="Close player">&times;</button>
       </header>
       <div class="dashcam-video-shell">
-        <video controls muted playsinline preload="metadata"></video>
-        <canvas class="dashcam-transition-frame" aria-hidden="true" hidden></canvas>
+        <video class="dashcam-video active" controls muted playsinline preload="metadata"></video>
+        <video class="dashcam-video staging" muted playsinline preload="none"></video>
         <div class="dashcam-player-state" role="status">Loading route metadata&hellip;</div>
       </div>
       <div class="dashcam-player-toolbar">
@@ -324,8 +324,9 @@ async function openOverlay(route) {
     </section>`
   document.body.appendChild(overlay)
 
-  const video = overlay.querySelector("video")
-  const transitionFrame = overlay.querySelector(".dashcam-transition-frame")
+  const [videoA, videoB] = overlay.querySelectorAll(".dashcam-video")
+  let activeVideo = videoA
+  let stagingVideo = videoB
   const playerState = overlay.querySelector(".dashcam-player-state")
   const segmentBar = overlay.querySelector(".dashcam-segment-bar")
   const segmentSelect = overlay.querySelector(".segment-select")
@@ -343,7 +344,7 @@ async function openOverlay(route) {
   let qualityToken = 0
   let upgradeController = null
   let upgradeTimer = null
-  let transitionActive = false
+  let isUpgrading = false
 
   const setPlayerMessage = (message, isError = false) => {
     playerState.textContent = message
@@ -363,59 +364,138 @@ async function openOverlay(route) {
     segmentBar.hidden = !segments.length
   }
 
-  const finishTransition = () => {
-    transitionActive = false
-    transitionFrame.hidden = true
-  }
-  const holdCurrentFrame = () => {
-    if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || !video.videoWidth || !video.videoHeight) return false
-    const context = transitionFrame.getContext("2d")
-    if (!context) return false
-    transitionFrame.width = video.videoWidth
-    transitionFrame.height = video.videoHeight
-    try {
-      context.drawImage(video, 0, 0, transitionFrame.width, transitionFrame.height)
-    } catch (_) {
-      return false
-    }
-    transitionActive = true
-    transitionFrame.hidden = false
-    setPlayerMessage("")
-    return true
-  }
-  const swapSource = (url, { message, seamless = false } = {}) => {
-    const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
-    const shouldResume = !video.paused && !video.ended
-    const heldFrame = seamless && holdCurrentFrame()
-    // Never trade a working preview for a black frame. The prepared full stream can
-    // be attempted again later, while the low-resolution video keeps playing.
-    if (seamless && !heldFrame) return false
-    if (heldFrame) video.addEventListener("canplay", finishTransition, { once: true })
-    video.addEventListener("loadedmetadata", () => {
-      if (playbackTime > 0) {
-        try {
-          video.currentTime = Math.min(playbackTime, Number.isFinite(video.duration) ? video.duration : playbackTime)
-        } catch (_) {}
-      }
-      if (shouldResume) video.play().catch(() => {})
-    }, { once: true })
-    if (!heldFrame) finishTransition()
-    if (message) setPlayerMessage(message)
-    video.src = url
-    video.load()
-    return true
-  }
-
   const cancelUpgrade = () => {
     qualityToken += 1
+    isUpgrading = false
     clearTimeout(upgradeTimer)
     upgradeTimer = null
     upgradeController?.abort()
     upgradeController = null
+    stagingVideo.pause()
+    stagingVideo.removeAttribute("src")
+    stagingVideo.load()
   }
 
-  // Prepare the real stream behind the playing preview. Only replace the media source
-  // after the server confirms the remux is ready, so slow device work never blanks it.
+  const performSeamlessUpgrade = (fullUrl, token) => {
+    if (token !== qualityToken || !showingPreview || !overlay) return
+    isUpgrading = true
+
+    stagingVideo.muted = activeVideo.muted
+    stagingVideo.volume = activeVideo.volume
+    stagingVideo.playbackRate = activeVideo.playbackRate
+    stagingVideo.src = fullUrl
+    stagingVideo.preload = "auto"
+    stagingVideo.load()
+
+    const cleanupStaging = () => {
+      stagingVideo.removeEventListener("loadedmetadata", onMetadata)
+      stagingVideo.removeEventListener("error", onStagingError)
+    }
+
+    const onStagingError = () => {
+      cleanupStaging()
+      if (token !== qualityToken) return
+      isUpgrading = false
+      showingPreview = false
+    }
+
+    const onMetadata = () => {
+      if (token !== qualityToken || !showingPreview || !overlay) {
+        cleanupStaging()
+        return
+      }
+
+      const syncAndSwap = () => {
+        if (token !== qualityToken || !showingPreview || !overlay) {
+          cleanupStaging()
+          return
+        }
+
+        const applySwap = () => {
+          if (token !== qualityToken || !showingPreview || !overlay) {
+            cleanupStaging()
+            return
+          }
+          cleanupStaging()
+
+          const targetTime = Number.isFinite(activeVideo.currentTime) ? activeVideo.currentTime : 0
+          const isPlaying = !activeVideo.paused && !activeVideo.ended
+
+          stagingVideo.muted = activeVideo.muted
+          stagingVideo.volume = activeVideo.volume
+          stagingVideo.playbackRate = activeVideo.playbackRate
+
+          if (Math.abs(stagingVideo.currentTime - targetTime) > 0.15) {
+            try {
+              stagingVideo.currentTime = targetTime
+            } catch (_) {}
+          }
+
+          if (isPlaying && stagingVideo.paused) {
+            stagingVideo.play().catch(() => {})
+          } else if (!isPlaying && !stagingVideo.paused) {
+            stagingVideo.pause()
+          }
+
+          activeVideo.classList.remove("active")
+          activeVideo.classList.add("staging")
+          activeVideo.controls = false
+
+          stagingVideo.classList.remove("staging")
+          stagingVideo.classList.add("active")
+          stagingVideo.controls = true
+
+          const oldActive = activeVideo
+          activeVideo = stagingVideo
+          stagingVideo = oldActive
+
+          stagingVideo.pause()
+          stagingVideo.removeAttribute("src")
+          stagingVideo.load()
+
+          showingPreview = false
+          isUpgrading = false
+          setPlayerMessage("")
+        }
+
+        const isPlaying = !activeVideo.paused && !activeVideo.ended
+        if (isPlaying) {
+          stagingVideo.play().then(() => {
+            if ("requestVideoFrameCallback" in stagingVideo) {
+              stagingVideo.requestVideoFrameCallback(() => applySwap())
+            } else {
+              stagingVideo.addEventListener("timeupdate", applySwap, { once: true })
+            }
+          }).catch(() => {
+            applySwap()
+          })
+        } else {
+          if ("requestVideoFrameCallback" in stagingVideo) {
+            stagingVideo.requestVideoFrameCallback(() => applySwap())
+          } else {
+            applySwap()
+          }
+        }
+      }
+
+      const playbackTime = Number.isFinite(activeVideo.currentTime) ? activeVideo.currentTime : 0
+      if (playbackTime > 0) {
+        stagingVideo.addEventListener("seeked", syncAndSwap, { once: true })
+        try {
+          stagingVideo.currentTime = Math.min(playbackTime, Number.isFinite(stagingVideo.duration) ? stagingVideo.duration : playbackTime)
+        } catch (_) {
+          syncAndSwap()
+        }
+      } else {
+        syncAndSwap()
+      }
+    }
+
+    stagingVideo.addEventListener("loadedmetadata", onMetadata, { once: true })
+    stagingVideo.addEventListener("error", onStagingError, { once: true })
+  }
+
+  // Request the real stream behind the playing preview without interrupting playback.
   const requestFullQuality = (segmentUrl, camera, attempt = 0) => {
     const token = ++qualityToken
     upgradeController?.abort()
@@ -423,24 +503,14 @@ async function openOverlay(route) {
     upgradeController = controller
     const fullUrl = cameraVideoUrl(segmentUrl, camera)
     const stillCurrent = () =>
-      token === qualityToken && showingPreview && segments[current] === segmentUrl && selectedCamera === camera && !!overlay
-    const swapPreparedStream = (attempt = 0) => {
-      if (!stillCurrent()) return
-      if (swapSource(fullUrl, { seamless: true })) {
-        showingPreview = false
-        return
-      }
-      if (attempt < 5) {
-        upgradeTimer = setTimeout(() => swapPreparedStream(attempt + 1), 100)
-      }
-    }
+      token === qualityToken && showingPreview && segments[current] === segmentUrl && selectedCamera === camera && Boolean(overlay)
 
     fetch(fullUrl, { method: "HEAD", signal: controller.signal })
       .then(response => {
         if (!stillCurrent()) return
         if (upgradeController === controller) upgradeController = null
         if (response.ok) {
-          swapPreparedStream()
+          performSeamlessUpgrade(fullUrl, token)
           return
         }
         if (response.status === 503 && attempt < FULL_QUALITY_RETRIES) {
@@ -468,13 +538,22 @@ async function openOverlay(route) {
     const camera = selectedCamera
     if (!segmentUrl || !camera) return
     cancelUpgrade()
-    finishTransition()
     wantsPlayback = autoplay
     showingPreview = preview === undefined ? supportsLowQuality(camera) : preview
     setPlayerMessage(message || "Loading video…")
-    video.src = cameraVideoUrl(segmentUrl, camera, showingPreview ? "low" : undefined)
-    video.load()
-    if (autoplay) video.play().catch(() => {})
+
+    stagingVideo.pause()
+    stagingVideo.removeAttribute("src")
+    stagingVideo.classList.remove("active")
+    stagingVideo.classList.add("staging")
+    stagingVideo.controls = false
+
+    activeVideo.classList.remove("staging")
+    activeVideo.classList.add("active")
+    activeVideo.controls = true
+    activeVideo.src = cameraVideoUrl(segmentUrl, camera, showingPreview ? "low" : undefined)
+    activeVideo.load()
+    if (autoplay) activeVideo.play().catch(() => {})
   }
 
   const playCurrentSegment = (autoplay = true) => {
@@ -489,7 +568,7 @@ async function openOverlay(route) {
       syncSegmentControls()
       return
     }
-    const keepPlaying = video.ended || (!video.paused && !video.error)
+    const keepPlaying = activeVideo.ended || (!activeVideo.paused && !activeVideo.error)
     current = target
     playCurrentSegment(keepPlaying)
   }
@@ -529,21 +608,26 @@ async function openOverlay(route) {
     link.remove()
   }
 
-  video.addEventListener("loadedmetadata", () => {
+  const handleLoadedMetadata = event => {
+    if (event.target !== activeVideo) return
     if (!showingPreview) return
-    if (shouldUpgradeFromHeight(video.videoHeight)) {
+    if (shouldUpgradeFromHeight(activeVideo.videoHeight)) {
       scheduleUpgrade(segments[current], selectedCamera)
     } else {
       showingPreview = false
     }
-  })
-  video.addEventListener("loadeddata", () => setPlayerMessage(""))
-  video.addEventListener("playing", () => setPlayerMessage(""))
-  video.addEventListener("waiting", () => {
-    if (!transitionActive) setPlayerMessage("Loading video…")
-  })
-  video.addEventListener("error", () => {
-    finishTransition()
+  }
+  const handleLoadedData = event => {
+    if (event.target === activeVideo) setPlayerMessage("")
+  }
+  const handlePlaying = event => {
+    if (event.target === activeVideo) setPlayerMessage("")
+  }
+  const handleWaiting = event => {
+    if (event.target === activeVideo && !isUpgrading) setPlayerMessage("Loading video…")
+  }
+  const handleError = event => {
+    if (event.target !== activeVideo) return
     // A dead preview drops through to the real stream rather than showing an error.
     if (showingPreview) {
       showingPreview = false
@@ -552,8 +636,42 @@ async function openOverlay(route) {
       return
     }
     setPlayerMessage("This segment could not be played.", true)
-  })
-  video.addEventListener("ended", () => goToSegment(current + 1))
+  }
+  const handleEnded = event => {
+    if (event.target === activeVideo) goToSegment(current + 1)
+  }
+  const handleSeeking = event => {
+    if (event.target !== activeVideo) return
+    if (isUpgrading && stagingVideo.readyState >= 1) {
+      try {
+        stagingVideo.currentTime = activeVideo.currentTime
+      } catch (_) {}
+    }
+  }
+  const handlePause = event => {
+    if (event.target !== activeVideo) return
+    if (isUpgrading && !stagingVideo.paused) stagingVideo.pause()
+  }
+  const handlePlay = event => {
+    if (event.target !== activeVideo) return
+    if (isUpgrading && stagingVideo.paused && stagingVideo.readyState >= 3) {
+      stagingVideo.play().catch(() => {})
+    }
+  }
+
+  const bindVideoEvents = el => {
+    el.addEventListener("loadedmetadata", handleLoadedMetadata)
+    el.addEventListener("loadeddata", handleLoadedData)
+    el.addEventListener("playing", handlePlaying)
+    el.addEventListener("waiting", handleWaiting)
+    el.addEventListener("error", handleError)
+    el.addEventListener("ended", handleEnded)
+    el.addEventListener("seeking", handleSeeking)
+    el.addEventListener("pause", handlePause)
+    el.addEventListener("play", handlePlay)
+  }
+  bindVideoEvents(videoA)
+  bindVideoEvents(videoB)
 
   prevSegmentButton.onclick = () => goToSegment(current - 1)
   nextSegmentButton.onclick = () => goToSegment(current + 1)
@@ -564,12 +682,12 @@ async function openOverlay(route) {
       if (button.disabled || button.dataset.camera === selectedCamera || !segments[current]) return
       selectedCamera = button.dataset.camera
       cameraButtons.forEach(candidate => candidate.classList.toggle("active", candidate === button))
-      const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
-      const shouldResume = !video.paused && !video.ended
-      video.addEventListener("loadedmetadata", () => {
+      const playbackTime = Number.isFinite(activeVideo.currentTime) ? activeVideo.currentTime : 0
+      const shouldResume = !activeVideo.paused && !activeVideo.ended
+      activeVideo.addEventListener("loadedmetadata", () => {
         if (playbackTime > 0) {
           try {
-            video.currentTime = Math.min(playbackTime, Number.isFinite(video.duration) ? video.duration : playbackTime)
+            activeVideo.currentTime = Math.min(playbackTime, Number.isFinite(activeVideo.duration) ? activeVideo.duration : playbackTime)
           } catch (_) {}
         }
       }, { once: true })
@@ -606,6 +724,12 @@ function closeOverlay() {
   if (!overlay) return
   overlay._cancelUpgrade?.()
   document.removeEventListener("keydown", overlay._closeOnEscape)
+  const videos = overlay.querySelectorAll("video")
+  videos.forEach(v => {
+    v.pause()
+    v.removeAttribute("src")
+    v.load()
+  })
   overlay.remove()
   overlay = null
   state.selectedRoute = null

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -1,165 +1,92 @@
 import { html, reactive } from "/assets/vendor/arrow-core.js"
-import { isGalaxyTunnel } from "/assets/js/utils.js"
-import { getOrdinalSuffix } from "/assets/components/navigation/navigation_utilities.js"
-import { Modal } from "/assets/components/modal.js";
+import { escapeHtml, isGalaxyTunnel } from "/assets/js/utils.js"
+import { Modal } from "/assets/components/modal.js"
+import {
+  buildRouteView,
+  cameraVideoUrl,
+  formatApproxDuration,
+  getSegmentStatus,
+  groupRoutesByDate,
+  MAX_RENDERED_ROUTES,
+  normalizeRoute,
+} from "/assets/components/recordings/dashcam_routes_helpers.js"
 
 const state = reactive({
   loading: true,
   error: null,
   routes: [],
   selectedRoute: null,
+  searchQuery: "",
+  sortOrder: "newest",
   showPreservedOnly: false,
   progress: 0,
   total: 0,
   showDeleteAllModal: false,
   isDeletingAll: false,
-  truncated: false,
 })
-
-const MAX_RENDERED_ROUTES = 250
-const ROUTE_FLUSH_INTERVAL_MS = 120
 
 let routesAbortController = null
 let routesRequestToken = 0
-let pendingRoutes = []
-let flushTimerId = null
 let seenRouteNames = new Set()
+let overlay = null
 
-function formatRouteDate(dateString) {
-  if (!dateString) {
-    return "Unknown Date"
-  }
-
-  const date = new Date(dateString)
-  if (isNaN(date.getTime())) {
-    return dateString
-  }
-  const month = date.toLocaleString("en-US", { month: "long" })
-  const day = date.getDate()
-  const year = date.getFullYear()
-  let hour = date.getHours()
-  const minute = date.getMinutes()
-  const ampm = hour >= 12 ? "pm" : "am"
-  hour = hour % 12
-  hour = hour || 12
-  const minuteStr = minute < 10 ? "0" + minute : minute
-  return `${month} ${day}${getOrdinalSuffix(day)}, ${year} - ${hour}:${minuteStr}${ampm}`
+function routeLabel(route) {
+  return route.displayName || route.displayDate || route.name
 }
 
-function resetRouteStreamState() {
-  pendingRoutes = []
-  if (flushTimerId !== null) {
-    clearTimeout(flushTimerId)
-    flushTimerId = null
-  }
-  seenRouteNames = new Set()
-}
-
-function flushPendingRoutes() {
-  if (pendingRoutes.length === 0) return
-
-  const availableSlots = Math.max(MAX_RENDERED_ROUTES - state.routes.length, 0)
-  if (availableSlots <= 0) {
-    pendingRoutes = []
-    state.truncated = true
-    return
-  }
-
-  const toAppend = pendingRoutes.slice(0, availableSlots)
-  pendingRoutes = []
-  if (toAppend.length > 0) {
-    state.routes = [...state.routes, ...toAppend]
-  }
-  if (state.routes.length >= MAX_RENDERED_ROUTES) {
-    state.truncated = true
-  }
-}
-
-function enqueueRoutes(rawRoutes) {
+function mergeRoutes(rawRoutes) {
   if (!Array.isArray(rawRoutes) || rawRoutes.length === 0) return
-
-  const nextRoutes = []
-  for (const route of rawRoutes) {
-    const name = String(route?.name || "")
+  const additions = []
+  for (const rawRoute of rawRoutes) {
+    const name = String(rawRoute?.name || "")
     if (!name || seenRouteNames.has(name)) continue
     seenRouteNames.add(name)
-    nextRoutes.push({
-      ...route,
-      timestamp: formatRouteDate(route.timestamp),
-    })
+    additions.push(normalizeRoute(rawRoute))
   }
-
-  if (nextRoutes.length === 0) return
-  pendingRoutes.push(...nextRoutes)
-
-  if (flushTimerId === null) {
-    flushTimerId = setTimeout(() => {
-      flushTimerId = null
-      flushPendingRoutes()
-    }, ROUTE_FLUSH_INTERVAL_MS)
-  }
+  // Worker completion order is irrelevant: buildRouteView sorts the list at render time.
+  if (additions.length) state.routes = [...state.routes, ...additions]
 }
 
 async function fetchRoutes() {
   const requestToken = ++routesRequestToken
-  if (routesAbortController) {
-    routesAbortController.abort()
-  }
+  routesAbortController?.abort()
   const controller = new AbortController()
   routesAbortController = controller
 
   try {
-    const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const response = await fetch(`/api/routes?timezone=${encodeURIComponent(userTimezone)}`, {
-      signal: controller.signal,
-    });
-    if (!response.ok) throw new Error();
+    const response = await fetch("/api/routes", { signal: controller.signal })
+    if (!response.ok || !response.body) throw new Error(`Route request failed (${response.status})`)
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
     while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-
+      const { value, done } = await reader.read()
+      if (done) break
       if (requestToken !== routesRequestToken) return
 
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split(/\r?\n\r?\n/);
-      buffer = lines.pop();
-
-      for (const line of lines) {
-        if (line.startsWith("data:")) {
-          try {
-            const payload = line.substring(5).trim()
-            if (!payload) continue
-            const data = JSON.parse(payload);
-            if (data.progress !== undefined && data.total !== undefined) {
-              state.progress = data.progress;
-              state.total = data.total;
-            }
-            if (data.routes) {
-              enqueueRoutes(data.routes)
-            }
-          } catch (e) {
-            console.error("Failed to parse JSON:", e);
-          }
+      buffer += decoder.decode(value, { stream: true })
+      const events = buffer.split(/\r?\n\r?\n/)
+      buffer = events.pop() || ""
+      for (const event of events) {
+        const dataLines = event.split(/\r?\n/).filter(line => line.startsWith("data:"))
+        if (!dataLines.length) continue
+        try {
+          const payload = JSON.parse(dataLines.map(line => line.slice(5).trimStart()).join("\n"))
+          if (Number.isFinite(payload.progress)) state.progress = payload.progress
+          if (Number.isFinite(payload.total)) state.total = payload.total
+          mergeRoutes(payload.routes)
+        } catch (error) {
+          console.error("Failed to parse route stream event:", error)
         }
       }
     }
-    flushPendingRoutes()
   } catch (error) {
-    if (error?.name !== "AbortError") {
-      state.error = "Couldn't load routes. Please try again later..."
-    }
+    if (error?.name !== "AbortError") state.error = "Couldn't load routes. Try refreshing."
   } finally {
     if (requestToken === routesRequestToken) {
-      flushPendingRoutes()
       state.loading = false
-      if (routesAbortController === controller) {
-        routesAbortController = null
-      }
+      if (routesAbortController === controller) routesAbortController = null
     }
   }
 }
@@ -170,313 +97,325 @@ function refresh() {
   state.routes = []
   state.progress = 0
   state.total = 0
-  state.truncated = false
-  resetRouteStreamState()
-  fetchRoutes()
+  seenRouteNames = new Set()
+  return fetchRoutes()
 }
 
-refresh()
+if (!isGalaxyTunnel()) refresh()
 
-let overlay = null
-
-function openDialog(htmlStr) {
-  const o = document.createElement("div")
-  o.className = "dialog-overlay"
-  o.innerHTML = htmlStr
-  document.body.appendChild(o)
-  return o
+function openDialog(htmlString) {
+  const dialog = document.createElement("div")
+  dialog.className = "dialog-overlay"
+  dialog.innerHTML = htmlString
+  document.body.appendChild(dialog)
+  return dialog
 }
 
-function closeDialog(o) {
-  if (o) o.remove()
+function closeDialog(dialog) {
+  dialog?.remove()
+}
+
+function replaceRoute(updatedRoute) {
+  state.routes = state.routes.map(route => route.name === updatedRoute.name ? updatedRoute : route)
+  if (state.selectedRoute?.name === updatedRoute.name) state.selectedRoute = updatedRoute
 }
 
 async function deleteRoute(route) {
-  const dlg = openDialog(`
+  const dialog = openDialog(`
     <div class="dialog-box">
-      <p>Delete “${route.timestamp}”?</p>
+      <p>Delete “${escapeHtml(routeLabel(route))}”?</p>
       <div class="dialog-buttons">
-        <button class="btn btn-cancel" ...>Cancel</button>
-        <button class="btn btn-danger btn-del" ...>Delete</button>
+        <button class="btn-cancel" type="button">Cancel</button>
+        <button class="btn-del" type="button">Delete</button>
       </div>
     </div>`)
-  dlg.querySelector(".btn-cancel").onclick = () => closeDialog(dlg)
-  dlg.querySelector(".btn-del").onclick = async () => {
-    const res = await fetch(`/api/routes/${route.name}`, { method: "DELETE" })
-    if (res.ok) {
-      state.routes = state.routes.filter(r => r.name !== route.name)
-      closeDialog(dlg)
-      closeOverlay()
-      refresh()
-      showSnackbar("Route deleted!")
-    } else {
+  dialog.querySelector(".btn-cancel").onclick = () => closeDialog(dialog)
+  dialog.querySelector(".btn-del").onclick = async () => {
+    const response = await fetch(`/api/routes/${route.name}`, { method: "DELETE" })
+    if (!response.ok) {
       showSnackbar("Delete failed...", "error")
+      return
     }
+    closeDialog(dialog)
+    closeOverlay()
+    await refresh()
+    showSnackbar("Route deleted!")
   }
 }
 
-async function resetRouteName(route, dlg) {
-  const res = await fetch(`/api/routes/reset_name`, {
+async function resetRouteName(route, dialog) {
+  const response = await fetch("/api/routes/reset_name", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: route.name })
-  });
-  if (res.ok) {
-    const { timestamp } = await res.json();
-    closeDialog(dlg);
-    const routeInList = state.routes.find(r => r.name === route.name);
-    if (routeInList) {
-      routeInList.timestamp = formatRouteDate(timestamp);
-    }
-    route.timestamp = formatRouteDate(timestamp);
-    const overlayTitleSpan = overlay.querySelector(".media-player-title span");
-    if (overlayTitleSpan) {
-      overlayTitleSpan.textContent = formatRouteDate(timestamp);
-    }
-    showSnackbar("Route name reset!");
-  } else {
-    showSnackbar("Resetting name failed...", "error");
+    body: JSON.stringify({ name: route.name }),
+  })
+  if (!response.ok) {
+    showSnackbar("Resetting name failed...", "error")
+    return
   }
+
+  const { timestamp } = await response.json()
+  const updatedRoute = normalizeRoute({ ...route, timestamp, isCustomName: false })
+  replaceRoute(updatedRoute)
+  closeDialog(dialog)
+  const title = overlay?.querySelector(".media-player-title-text")
+  if (title) title.textContent = routeLabel(updatedRoute)
+  showSnackbar("Route name reset!")
 }
 
 async function renameRoute(route) {
-  const dlg = openDialog(`
+  const dialog = openDialog(`
     <div class="dialog-box">
-      <p>Rename "${route.timestamp}"</p>
-      <input class="rn-input" value="${route.timestamp}" />
+      <p>Rename “${escapeHtml(routeLabel(route))}”</p>
+      <input class="rn-input" value="${escapeHtml(routeLabel(route))}" aria-label="New route name">
       <div class="dialog-buttons">
-        <button class="btn-cancel">Cancel</button>
-        <button class="btn-reset">Reset</button>
-        <button class="btn-save">Save</button>
+        <button class="btn-cancel" type="button">Cancel</button>
+        <button class="btn-reset" type="button">Reset</button>
+        <button class="btn-save" type="button">Save</button>
       </div>
-    </div>`);
-  dlg.querySelector(".btn-cancel").onclick = () => closeDialog(dlg);
-  dlg.querySelector(".btn-reset").onclick = () => resetRouteName(route, dlg);
-  dlg.querySelector(".btn-save").onclick = async () => {
-    const newName = dlg.querySelector(".rn-input").value.trim();
-    if (!newName) return;
-    const res = await fetch(`/api/routes/rename`, {
+    </div>`)
+  dialog.querySelector(".btn-cancel").onclick = () => closeDialog(dialog)
+  dialog.querySelector(".btn-reset").onclick = () => resetRouteName(route, dialog)
+  dialog.querySelector(".btn-save").onclick = async () => {
+    const newName = dialog.querySelector(".rn-input").value.trim()
+    if (!newName) return
+    const response = await fetch("/api/routes/rename", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ old: route.name, new: newName })
-    });
-    if (res.ok) {
-      closeDialog(dlg);
-      const routeInList = state.routes.find(r => r.name === route.name);
-      if (routeInList) {
-        routeInList.timestamp = newName;
-      }
-      route.timestamp = newName;
-      const overlayTitleSpan = overlay.querySelector(".media-player-title span");
-      if (overlayTitleSpan) {
-        overlayTitleSpan.textContent = newName;
-      }
-      showSnackbar("Route renamed!");
-    } else {
-      showSnackbar("Rename failed...", "error");
+      body: JSON.stringify({ old: route.name, new: newName }),
+    })
+    if (!response.ok) {
+      showSnackbar("Rename failed...", "error")
+      return
     }
-  };
+
+    const updatedRoute = normalizeRoute({ ...route, timestamp: newName, isCustomName: true })
+    replaceRoute(updatedRoute)
+    closeDialog(dialog)
+    const title = overlay?.querySelector(".media-player-title-text")
+    if (title) title.textContent = newName
+    showSnackbar("Route renamed!")
+  }
+}
+
+function formatBytes(bytes) {
+  if (!bytes) return "0 MB"
+  const megabytes = bytes / 1e6
+  return megabytes >= 1000 ? `${(megabytes / 1000).toFixed(2)} GB` : `${megabytes.toFixed(1)} MB`
+}
+
+function openLogsDialog(route, logsButton, getCachedLogs, setCachedLogs) {
+  const logsDialog = openDialog(`
+    <section class="dialog-box route-logs-dialog" role="dialog" aria-modal="true" aria-labelledby="route-logs-title">
+      <header class="route-logs-toolbar">
+        <div><p class="route-logs-eyebrow">Route data</p><h2 id="route-logs-title">Full logs</h2></div>
+        <button class="route-logs-close" type="button" aria-label="Close full logs">&times;</button>
+      </header>
+      <div class="route-logs-content" aria-live="polite"><p class="route-logs-message">Looking for full logs&hellip;</p></div>
+    </section>`)
+  const content = logsDialog.querySelector(".route-logs-content")
+  const closeButton = logsDialog.querySelector(".route-logs-close")
+  const closeLogsDialog = () => {
+    document.removeEventListener("keydown", handleKeydown)
+    closeDialog(logsDialog)
+    logsButton.focus()
+  }
+  const handleKeydown = event => { if (event.key === "Escape") closeLogsDialog() }
+  closeButton.onclick = closeLogsDialog
+  logsDialog.addEventListener("click", event => { if (event.target === logsDialog) closeLogsDialog() })
+  document.addEventListener("keydown", handleKeydown)
+  closeButton.focus()
+
+  const renderLogs = data => {
+    content.innerHTML = `
+      <div class="route-logs-summary">
+        <div><strong>${data.segments.length} segment${data.segments.length === 1 ? "" : "s"}</strong><span>${formatBytes(data.totalBytes)} total download</span></div>
+        <a class="route-logs-download-all" href="/api/routes/${route.name}/logs/download" download>Download all <span>.tar</span></a>
+      </div>
+      <ul class="route-logs-list">
+        ${data.segments.map(segment => `<li>
+          <div class="route-log-details"><strong>Segment ${Number(segment.segmentNum)}</strong><span>${formatBytes(segment.bytes)} &middot; ${escapeHtml(segment.filename)}</span></div>
+          <a class="route-log-download" href="${escapeHtml(segment.url)}" download>Download</a>
+        </li>`).join("")}
+      </ul>`
+  }
+
+  const cachedLogs = getCachedLogs()
+  if (cachedLogs) {
+    renderLogs(cachedLogs)
+    return
+  }
+
+  fetch(`/api/routes/${route.name}/logs`)
+    .then(async response => ({ response, data: await response.json() }))
+    .then(({ response, data }) => {
+      if (!response.ok) {
+        if (content.isConnected) content.innerHTML = `<p class="route-logs-message route-logs-error">${escapeHtml(data.error || "Could not read logs.")}</p>`
+        return
+      }
+      setCachedLogs(data)
+      if (content.isConnected) renderLogs(data)
+    })
+    .catch(error => {
+      if (content.isConnected) content.innerHTML = `<p class="route-logs-message route-logs-error">Could not reach the device: ${escapeHtml(error.message)}</p>`
+    })
 }
 
 async function openOverlay(route) {
-  if (overlay) return;
-
-  overlay = document.createElement("div");
-  overlay.className = "media-player-overlay";
+  if (overlay) return
+  overlay = document.createElement("div")
+  overlay.className = "media-player-overlay dashcam-player-overlay"
   overlay.innerHTML = `
-    <div class="media-player-content">
-      <div class="media-player-title">
-        <span>${route.timestamp}</span>
-        <i class="bi bi-pencil-fill action-rename-icon"></i>
+    <section class="media-player-content dashcam-player" role="dialog" aria-modal="true" aria-label="Route player">
+      <header class="dashcam-player-header">
+        <div><p class="dashcam-player-eyebrow">Dashcam route</p><h2 class="media-player-title-text">${escapeHtml(routeLabel(route))}</h2></div>
+        <button class="dashcam-player-close action-close" type="button" aria-label="Close player">&times;</button>
+      </header>
+      <div class="dashcam-video-shell">
+        <video controls muted playsinline></video>
+        <div class="dashcam-player-state" role="status">Loading route metadata&hellip;</div>
       </div>
-      <video controls autoplay muted>
-        <source src="/thumbnails/${route.name}--0/preview.png" type="video/mp4">
-      </video>
-      <div class="button-row">
-        <button class="close-button action-close">Close</button>
-        <button class="close-button camera-button active" data-camera="forward">Forward</button>
-        <button class="close-button camera-button" data-camera="wide">Wide</button>
-        <button class="close-button camera-button" data-camera="driver">Driver</button>
-        <button class="close-button action-download">Download</button>
-        <button class="close-button action-logs">Logs</button>
-        <button class="close-button action-delete">Delete</button>
+      <div class="dashcam-segment-status" aria-live="polite" hidden></div>
+      <div class="dashcam-camera-selector" aria-label="Camera selector">
+        <button class="camera-button" data-camera="forward" type="button" disabled hidden>Forward</button>
+        <button class="camera-button" data-camera="wide" type="button" disabled hidden>Wide</button>
+        <button class="camera-button" data-camera="driver" type="button" disabled hidden>Driver</button>
       </div>
-    </div>`;
-  document.body.appendChild(overlay);
+      <div class="dashcam-player-actions">
+        <button class="action-download" type="button" disabled><i class="bi bi-download"></i> Download</button>
+        <button class="action-logs" type="button"><i class="bi bi-file-earmark-arrow-down"></i> Logs</button>
+        <button class="action-rename" type="button"><i class="bi bi-pencil"></i> Rename</button>
+        <button class="action-delete" type="button"><i class="bi bi-trash"></i> Delete</button>
+      </div>
+    </section>`
+  document.body.appendChild(overlay)
 
-  overlay.addEventListener("click", e => {
-    if (e.target === overlay) closeOverlay();
-  });
-  overlay.querySelector(".action-rename-icon").onclick = () => renameRoute(route);
-  overlay.querySelector(".action-close").onclick = closeOverlay;
-  overlay.querySelector(".action-delete").onclick = () => deleteRoute(route);
+  const video = overlay.querySelector("video")
+  const playerState = overlay.querySelector(".dashcam-player-state")
+  const statusStrip = overlay.querySelector(".dashcam-segment-status")
+  const downloadButton = overlay.querySelector(".action-download")
+  const logsButton = overlay.querySelector(".action-logs")
+  const cameraButtons = [...overlay.querySelectorAll(".camera-button")]
+  let segments = []
+  let current = 0
+  let selectedCamera = null
+  let logsData = null
 
-  const vid = overlay.querySelector("video");
-  const downloadButton = overlay.querySelector(".action-download");
-  const logsButton = overlay.querySelector(".action-logs");
+  const setPlayerMessage = (message, isError = false) => {
+    playerState.textContent = message
+    playerState.hidden = !message
+    playerState.classList.toggle("error", isError)
+  }
+  const updateSegmentStatus = () => {
+    const status = getSegmentStatus(segments, current)
+    statusStrip.textContent = status
+    statusStrip.hidden = !status
+  }
+  const playCurrentSegment = () => {
+    if (!segments[current] || !selectedCamera) return
+    updateSegmentStatus()
+    setPlayerMessage("Loading video…")
+    video.src = cameraVideoUrl(segments[current], selectedCamera)
+    video.load()
+    video.play().catch(() => {})
+  }
+  const closeOnEscape = event => {
+    if (event.key === "Escape" && !document.querySelector(".route-logs-dialog")) closeOverlay()
+  }
 
-  const formatBytes = bytes => {
-    if (!bytes) return "0 MB";
-    const mb = bytes / 1e6;
-    return mb >= 1000 ? `${(mb / 1000).toFixed(2)} GB` : `${mb.toFixed(1)} MB`;
-  };
+  overlay.addEventListener("click", event => { if (event.target === overlay) closeOverlay() })
+  document.addEventListener("keydown", closeOnEscape)
+  overlay._closeOnEscape = closeOnEscape
+  overlay.querySelector(".action-close").onclick = closeOverlay
+  overlay.querySelector(".action-delete").onclick = () => deleteRoute(state.selectedRoute || route)
+  overlay.querySelector(".action-rename").onclick = () => renameRoute(state.selectedRoute || route)
 
-  let logsData = null;
-  logsButton.onclick = async () => {
-    const logsDialog = openDialog(`
-      <section class="dialog-box route-logs-dialog" role="dialog" aria-modal="true" aria-labelledby="route-logs-title">
-        <header class="route-logs-toolbar">
-          <div>
-            <p class="route-logs-eyebrow">Route data</p>
-            <h2 id="route-logs-title">Full logs</h2>
-          </div>
-          <button class="route-logs-close" type="button" aria-label="Close full logs">&times;</button>
-        </header>
-        <div class="route-logs-content" aria-live="polite">
-          <p class="route-logs-message">Looking for full logs&hellip;</p>
-        </div>
-      </section>`);
-    const logsContent = logsDialog.querySelector(".route-logs-content");
-    const logsCloseButton = logsDialog.querySelector(".route-logs-close");
-
-    const closeLogsDialog = () => {
-      document.removeEventListener("keydown", handleLogsKeydown);
-      closeDialog(logsDialog);
-      logsButton.focus();
-    };
-    const handleLogsKeydown = event => {
-      if (event.key === "Escape") closeLogsDialog();
-    };
-    logsCloseButton.onclick = closeLogsDialog;
-    logsDialog.addEventListener("click", event => {
-      if (event.target === logsDialog) closeLogsDialog();
-    });
-    document.addEventListener("keydown", handleLogsKeydown);
-    logsCloseButton.focus();
-
-    const renderLogs = data => {
-      logsContent.innerHTML = `
-        <div class="route-logs-summary">
-          <div>
-            <strong>${data.segments.length} segment${data.segments.length === 1 ? "" : "s"}</strong>
-            <span>${formatBytes(data.totalBytes)} total download</span>
-          </div>
-          <a class="route-logs-download-all" href="/api/routes/${route.name}/logs/download" download>
-            Download all <span>.tar</span>
-          </a>
-        </div>
-        <ul class="route-logs-list">
-          ${data.segments.map(segment => `
-            <li>
-              <div class="route-log-details">
-                <strong>Segment ${segment.segmentNum}</strong>
-                <span>${formatBytes(segment.bytes)} &middot; ${segment.filename}</span>
-              </div>
-              <a class="route-log-download" href="${segment.url}" download>Download</a>
-            </li>`).join("")}
-        </ul>`;
-    };
-
-    if (logsData) {
-      renderLogs(logsData);
-      return;
-    }
-
-    try {
-      const response = await fetch(`/api/routes/${route.name}/logs`);
-      const data = await response.json();
-      if (!response.ok) {
-        if (logsContent.isConnected) {
-          logsContent.innerHTML = `<p class="route-logs-message route-logs-error">${data.error || "Could not read logs."}</p>`;
-        }
-        return;
-      }
-
-      // sizes are shown up front so a metered connection is a deliberate choice
-      logsData = data;
-      if (logsContent.isConnected) renderLogs(data);
-    } catch (error) {
-      if (logsContent.isConnected) {
-        logsContent.innerHTML = `<p class="route-logs-message route-logs-error">Could not reach the device: ${error.message}</p>`;
-      }
-    }
-  };
-
-  let segments;
-  let current = 0;
-  let selectedCamera = "forward";
-
+  logsButton.onclick = () => openLogsDialog(route, logsButton, () => logsData, value => { logsData = value })
   downloadButton.onclick = () => {
-    const link = document.createElement("a");
-    const videoPath = `/video/${route.name}/combined?camera=${selectedCamera}`;
-    link.href = videoPath;
-    link.download = `${route.timestamp}-${selectedCamera}.mp4`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
+    if (!selectedCamera) return
+    const link = document.createElement("a")
+    link.href = `/video/${route.name}/combined?camera=${encodeURIComponent(selectedCamera)}`
+    link.download = `${routeLabel(state.selectedRoute || route)}-${selectedCamera}.mp4`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+  }
 
-  (async () => {
-    try {
-      const response = await fetch(`/api/routes/${route.name}`);
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      const data = await response.json();
-      segments = data.segment_urls;
+  video.addEventListener("loadeddata", () => setPlayerMessage(""))
+  video.addEventListener("playing", () => setPlayerMessage(""))
+  video.addEventListener("waiting", () => setPlayerMessage("Loading video…"))
+  video.addEventListener("error", () => setPlayerMessage("This segment could not be played.", true))
+  video.addEventListener("ended", () => {
+    if (current + 1 >= segments.length) return
+    current += 1
+    playCurrentSegment()
+  })
 
-      if (!segments || segments.length === 0) {
-        segments = [`/video/${route.name}--0`];
-      }
-      vid.src = `${segments[0]}?camera=forward`;
-      vid.load();
-      vid.play();
-    } catch (error) {
-      showSnackbar("Error: Could not load combined route video.", "error");
+  for (const button of cameraButtons) {
+    button.addEventListener("click", () => {
+      if (button.disabled || button.dataset.camera === selectedCamera || !segments[current]) return
+      const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
+      const shouldResume = !video.paused && !video.ended
+      selectedCamera = button.dataset.camera
+      cameraButtons.forEach(candidate => candidate.classList.toggle("active", candidate === button))
+      video.addEventListener("loadedmetadata", () => {
+        if (playbackTime > 0) {
+          try {
+            video.currentTime = Math.min(playbackTime, Number.isFinite(video.duration) ? video.duration : playbackTime)
+          } catch (_) {}
+        }
+        if (shouldResume) video.play().catch(() => {})
+      }, { once: true })
+      setPlayerMessage("Switching camera…")
+      video.src = cameraVideoUrl(segments[current], selectedCamera)
+      video.load()
+      // Switching cameras deliberately leaves current and the status strip unchanged.
+    })
+  }
+
+  try {
+    const response = await fetch(`/api/routes/${route.name}`)
+    if (!response.ok) throw new Error(`Route metadata request failed (${response.status})`)
+    const data = await response.json()
+    segments = Array.isArray(data.segment_urls) ? data.segment_urls.filter(url => typeof url === "string") : []
+    const availableCameras = ["forward", "wide", "driver"].filter(camera => data.available_cameras?.includes(camera))
+    if (!segments.length) throw new Error("No video segments are stored for this route")
+    if (!availableCameras.length) throw new Error("No camera video is stored for this route")
+
+    selectedCamera = availableCameras.includes("forward") ? "forward" : availableCameras[0]
+    for (const button of cameraButtons) {
+      const available = availableCameras.includes(button.dataset.camera)
+      button.hidden = !available
+      button.disabled = !available
+      button.classList.toggle("active", button.dataset.camera === selectedCamera)
     }
-  })();
-
-  vid.addEventListener("ended", () => {
-    current++;
-    if (current < segments.length) {
-      const videoPath = segments[current].includes("?") ? `${segments[current]}&camera=${selectedCamera}` : `${segments[current]}?camera=${selectedCamera}`
-      vid.src = videoPath;
-      vid.load();
-      vid.play();
-    }
-  });
-
-  overlay.querySelectorAll(".camera-button").forEach(button => {
-    button.addEventListener("click", e => {
-      overlay.querySelectorAll(".camera-button").forEach(btn => btn.classList.remove("active"));
-      e.target.classList.add("active");
-      selectedCamera = e.target.dataset.camera;
-      vid.src = segments[current].includes("?") ? `${segments[current]}&camera=${selectedCamera}` : `${segments[current]}?camera=${selectedCamera}`;
-      vid.load();
-      vid.play();
-    });
-  });
+    downloadButton.disabled = false
+    playCurrentSegment()
+  } catch (error) {
+    cameraButtons.forEach(button => { button.disabled = true })
+    setPlayerMessage(error.message || "Could not load this route.", true)
+  }
 }
 
 function closeOverlay() {
   if (!overlay) return
+  document.removeEventListener("keydown", overlay._closeOnEscape)
   overlay.remove()
   overlay = null
   state.selectedRoute = null
 }
 
-async function togglePreserved(route, e) {
-  e.stopPropagation()
-  const newPreservedState = !route.is_preserved
-  const method = newPreservedState ? "POST" : "DELETE"
+async function togglePreserved(route, event) {
+  event.stopPropagation()
+  const isPreserved = !route.is_preserved
   try {
-    const response = await fetch(`/api/routes/${route.name}/preserve`, { method })
-    if (response.ok) {
-      route.is_preserved = newPreservedState
-    } else {
+    const response = await fetch(`/api/routes/${route.name}/preserve`, { method: isPreserved ? "POST" : "DELETE" })
+    if (!response.ok) {
       const errorData = await response.json()
       showSnackbar(errorData.error || "Failed to update preserved state...", "error")
+      return
     }
+    replaceRoute({ ...route, is_preserved: isPreserved })
   } catch (_) {
     showSnackbar("An error occurred...", "error")
   }
@@ -486,15 +425,20 @@ async function deleteAllRoutes() {
   state.showDeleteAllModal = false
   state.isDeletingAll = true
   try {
-    const res = await fetch("/api/routes/delete_all", { method: "DELETE" })
-    if (!res.ok) throw new Error()
+    const response = await fetch("/api/routes/delete_all", { method: "DELETE" })
+    if (!response.ok) throw new Error()
     await refresh()
     showSnackbar("All routes deleted!")
-  } catch {
+  } catch (_) {
     showSnackbar("An error occurred while deleting all routes...", "error")
   } finally {
     state.isDeletingAll = false
   }
+}
+
+function thumbnailFailed(event) {
+  event.currentTarget.hidden = true
+  event.currentTarget.parentElement?.classList.add("thumbnail-failed")
 }
 
 export function RouteRecordings() {
@@ -504,97 +448,87 @@ export function RouteRecordings() {
         <div class="tunnel-notice-icon">🛰️</div>
         <h3 class="tunnel-notice-title">Dashcam Routes Unavailable via Galaxy</h3>
         <p class="tunnel-notice-body">Loading dashcam routes requires a direct connection.<br>Connect to your device's local network to use this feature.</p>
-      </div>
-    `;
+      </div>`
   }
 
-  if (state.selectedRoute && !overlay) openOverlay(state.selectedRoute);
+  if (state.selectedRoute && !overlay) openOverlay(state.selectedRoute)
 
   return html`
-    <div class="screen-recordings-wrapper">
-      <div class="screen-recordings-widget">
-        <div class="screen-recordings-title">Dashcam Routes</div>
-        <button
-          class="show-preserved-button"
-          @click="${() => (state.showPreservedOnly = !state.showPreservedOnly)}"
-          disabled="${() => (state.loading && state.routes.length === 0) || false}"
-        >          ${() => (state.showPreservedOnly ? "Show All" : "Show Only Preserved Routes")}
-        </button>
+    <div class="screen-recordings-wrapper dashcam-routes-wrapper">
+      <section class="screen-recordings-widget dashcam-library">
+        <header class="dashcam-library-header">
+          <div><p class="dashcam-library-eyebrow">Local recordings</p><h1>Dashcam Routes</h1></div>
+          <button class="dashcam-refresh-button" type="button" @click="${refresh}" disabled="${() => state.loading || false}"><i class="bi bi-arrow-clockwise"></i> Refresh</button>
+        </header>
+
+        <div class="dashcam-toolbar">
+          <label class="dashcam-search">
+            <i class="bi bi-search"></i>
+            <input type="search" placeholder="Search names, dates, or route IDs" aria-label="Search routes" value="${() => state.searchQuery}" @input="${event => { state.searchQuery = event.target.value }}">
+          </label>
+          <label class="dashcam-sort">
+            <span>Sort</span>
+            <select @change="${event => { state.sortOrder = event.target.value }}">
+              <option value="newest" selected="${() => state.sortOrder === "newest" || false}">Newest</option>
+              <option value="oldest" selected="${() => state.sortOrder === "oldest" || false}">Oldest</option>
+            </select>
+          </label>
+          <button class="dashcam-preserved-filter" type="button" aria-pressed="${() => String(state.showPreservedOnly)}" @click="${() => { state.showPreservedOnly = !state.showPreservedOnly }}">
+            <i class="bi bi-heart-fill"></i> ${() => state.showPreservedOnly ? "Preserved only" : "All routes"}
+          </button>
+        </div>
 
         ${() => {
-      const routesToShow = state.routes.filter(r => !state.showPreservedOnly || r.is_preserved);
-
-      if (routesToShow.length === 0) {
-        if (state.loading && state.total > 0) {
-          return html`<p class="screen-recordings-message">Processing Routes: ${state.progress} of ${state.total}</p>`;
-        }
-        if (state.loading && !state.isDeletingAll) {
-          return html`<p class="screen-recordings-message">Loading...</p>`;
-        }
-        if (state.isDeletingAll) {
-          return html`<p class="screen-recordings-message">Deleting routes...</p>`;
-        }
-        if (state.showPreservedOnly) {
-          return html`<p class="screen-recordings-message">No preserved routes...</p>`;
-        }
-        if (state.error) {
-          return html`<p class="screen-recordings-message">${state.error}</p>`;
-        }
-        return html`<p class="screen-recordings-message">No routes found...</p>`;
-      }
-
-      return html`
-            <div class="screen-recordings-grid">
-              ${routesToShow.map(
-        route => html`
-                  <div
-                    class="recording-card"
-                    @click="${() => {
-            state.selectedRoute = route;
-          }}"
-                  >
-                    <div class="preserved-icon" @click="${e => togglePreserved(route, e)}">
-                      ${() => html`<i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>`}
-                    </div>
-                    <div class="recording-preview-container">
-                      <img
-                        src="${route.png}"
-                        class="recording-preview recording-preview-png"
-                        style="display:block;"
-                        loading="lazy"
-                      >
-                    </div>
-                    <p class="recording-filename">${route.timestamp}</p>
-                  </div>
-                `
-      )}
+          const view = buildRouteView(state.routes, { preservedOnly: state.showPreservedOnly, searchQuery: state.searchQuery, sortOrder: state.sortOrder })
+          const groups = groupRoutesByDate(view.visible)
+          return html`
+            <div class="dashcam-results-summary" aria-live="polite">
+              <span>${view.matching.length} matching route${view.matching.length === 1 ? "" : "s"}</span>
+              ${state.loading ? html`<span>Loading ${state.progress} of ${state.total}</span>` : html`<span>${state.routes.length} total</span>`}
             </div>
-          `;
-    }}
-        ${() => state.truncated ? html`
-          <p class="screen-recordings-message">Showing first ${MAX_RENDERED_ROUTES} routes to keep the UI responsive.</p>
-        ` : ""}
-        ${() => {
-      if (state.routes.length > 0) {
-        return html`
-              <button
-                class="delete-all-button"
-                @click="${() => (state.showDeleteAllModal = true)}"
-                disabled="${() => state.isDeletingAll || false}"
-              >                ${() => (state.isDeletingAll ? "Deleting..." : "Delete All Routes")}
-              </button>
-            `;
-      }
-      return "";
-    }}
-      </div>
+            ${state.error ? html`<p class="screen-recordings-message dashcam-error">${state.error}</p>` : ""}
+            ${state.isDeletingAll ? html`<p class="screen-recordings-message">Deleting routes&hellip;</p>` : ""}
+            ${!view.visible.length && state.loading ? html`<div class="dashcam-loading"><span></span><p>Finding local routes&hellip;</p></div>` : ""}
+            ${!view.visible.length && !state.loading && !state.isDeletingAll ? html`<div class="dashcam-empty-state"><i class="bi bi-camera-reels"></i><p>${state.routes.length ? "No routes match these filters." : "No routes found."}</p></div>` : ""}
+            <div class="dashcam-date-groups">
+              ${groups.map(group => html`
+                <section class="dashcam-date-group">
+                  <h2>${group.label}</h2>
+                  <div class="screen-recordings-grid dashcam-routes-grid">
+                    ${group.routes.map(route => html`
+                      <article class="recording-card dashcam-route-card" @click="${() => { state.selectedRoute = route }}">
+                        <button class="preserved-icon" type="button" aria-label="${route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${route.is_preserved ? "Preserved" : "Not preserved"}" @click="${event => togglePreserved(route, event)}">
+                          ${() => html`<i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>`}
+                        </button>
+                        <div class="recording-preview-container dashcam-preview">
+                          <span class="dashcam-preview-fallback"><i class="bi bi-camera-video"></i><small>Preview unavailable</small></span>
+                          <img src="${route.png}" class="recording-preview" loading="lazy" alt="" @error="${thumbnailFailed}">
+                        </div>
+                        <div class="dashcam-card-body">
+                          <h3>${route.displayName}</h3>
+                          ${route.isCustomName ? html`<p class="dashcam-card-date">${route.displayDate}</p>` : ""}
+                          <p class="dashcam-card-details"><span>${formatApproxDuration(route.approxDurationSeconds)}</span><span>${route.segmentCount} segment${route.segmentCount === 1 ? "" : "s"}</span></p>
+                          <p class="dashcam-preserve-status ${route.is_preserved ? "preserved" : ""}"><i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i> ${route.is_preserved ? "Preserved" : "Not preserved"}</p>
+                        </div>
+                      </article>`)}
+                  </div>
+                </section>`)}
+            </div>
+            ${view.truncated ? html`<p class="screen-recordings-message">Showing the first ${MAX_RENDERED_ROUTES} of ${view.matching.length} matching routes.</p>` : ""}`
+        }}
+
+        ${() => state.routes.length ? html`
+          <footer class="dashcam-danger-zone">
+            <div><strong>Delete all local routes</strong><span>Preserved routes are included.</span></div>
+            <button class="delete-all-button" type="button" @click="${() => { state.showDeleteAllModal = true }}" disabled="${() => state.isDeletingAll || false}">${() => state.isDeletingAll ? "Deleting…" : "Delete All"}</button>
+          </footer>` : ""}
+      </section>
       ${() => state.showDeleteAllModal ? Modal({
-      title: "Confirm Delete All",
-      message: "Are you sure you want to delete all routes? This action cannot be undone...",
-      onConfirm: deleteAllRoutes,
-      onCancel: () => { state.showDeleteAllModal = false; },
-      confirmText: "Delete All"
-    }) : ""}
-    </div>
-  `;
+        title: "Confirm Delete All",
+        message: "Are you sure you want to delete all routes? This action cannot be undone...",
+        onConfirm: deleteAllRoutes,
+        onCancel: () => { state.showDeleteAllModal = false },
+        confirmText: "Delete All",
+      }) : ""}
+    </div>`
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -468,26 +468,21 @@ export function RouteRecordings() {
   return html`
     <div class="screen-recordings-wrapper dashcam-routes-wrapper">
       <section class="screen-recordings-widget dashcam-library">
-        ${() => {
-          const stats = computeRouteStats(state.routes)
-          return html`
-            <header class="dashcam-library-header">
-              <div class="dashcam-header-info">
-                <p class="dashcam-library-eyebrow">Local recordings</p>
-                <h1>Dashcam Routes</h1>
-                <div class="dashcam-stats-bar">
-                  <span class="dashcam-stat-chip"><i class="bi bi-car-front-fill"></i> <strong>${stats.count}</strong> ${stats.count === 1 ? "drive" : "drives"}</span>
-                  <span class="dashcam-stat-chip"><i class="bi bi-stopwatch-fill"></i> <strong>${stats.formattedDuration}</strong> total</span>
-                  ${stats.preservedCount > 0 ? html`<span class="dashcam-stat-chip stat-chip-preserved"><i class="bi bi-heart-fill"></i> <strong>${stats.preservedCount}</strong> preserved</span>` : ""}
-                </div>
-              </div>
-              <div class="dashcam-header-controls">
-                <button class="dashcam-refresh-button" type="button" @click="${refresh}" disabled="${() => state.loading || false}" title="Refresh routes">
-                  <i class="bi bi-arrow-clockwise"></i> Refresh
-                </button>
-              </div>
-            </header>`
-        }}
+        <header class="dashcam-library-header">
+          <div class="dashcam-header-info">
+            <p class="dashcam-library-eyebrow">Local recordings</p>
+            <h1>Dashcam Routes</h1>
+            ${() => {
+              const stats = computeRouteStats(state.routes)
+              return html`<div class="dashcam-stats-bar"><span class="dashcam-stat-chip"><i class="bi bi-car-front-fill"></i> <strong>${stats.count}</strong> ${stats.count === 1 ? "drive" : "drives"}</span><span class="dashcam-stat-chip"><i class="bi bi-stopwatch-fill"></i> <strong>${stats.formattedDuration}</strong> total</span>${stats.preservedCount > 0 ? html`<span class="dashcam-stat-chip stat-chip-preserved"><i class="bi bi-heart-fill"></i> <strong>${stats.preservedCount}</strong> preserved</span>` : ""}</div>`
+            }}
+          </div>
+          <div class="dashcam-header-controls">
+            <button class="dashcam-refresh-button" type="button" @click="${refresh}" disabled="${() => state.loading || false}" title="Refresh routes">
+              <i class="bi bi-arrow-clockwise"></i> Refresh
+            </button>
+          </div>
+        </header>
 
         <div class="dashcam-toolbar">
           <div class="dashcam-search-box">
@@ -498,10 +493,10 @@ export function RouteRecordings() {
             ` : ""}
           </div>
           <div class="dashcam-filter-group">
-            <button class="dashcam-filter-pill ${() => !state.showPreservedOnly ? "active" : ""}" type="button" @click="${() => { state.showPreservedOnly = false }}">
+            <button class="${() => `dashcam-filter-pill ${!state.showPreservedOnly ? "active" : ""}`}" type="button" @click="${() => { state.showPreservedOnly = false }}">
               All Drives
             </button>
-            <button class="dashcam-filter-pill ${() => state.showPreservedOnly ? "active" : ""}" type="button" @click="${() => { state.showPreservedOnly = true }}">
+            <button class="${() => `dashcam-filter-pill ${state.showPreservedOnly ? "active" : ""}`}" type="button" @click="${() => { state.showPreservedOnly = true }}">
               <i class="bi bi-heart-fill"></i> Preserved
             </button>
           </div>
@@ -515,10 +510,10 @@ export function RouteRecordings() {
             </select>
           </label>
           <div class="dashcam-view-toggle" aria-label="Layout view mode">
-            <button class="dashcam-view-btn ${() => state.viewMode === "list" ? "active" : ""}" type="button" title="List View" @click="${() => { state.viewMode = "list" }}">
+            <button class="${() => `dashcam-view-btn ${state.viewMode === "list" ? "active" : ""}`}" type="button" title="List View" @click="${() => { state.viewMode = "list" }}">
               <i class="bi bi-list-ul"></i>
             </button>
-            <button class="dashcam-view-btn ${() => state.viewMode === "grid" ? "active" : ""}" type="button" title="Grid View" @click="${() => { state.viewMode = "grid" }}">
+            <button class="${() => `dashcam-view-btn ${state.viewMode === "grid" ? "active" : ""}`}" type="button" title="Grid View" @click="${() => { state.viewMode = "grid" }}">
               <i class="bi bi-grid-fill"></i>
             </button>
           </div>

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -825,11 +825,11 @@ export function RouteRecordings() {
           </div>
           <label class="dashcam-sort">
             <span>Sort</span>
-            <select @change="${event => { state.sortOrder = event.target.value }}">
-              <option value="newest" selected="${() => state.sortOrder === "newest" || false}">Newest first</option>
-              <option value="oldest" selected="${() => state.sortOrder === "oldest" || false}">Oldest first</option>
-              <option value="longest" selected="${() => state.sortOrder === "longest" || false}">Longest duration</option>
-              <option value="shortest" selected="${() => state.sortOrder === "shortest" || false}">Shortest duration</option>
+            <select value="${() => state.sortOrder}" @change="${event => { state.sortOrder = event.target.value }}">
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+              <option value="longest">Longest duration</option>
+              <option value="shortest">Shortest duration</option>
             </select>
           </label>
           <div class="dashcam-view-toggle" aria-label="Layout view mode">
@@ -862,7 +862,7 @@ export function RouteRecordings() {
                     <h2>${group.label}</h2>
                     <span class="dashcam-date-group-count">${group.routes.length} ${group.routes.length === 1 ? "drive" : "drives"}</span>
                   </div>
-                  ${() => state.viewMode === "grid" ? html`<div class="screen-recordings-grid dashcam-routes-grid">
+                  ${state.viewMode === "grid" ? html`<div class="screen-recordings-grid dashcam-routes-grid">
                       ${group.routes.map(route => html`
                         <article class="${() => `recording-card dashcam-route-card ${route.is_preserved ? "is-preserved" : ""}`}" @click="${() => { state.selectedRoute = route }}">
                           <div class="dashcam-card-top-bar">
@@ -901,7 +901,7 @@ export function RouteRecordings() {
                               </button>
                             </div>
                           </div>
-                        </article>`)}
+                        </article>`.key(route.name))}
                     </div>` : html`<div class="dashcam-routes-list">
                       ${group.routes.map(route => html`
                         <article class="${() => `dashcam-route-row ${route.is_preserved ? "is-preserved" : ""}`}" @click="${() => { state.selectedRoute = route }}">
@@ -940,9 +940,9 @@ export function RouteRecordings() {
                               <i class="bi bi-trash"></i>
                             </button>
                           </div>
-                        </article>`)}
+                        </article>`.key(route.name))}
                     </div>`}
-                </section>`)}
+                </section>`.key(group.key))}
             </div>
             ${view.truncated ? html`<p class="screen-recordings-message">Showing the first ${MAX_RENDERED_ROUTES} of ${view.matching.length} matching routes.</p>` : ""}`
         }}

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -7,6 +7,7 @@ import {
   computeRouteStats,
   formatApproxDuration,
   getSegmentOptions,
+  shouldUpgradeFromHeight,
   supportsLowQuality,
   groupRoutesForView,
   MAX_RENDERED_ROUTES,
@@ -33,10 +34,10 @@ let routesRequestToken = 0
 let seenRouteNames = new Set()
 let overlay = null
 const routeLogsCache = new Map()
-const FULL_QUALITY_RETRIES = 3
-const FULL_QUALITY_RETRY_MS = 4000
-// Wait for the viewer to settle, so scrubbing never queues a remux per segment.
-const FULL_QUALITY_SETTLE_MS = 1500
+const FULL_QUALITY_RETRIES = 2
+const FULL_QUALITY_RETRY_MS = 1000
+// Only ask for the full stream once the viewer settles, so scrubbing queues no remuxes.
+const FULL_QUALITY_SETTLE_MS = 1200
 
 function routeLabel(route) {
   return route.displayName || route.displayDate || route.name
@@ -289,28 +290,35 @@ async function openOverlay(route) {
   overlay.innerHTML = `
     <section class="media-player-content dashcam-player" role="dialog" aria-modal="true" aria-label="Route player">
       <header class="dashcam-player-header">
-        <div><p class="dashcam-player-eyebrow">Dashcam route</p><h2 class="media-player-title-text">${escapeHtml(routeLabel(route))}</h2></div>
+        <div class="dashcam-player-heading">
+          <p class="dashcam-player-eyebrow">Dashcam route</p>
+          <div class="dashcam-player-title-row">
+            <h2 class="media-player-title-text">${escapeHtml(routeLabel(route))}</h2>
+            <button class="dashcam-title-rename action-rename" type="button" title="Rename route" aria-label="Rename route"><i class="bi bi-pencil"></i></button>
+          </div>
+        </div>
         <button class="dashcam-player-close action-close" type="button" aria-label="Close player">&times;</button>
       </header>
       <div class="dashcam-video-shell">
         <video controls muted playsinline preload="metadata"></video>
         <div class="dashcam-player-state" role="status">Loading route metadata&hellip;</div>
       </div>
-      <div class="dashcam-segment-bar" hidden>
-        <button class="segment-step action-prev-segment" type="button" title="Previous segment (Shift + \u2190)" aria-label="Previous segment"><i class="bi bi-skip-start-fill"></i></button>
-        <select class="segment-select" aria-label="Jump to segment"></select>
-        <button class="segment-step action-next-segment" type="button" title="Next segment (Shift + \u2192)" aria-label="Next segment"><i class="bi bi-skip-end-fill"></i></button>
-      </div>
-      <div class="dashcam-camera-selector" aria-label="Camera selector">
-        <button class="camera-button" data-camera="forward" type="button" disabled hidden>Forward</button>
-        <button class="camera-button" data-camera="wide" type="button" disabled hidden>Wide</button>
-        <button class="camera-button" data-camera="driver" type="button" disabled hidden>Driver</button>
-      </div>
-      <div class="dashcam-player-actions">
-        <button class="action-download" type="button" disabled><i class="bi bi-download"></i> Download</button>
-        <button class="action-logs" type="button"><i class="bi bi-file-earmark-arrow-down"></i> Logs</button>
-        <button class="action-rename" type="button"><i class="bi bi-pencil"></i> Rename</button>
-        <button class="action-delete" type="button"><i class="bi bi-trash"></i> Delete</button>
+      <div class="dashcam-player-toolbar">
+        <div class="dashcam-camera-selector" aria-label="Camera selector">
+          <button class="camera-button" data-camera="forward" type="button" disabled hidden>Forward</button>
+          <button class="camera-button" data-camera="wide" type="button" disabled hidden>Wide</button>
+          <button class="camera-button" data-camera="driver" type="button" disabled hidden>Driver</button>
+        </div>
+        <div class="dashcam-segment-bar" hidden>
+          <button class="segment-step action-prev-segment" type="button" title="Previous segment (Shift + \u2190)" aria-label="Previous segment"><i class="bi bi-skip-start-fill"></i></button>
+          <select class="segment-select" aria-label="Jump to segment"></select>
+          <button class="segment-step action-next-segment" type="button" title="Next segment (Shift + \u2192)" aria-label="Next segment"><i class="bi bi-skip-end-fill"></i></button>
+        </div>
+        <div class="dashcam-player-actions">
+          <button class="action-download" type="button" disabled title="Download route" aria-label="Download route"><i class="bi bi-download"></i></button>
+          <button class="action-logs" type="button" title="View &amp; download logs" aria-label="View and download logs"><i class="bi bi-file-earmark-arrow-down"></i></button>
+          <button class="action-delete" type="button" title="Delete route" aria-label="Delete route"><i class="bi bi-trash"></i></button>
+        </div>
       </div>
     </section>`
   document.body.appendChild(overlay)
@@ -328,8 +336,10 @@ async function openOverlay(route) {
   let current = 0
   let selectedCamera = null
   let logsData = null
+  let showingPreview = false
+  let wantsPlayback = true
   let qualityToken = 0
-  let warmedSegment = null
+  let upgradeController = null
   let upgradeTimer = null
 
   const setPlayerMessage = (message, isError = false) => {
@@ -365,66 +375,71 @@ async function openOverlay(route) {
     video.load()
   }
 
-  // Full-res needs a device-side remux, so wait for it behind playback rather than in front.
+  const cancelUpgrade = () => {
+    qualityToken += 1
+    clearTimeout(upgradeTimer)
+    upgradeTimer = null
+    upgradeController?.abort()
+    upgradeController = null
+  }
+
+  // Prepare the real stream behind the playing preview. Only replace the media source
+  // after the server confirms the remux is ready, so slow device work never blanks it.
   const requestFullQuality = (segmentUrl, camera, attempt = 0) => {
     const token = ++qualityToken
+    upgradeController?.abort()
+    const controller = new AbortController()
+    upgradeController = controller
     const fullUrl = cameraVideoUrl(segmentUrl, camera)
     const stillCurrent = () =>
-      token === qualityToken && segments[current] === segmentUrl && selectedCamera === camera && !!overlay
-    fetch(fullUrl, { method: "HEAD" })
+      token === qualityToken && showingPreview && segments[current] === segmentUrl && selectedCamera === camera && !!overlay
+
+    fetch(fullUrl, { method: "HEAD", signal: controller.signal })
       .then(response => {
         if (!stillCurrent()) return
+        if (upgradeController === controller) upgradeController = null
         if (response.ok) {
+          showingPreview = false
           swapSource(fullUrl)
           return
         }
-        // 503 means the remux is queued behind another one; check back a few times.
         if (response.status === 503 && attempt < FULL_QUALITY_RETRIES) {
-          setTimeout(() => {
+          upgradeTimer = setTimeout(() => {
             if (stillCurrent()) requestFullQuality(segmentUrl, camera, attempt + 1)
           }, FULL_QUALITY_RETRY_MS)
         }
       })
-      .catch(() => {})
+      .catch(error => {
+        if (upgradeController === controller) upgradeController = null
+        if (error?.name !== "AbortError") console.error("Could not prepare full-quality route video:", error)
+      })
   }
 
-  overlay._cancelUpgrade = () => {
-    qualityToken += 1
-    clearTimeout(upgradeTimer)
-  }
-
-  const upgradeToFullQuality = (segmentUrl, camera) => {
-    qualityToken += 1
-    clearTimeout(upgradeTimer)
+  const scheduleUpgrade = (segmentUrl, camera) => {
+    cancelUpgrade()
     upgradeTimer = setTimeout(() => {
-      if (segments[current] === segmentUrl && selectedCamera === camera && overlay) {
-        requestFullQuality(segmentUrl, camera)
-      }
+      if (!showingPreview || segments[current] !== segmentUrl || selectedCamera !== camera) return
+      requestFullQuality(segmentUrl, camera)
     }, FULL_QUALITY_SETTLE_MS)
   }
 
-  const warmNextSegment = () => {
-    const nextUrl = segments[current + 1]
-    if (!nextUrl || !selectedCamera || !supportsLowQuality(selectedCamera)) return
-    if (warmedSegment === nextUrl) return
-    warmedSegment = nextUrl
-    // Only the ffmpeg-free stream is warmed; never transcode a segment nobody watches.
-    fetch(cameraVideoUrl(nextUrl, selectedCamera, "low"), { method: "HEAD" }).catch(() => {})
+  const loadSegment = (autoplay, { message, preview } = {}) => {
+    const segmentUrl = segments[current]
+    const camera = selectedCamera
+    if (!segmentUrl || !camera) return
+    cancelUpgrade()
+    wantsPlayback = autoplay
+    showingPreview = preview === undefined ? supportsLowQuality(camera) : preview
+    setPlayerMessage(message || "Loading video…")
+    video.src = cameraVideoUrl(segmentUrl, camera, showingPreview ? "low" : undefined)
+    video.load()
+    if (autoplay) video.play().catch(() => {})
   }
 
   const playCurrentSegment = (autoplay = true) => {
     if (!segments[current] || !selectedCamera) return
     syncSegmentControls()
-    setPlayerMessage("Loading video…")
-    const segmentUrl = segments[current]
-    const camera = selectedCamera
-    const useLowFirst = supportsLowQuality(camera)
-    qualityToken += 1
-    video.src = cameraVideoUrl(segmentUrl, camera, useLowFirst ? "low" : undefined)
-    video.load()
-    if (autoplay) video.play().catch(() => {})
-    if (useLowFirst) upgradeToFullQuality(segmentUrl, camera)
-    warmNextSegment()
+    loadSegment(autoplay)
   }
   const goToSegment = index => {
     if (!segments.length) return
@@ -435,9 +450,10 @@ async function openOverlay(route) {
     }
     const keepPlaying = video.ended || (!video.paused && !video.error)
     current = target
-    warmedSegment = null
     playCurrentSegment(keepPlaying)
   }
+  overlay._cancelUpgrade = cancelUpgrade
+
   const closeOnEscape = event => {
     if (document.querySelector(".route-logs-dialog")) return
     if (event.key === "Escape") {
@@ -472,10 +488,27 @@ async function openOverlay(route) {
     link.remove()
   }
 
+  video.addEventListener("loadedmetadata", () => {
+    if (!showingPreview) return
+    if (shouldUpgradeFromHeight(video.videoHeight)) {
+      scheduleUpgrade(segments[current], selectedCamera)
+    } else {
+      showingPreview = false
+    }
+  })
   video.addEventListener("loadeddata", () => setPlayerMessage(""))
   video.addEventListener("playing", () => setPlayerMessage(""))
   video.addEventListener("waiting", () => setPlayerMessage("Loading video…"))
-  video.addEventListener("error", () => setPlayerMessage("This segment could not be played.", true))
+  video.addEventListener("error", () => {
+    // A dead preview drops through to the real stream rather than showing an error.
+    if (showingPreview) {
+      showingPreview = false
+      cancelUpgrade()
+      loadSegment(wantsPlayback, { preview: false })
+      return
+    }
+    setPlayerMessage("This segment could not be played.", true)
+  })
   video.addEventListener("ended", () => goToSegment(current + 1))
 
   prevSegmentButton.onclick = () => goToSegment(current - 1)
@@ -487,12 +520,16 @@ async function openOverlay(route) {
       if (button.disabled || button.dataset.camera === selectedCamera || !segments[current]) return
       selectedCamera = button.dataset.camera
       cameraButtons.forEach(candidate => candidate.classList.toggle("active", candidate === button))
-      const segmentUrl = segments[current]
-      const camera = selectedCamera
-      const useLowFirst = supportsLowQuality(camera)
-      qualityToken += 1
-      swapSource(cameraVideoUrl(segmentUrl, camera, useLowFirst ? "low" : undefined), { message: "Switching camera…" })
-      if (useLowFirst) upgradeToFullQuality(segmentUrl, camera)
+      const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
+      const shouldResume = !video.paused && !video.ended
+      video.addEventListener("loadedmetadata", () => {
+        if (playbackTime > 0) {
+          try {
+            video.currentTime = Math.min(playbackTime, Number.isFinite(video.duration) ? video.duration : playbackTime)
+          } catch (_) {}
+        }
+      }, { once: true })
+      loadSegment(shouldResume, { message: "Switching camera…" })
     })
   }
 

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -298,8 +298,10 @@ async function openOverlay(route) {
         <button class="close-button camera-button" data-camera="wide">Wide</button>
         <button class="close-button camera-button" data-camera="driver">Driver</button>
         <button class="close-button action-download">Download</button>
+        <button class="close-button action-logs">Logs</button>
         <button class="close-button action-delete">Delete</button>
       </div>
+      <div class="route-logs" hidden></div>
     </div>`;
   document.body.appendChild(overlay);
 
@@ -312,6 +314,50 @@ async function openOverlay(route) {
 
   const vid = overlay.querySelector("video");
   const downloadButton = overlay.querySelector(".action-download");
+  const logsButton = overlay.querySelector(".action-logs");
+  const logsPanel = overlay.querySelector(".route-logs");
+
+  const formatBytes = bytes => {
+    if (!bytes) return "0 MB";
+    const mb = bytes / 1e6;
+    return mb >= 1000 ? `${(mb / 1000).toFixed(2)} GB` : `${mb.toFixed(1)} MB`;
+  };
+
+  let logsLoaded = false;
+  logsButton.onclick = async () => {
+    if (logsLoaded) {
+      logsPanel.hidden = !logsPanel.hidden;
+      return;
+    }
+
+    logsPanel.hidden = false;
+    logsPanel.innerHTML = `<p class="route-logs-message">Looking for full logs...</p>`;
+    try {
+      const response = await fetch(`/api/routes/${route.name}/logs`);
+      const data = await response.json();
+      if (!response.ok) {
+        logsPanel.innerHTML = `<p class="route-logs-message">${data.error || "Could not read logs."}</p>`;
+        return;
+      }
+
+      // sizes are shown up front so a metered connection is a deliberate choice
+      logsPanel.innerHTML = `
+        <div class="route-logs-header">
+          <span>${data.segments.length} segment${data.segments.length === 1 ? "" : "s"} &middot; ${formatBytes(data.totalBytes)} total</span>
+          <a class="route-logs-all" href="/api/routes/${route.name}/logs/download" download>Download all (.tar)</a>
+        </div>
+        <ul class="route-logs-list">
+          ${data.segments.map(segment => `
+            <li>
+              <span>Segment ${segment.segmentNum} &middot; ${formatBytes(segment.bytes)}</span>
+              <a href="${segment.url}" download>${segment.filename}</a>
+            </li>`).join("")}
+        </ul>`;
+      logsLoaded = true;
+    } catch (error) {
+      logsPanel.innerHTML = `<p class="route-logs-message">Could not reach the device: ${error.message}</p>`;
+    }
+  };
 
   let segments;
   let current = 0;

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -340,6 +340,7 @@ async function openOverlay(route) {
   const [videoA, videoB] = overlay.querySelectorAll(".dashcam-video")
   let activeVideo = videoA
   let stagingVideo = videoB
+  const videoShell = overlay.querySelector(".dashcam-video-shell")
   const playerState = overlay.querySelector(".dashcam-player-state")
   const segmentBar = overlay.querySelector(".dashcam-segment-bar")
   const segmentSelect = overlay.querySelector(".segment-select")
@@ -579,6 +580,9 @@ async function openOverlay(route) {
     cancelUpgrade()
     wantsPlayback = autoplay
     showingPreview = preview === undefined ? supportsLowQuality(camera) : preview
+    // qcamera.ts scales the complete road frame to 526x330. Keep that same mapping
+    // after the full stream arrives so its slightly wider aspect ratio is not cropped.
+    videoShell.classList.toggle("qcamera-framing", showingPreview)
     if (message) setPlayerMessage(message)
 
     stagingVideo.pause()

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -110,6 +110,14 @@ function refresh() {
   return fetchRoutes()
 }
 
+function changeSortOrder(event) {
+  const sortOrder = String(event.target.value || "")
+  if (!["newest", "oldest", "longest", "shortest"].includes(sortOrder)) return
+  state.sortOrder = sortOrder
+  // Replacing the array forces the keyed route templates to move immediately.
+  state.routes = [...state.routes]
+}
+
 if (!isGalaxyTunnel()) refresh()
 
 function openDialog(htmlString) {
@@ -825,7 +833,7 @@ export function RouteRecordings() {
           </div>
           <label class="dashcam-sort">
             <span>Sort</span>
-            <select value="${() => state.sortOrder}" @change="${event => { state.sortOrder = event.target.value }}">
+            <select value="${() => state.sortOrder}" @input="${changeSortOrder}" @change="${changeSortOrder}">
               <option value="newest">Newest first</option>
               <option value="oldest">Oldest first</option>
               <option value="longest">Longest duration</option>

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -359,6 +359,30 @@ async function openOverlay(route) {
   let upgradeTimer = null
   let isUpgrading = false
 
+  const clearDeferredNativeControls = video => {
+    if (typeof video._dashcamControlsCleanup === "function") video._dashcamControlsCleanup()
+  }
+  const setNativeControls = (video, enabled) => {
+    clearDeferredNativeControls(video)
+    video.controls = enabled
+  }
+  const deferNativeControlsUntilInteraction = video => {
+    clearDeferredNativeControls(video)
+    video.controls = false
+
+    const restore = () => {
+      if (video !== activeVideo || !overlay) return
+      setNativeControls(video, true)
+    }
+    const events = ["pointermove", "pointerdown", "focus"]
+    const cleanup = () => {
+      events.forEach(eventName => video.removeEventListener(eventName, restore))
+      delete video._dashcamControlsCleanup
+    }
+    video._dashcamControlsCleanup = cleanup
+    events.forEach(eventName => video.addEventListener(eventName, restore))
+  }
+
   const setPlayerMessage = (message, isError = false) => {
     playerState.textContent = message
     playerState.hidden = !message
@@ -386,6 +410,7 @@ async function openOverlay(route) {
     upgradeController = null
     stagingVideo.pause()
     stagingVideo.removeAttribute("src")
+    setNativeControls(stagingVideo, false)
     stagingVideo.load()
   }
 
@@ -452,11 +477,12 @@ async function openOverlay(route) {
 
           activeVideo.classList.remove("active")
           activeVideo.classList.add("staging")
-          activeVideo.controls = false
+          setNativeControls(activeVideo, false)
 
           stagingVideo.classList.remove("staging")
           stagingVideo.classList.add("active")
-          stagingVideo.controls = true
+          if (isPlaying) deferNativeControlsUntilInteraction(stagingVideo)
+          else setNativeControls(stagingVideo, true)
 
           const oldActive = activeVideo
           activeVideo = stagingVideo
@@ -559,11 +585,11 @@ async function openOverlay(route) {
     stagingVideo.removeAttribute("src")
     stagingVideo.classList.remove("active")
     stagingVideo.classList.add("staging")
-    stagingVideo.controls = false
+    setNativeControls(stagingVideo, false)
 
     activeVideo.classList.remove("staging")
     activeVideo.classList.add("active")
-    activeVideo.controls = true
+    setNativeControls(activeVideo, true)
     activeVideo.src = cameraVideoUrl(segmentUrl, camera, showingPreview ? "low" : undefined)
     activeVideo.load()
     if (autoplay) activeVideo.play().catch(() => {})
@@ -737,6 +763,7 @@ function closeOverlay() {
   document.removeEventListener("keydown", overlay._closeOnEscape)
   const videos = overlay.querySelectorAll("video")
   videos.forEach(v => {
+    v._dashcamControlsCleanup?.()
     v.pause()
     v.removeAttribute("src")
     v.load()

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -12,6 +12,7 @@ import {
   groupRoutesForView,
   MAX_RENDERED_ROUTES,
   normalizeRoute,
+  routeViewRenderKey,
 } from "/assets/components/recordings/dashcam_routes_helpers.js"
 
 const state = reactive({
@@ -114,8 +115,6 @@ function changeSortOrder(event) {
   const sortOrder = String(event.target.value || "")
   if (!["newest", "oldest", "longest", "shortest"].includes(sortOrder)) return
   state.sortOrder = sortOrder
-  // Replacing the array forces the keyed route templates to move immediately.
-  state.routes = [...state.routes]
 }
 
 if (!isGalaxyTunnel()) refresh()
@@ -853,6 +852,7 @@ export function RouteRecordings() {
         ${() => {
           const view = buildRouteView(state.routes, { preservedOnly: state.showPreservedOnly, searchQuery: state.searchQuery, sortOrder: state.sortOrder })
           const groups = groupRoutesForView(view.visible, state.sortOrder)
+          const renderKey = routeViewRenderKey(view.visible, state.sortOrder, state.viewMode)
 
           return html`
             <div class="dashcam-results-summary" aria-live="polite">
@@ -863,7 +863,7 @@ export function RouteRecordings() {
             ${state.isDeletingAll ? html`<p class="screen-recordings-message">Deleting routes&hellip;</p>` : ""}
             ${!view.visible.length && state.loading ? html`<div class="dashcam-loading"><span></span><p>Finding local routes&hellip;</p></div>` : ""}
             ${!view.visible.length && !state.loading && !state.isDeletingAll ? html`<div class="dashcam-empty-state"><i class="bi bi-camera-reels"></i><p>${state.routes.length ? "No routes match these filters." : "No routes found."}</p></div>` : ""}
-            <div class="dashcam-date-groups">
+            <div class="dashcam-date-groups" data-view-key="${renderKey}">
               ${groups.map(group => html`
                 <section class="dashcam-date-group">
                   <div class="dashcam-date-group-header">

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -205,11 +205,13 @@ async function renameRoute(route) {
       return
     }
 
-    const updatedRoute = normalizeRoute({ ...route, timestamp: newName, isCustomName: true })
+    const payload = await response.json().catch(() => ({}))
+    const savedName = payload.name || newName
+    const updatedRoute = normalizeRoute({ ...route, timestamp: savedName, isCustomName: true })
     replaceRoute(updatedRoute)
     closeDialog(dialog)
     const title = overlay?.querySelector(".media-player-title-text")
-    if (title) title.textContent = newName
+    if (title) title.textContent = savedName
     showSnackbar("Route renamed!")
   }
 }
@@ -301,7 +303,7 @@ async function openOverlay(route) {
             <button class="dashcam-title-rename action-rename" type="button" title="Rename route" aria-label="Rename route"><i class="bi bi-pencil"></i></button>
           </div>
         </div>
-        <button class="dashcam-player-close action-close" type="button" aria-label="Close player">&times;</button>
+        <button class="dashcam-player-close" type="button" aria-label="Close player">&times;</button>
       </header>
       <div class="dashcam-video-shell">
         <video class="dashcam-video active" controls muted playsinline preload="metadata"></video>
@@ -597,7 +599,7 @@ async function openOverlay(route) {
   overlay.addEventListener("click", event => { if (event.target === overlay) closeOverlay() })
   document.addEventListener("keydown", closeOnEscape)
   overlay._closeOnEscape = closeOnEscape
-  overlay.querySelector(".action-close").onclick = closeOverlay
+  overlay.querySelector(".dashcam-player-close").onclick = closeOverlay
   overlay.querySelector(".action-delete").onclick = () => deleteRoute(state.selectedRoute || route)
   overlay.querySelector(".action-rename").onclick = () => renameRoute(state.selectedRoute || route)
 
@@ -876,10 +878,10 @@ export function RouteRecordings() {
                           </div>
                           <div class="dashcam-card-body">
                             <div class="dashcam-route-title-row">
-                              <h3 title="${route.displayName}">${route.displayName}</h3>
-                              ${route.isCustomName ? html`<span class="dashcam-custom-badge" title="Custom name"><i class="bi bi-tag-fill"></i></span>` : ""}
+                              <h3 title="${() => route.displayName}">${() => route.displayName}</h3>
+                              ${() => route.isCustomName ? html`<span class="dashcam-custom-badge" title="Custom name"><i class="bi bi-tag-fill"></i></span>` : ""}
                             </div>
-                            ${route.isCustomName ? html`<p class="dashcam-card-date">${route.displayDate}</p>` : ""}
+                            ${() => route.isCustomName ? html`<p class="dashcam-card-date">${route.displayDate}</p>` : ""}
                             <div class="dashcam-route-meta-pills">
                               <span class="meta-pill duration-pill"><i class="bi bi-clock"></i> ${formatApproxDuration(route.approxDurationSeconds)}</span>
                               <span class="meta-pill segments-pill"><i class="bi bi-collection-play"></i> ${route.segmentCount} seg</span>
@@ -910,10 +912,10 @@ export function RouteRecordings() {
                           </div>
                           <div class="dashcam-route-info">
                             <div class="dashcam-route-title-row">
-                              <h3 class="dashcam-route-title" title="${route.displayName}">${route.displayName}</h3>
-                              ${route.isCustomName ? html`<span class="dashcam-custom-badge" title="Custom name"><i class="bi bi-tag-fill"></i> Custom</span>` : ""}
+                              <h3 class="dashcam-route-title" title="${() => route.displayName}">${() => route.displayName}</h3>
+                              ${() => route.isCustomName ? html`<span class="dashcam-custom-badge" title="Custom name"><i class="bi bi-tag-fill"></i> Custom</span>` : ""}
                             </div>
-                            ${route.isCustomName ? html`<p class="dashcam-route-subdate"><i class="bi bi-calendar3"></i> ${route.displayDate}</p>` : ""}
+                            ${() => route.isCustomName ? html`<p class="dashcam-route-subdate"><i class="bi bi-calendar3"></i> ${route.displayDate}</p>` : ""}
                             <div class="dashcam-route-meta-pills">
                               <span class="meta-pill duration-pill" title="Estimated duration"><i class="bi bi-clock"></i> ${formatApproxDuration(route.approxDurationSeconds)}</span>
                               <span class="meta-pill segments-pill" title="Segments recorded"><i class="bi bi-collection-play"></i> ${route.segmentCount} segment${route.segmentCount === 1 ? "" : "s"}</span>

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -301,7 +301,6 @@ async function openOverlay(route) {
         <button class="close-button action-logs">Logs</button>
         <button class="close-button action-delete">Delete</button>
       </div>
-      <div class="route-logs" hidden></div>
     </div>`;
   document.body.appendChild(overlay);
 
@@ -315,7 +314,6 @@ async function openOverlay(route) {
   const vid = overlay.querySelector("video");
   const downloadButton = overlay.querySelector(".action-download");
   const logsButton = overlay.querySelector(".action-logs");
-  const logsPanel = overlay.querySelector(".route-logs");
 
   const formatBytes = bytes => {
     if (!bytes) return "0 MB";
@@ -323,39 +321,84 @@ async function openOverlay(route) {
     return mb >= 1000 ? `${(mb / 1000).toFixed(2)} GB` : `${mb.toFixed(1)} MB`;
   };
 
-  let logsLoaded = false;
+  let logsData = null;
   logsButton.onclick = async () => {
-    if (logsLoaded) {
-      logsPanel.hidden = !logsPanel.hidden;
-      return;
-    }
+    const logsDialog = openDialog(`
+      <section class="dialog-box route-logs-dialog" role="dialog" aria-modal="true" aria-labelledby="route-logs-title">
+        <header class="route-logs-toolbar">
+          <div>
+            <p class="route-logs-eyebrow">Route data</p>
+            <h2 id="route-logs-title">Full logs</h2>
+          </div>
+          <button class="route-logs-close" type="button" aria-label="Close full logs">&times;</button>
+        </header>
+        <div class="route-logs-content" aria-live="polite">
+          <p class="route-logs-message">Looking for full logs&hellip;</p>
+        </div>
+      </section>`);
+    const logsContent = logsDialog.querySelector(".route-logs-content");
+    const logsCloseButton = logsDialog.querySelector(".route-logs-close");
 
-    logsPanel.hidden = false;
-    logsPanel.innerHTML = `<p class="route-logs-message">Looking for full logs...</p>`;
-    try {
-      const response = await fetch(`/api/routes/${route.name}/logs`);
-      const data = await response.json();
-      if (!response.ok) {
-        logsPanel.innerHTML = `<p class="route-logs-message">${data.error || "Could not read logs."}</p>`;
-        return;
-      }
+    const closeLogsDialog = () => {
+      document.removeEventListener("keydown", handleLogsKeydown);
+      closeDialog(logsDialog);
+      logsButton.focus();
+    };
+    const handleLogsKeydown = event => {
+      if (event.key === "Escape") closeLogsDialog();
+    };
+    logsCloseButton.onclick = closeLogsDialog;
+    logsDialog.addEventListener("click", event => {
+      if (event.target === logsDialog) closeLogsDialog();
+    });
+    document.addEventListener("keydown", handleLogsKeydown);
+    logsCloseButton.focus();
 
-      // sizes are shown up front so a metered connection is a deliberate choice
-      logsPanel.innerHTML = `
-        <div class="route-logs-header">
-          <span>${data.segments.length} segment${data.segments.length === 1 ? "" : "s"} &middot; ${formatBytes(data.totalBytes)} total</span>
-          <a class="route-logs-all" href="/api/routes/${route.name}/logs/download" download>Download all (.tar)</a>
+    const renderLogs = data => {
+      logsContent.innerHTML = `
+        <div class="route-logs-summary">
+          <div>
+            <strong>${data.segments.length} segment${data.segments.length === 1 ? "" : "s"}</strong>
+            <span>${formatBytes(data.totalBytes)} total download</span>
+          </div>
+          <a class="route-logs-download-all" href="/api/routes/${route.name}/logs/download" download>
+            Download all <span>.tar</span>
+          </a>
         </div>
         <ul class="route-logs-list">
           ${data.segments.map(segment => `
             <li>
-              <span>Segment ${segment.segmentNum} &middot; ${formatBytes(segment.bytes)}</span>
-              <a href="${segment.url}" download>${segment.filename}</a>
+              <div class="route-log-details">
+                <strong>Segment ${segment.segmentNum}</strong>
+                <span>${formatBytes(segment.bytes)} &middot; ${segment.filename}</span>
+              </div>
+              <a class="route-log-download" href="${segment.url}" download>Download</a>
             </li>`).join("")}
         </ul>`;
-      logsLoaded = true;
+    };
+
+    if (logsData) {
+      renderLogs(logsData);
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/routes/${route.name}/logs`);
+      const data = await response.json();
+      if (!response.ok) {
+        if (logsContent.isConnected) {
+          logsContent.innerHTML = `<p class="route-logs-message route-logs-error">${data.error || "Could not read logs."}</p>`;
+        }
+        return;
+      }
+
+      // sizes are shown up front so a metered connection is a deliberate choice
+      logsData = data;
+      if (logsContent.isConnected) renderLogs(data);
     } catch (error) {
-      logsPanel.innerHTML = `<p class="route-logs-message">Could not reach the device: ${error.message}</p>`;
+      if (logsContent.isConnected) {
+        logsContent.innerHTML = `<p class="route-logs-message route-logs-error">Could not reach the device: ${error.message}</p>`;
+      }
     }
   };
 

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -25,7 +25,7 @@ const state = reactive({
   viewMode: "list",
   progress: 0,
   total: 0,
-  showDeleteAllModal: false,
+  deleteMode: null,
   isDeletingAll: false,
 })
 
@@ -129,7 +129,11 @@ function replaceRoute(updatedRoute) {
   const existing = state.routes.find(route => route.name === updatedRoute.name)
   if (existing) Object.assign(existing, updatedRoute)
   const selected = state.selectedRoute
-  if (selected?.name === updatedRoute.name && selected !== existing) Object.assign(selected, updatedRoute)
+  if (selected?.name === updatedRoute.name && selected !== existing) {
+    Object.assign(selected, updatedRoute)
+  }
+  // Reassigning state.routes notifies ArrowJS to re-render views that depend on the routes array
+  state.routes = [...state.routes]
 }
 
 async function deleteRoute(route) {
@@ -749,16 +753,17 @@ async function togglePreserved(route, event) {
   }
 }
 
-async function deleteAllRoutes() {
-  state.showDeleteAllModal = false
+async function deleteAllRoutes(includePreserved) {
+  state.deleteMode = null
   state.isDeletingAll = true
   try {
-    const response = await fetch("/api/routes/delete_all", { method: "DELETE" })
-    if (!response.ok) throw new Error()
+    const response = await fetch(`/api/routes/delete_all?include_preserved=${includePreserved}`, { method: "DELETE" })
+    const payload = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(payload.error || "Route deletion failed")
     await refresh()
-    showSnackbar("All routes deleted!")
-  } catch (_) {
-    showSnackbar("An error occurred while deleting all routes...", "error")
+    showSnackbar(payload.message || "Routes deleted!")
+  } catch (error) {
+    showSnackbar(error?.message || "An error occurred while deleting routes...", "error")
   } finally {
     state.isDeletingAll = false
   }
@@ -942,16 +947,21 @@ export function RouteRecordings() {
 
         ${() => state.routes.length ? html`
           <footer class="dashcam-danger-zone">
-            <div><strong>Delete all local routes</strong><span>Preserved routes are included.</span></div>
-            <button class="delete-all-button" type="button" @click="${() => { state.showDeleteAllModal = true }}" disabled="${() => state.isDeletingAll || false}">${() => state.isDeletingAll ? "Deleting…" : "Delete All"}</button>
+            <div class="dashcam-danger-copy"><strong>Delete local routes</strong><span>Keep preserved routes, or remove everything.</span></div>
+            <div class="dashcam-danger-actions">
+              <button class="delete-all-button delete-non-preserved-button" type="button" @click="${() => { state.deleteMode = "non-preserved" }}" disabled="${() => state.isDeletingAll || state.routes.every(route => route.is_preserved) || false}">${() => state.isDeletingAll ? "Deleting…" : "Delete Non-Preserved"}</button>
+              <button class="delete-all-button" type="button" @click="${() => { state.deleteMode = "all" }}" disabled="${() => state.isDeletingAll || false}">${() => state.isDeletingAll ? "Deleting…" : "Delete All Including Preserved"}</button>
+            </div>
           </footer>` : ""}
       </section>
-      ${() => state.showDeleteAllModal ? Modal({
-        title: "Confirm Delete All",
-        message: "Are you sure you want to delete all routes? This action cannot be undone...",
-        onConfirm: deleteAllRoutes,
-        onCancel: () => { state.showDeleteAllModal = false },
-        confirmText: "Delete All",
+      ${() => state.deleteMode ? Modal({
+        title: state.deleteMode === "all" ? "Delete All Routes, Including Preserved?" : "Delete All Non-Preserved Routes?",
+        message: state.deleteMode === "all"
+          ? "This permanently deletes every local route, including preserved routes. This action cannot be undone."
+          : "This permanently deletes every non-preserved local route. Preserved routes will be kept.",
+        onConfirm: () => deleteAllRoutes(state.deleteMode === "all"),
+        onCancel: () => { state.deleteMode = null },
+        confirmText: state.deleteMode === "all" ? "Delete Everything" : "Delete Non-Preserved",
       }) : ""}
     </div>`
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -6,8 +6,9 @@ import {
   cameraVideoUrl,
   computeRouteStats,
   formatApproxDuration,
-  getSegmentStatus,
-  groupRoutesByDate,
+  getSegmentOptions,
+  supportsLowQuality,
+  groupRoutesForView,
   MAX_RENDERED_ROUTES,
   normalizeRoute,
 } from "/assets/components/recordings/dashcam_routes_helpers.js"
@@ -32,6 +33,10 @@ let routesRequestToken = 0
 let seenRouteNames = new Set()
 let overlay = null
 const routeLogsCache = new Map()
+const FULL_QUALITY_RETRIES = 3
+const FULL_QUALITY_RETRY_MS = 4000
+// Wait for the viewer to settle, so scrubbing never queues a remux per segment.
+const FULL_QUALITY_SETTLE_MS = 1500
 
 function routeLabel(route) {
   return route.displayName || route.displayDate || route.name
@@ -119,8 +124,11 @@ function closeDialog(dialog) {
 }
 
 function replaceRoute(updatedRoute) {
-  state.routes = state.routes.map(route => route.name === updatedRoute.name ? updatedRoute : route)
-  if (state.selectedRoute?.name === updatedRoute.name) state.selectedRoute = updatedRoute
+  // Rows bind to this exact object, so replacing it would strand them on the stale one.
+  const existing = state.routes.find(route => route.name === updatedRoute.name)
+  if (existing) Object.assign(existing, updatedRoute)
+  const selected = state.selectedRoute
+  if (selected?.name === updatedRoute.name && selected !== existing) Object.assign(selected, updatedRoute)
 }
 
 async function deleteRoute(route) {
@@ -285,10 +293,14 @@ async function openOverlay(route) {
         <button class="dashcam-player-close action-close" type="button" aria-label="Close player">&times;</button>
       </header>
       <div class="dashcam-video-shell">
-        <video controls muted playsinline></video>
+        <video controls muted playsinline preload="metadata"></video>
         <div class="dashcam-player-state" role="status">Loading route metadata&hellip;</div>
       </div>
-      <div class="dashcam-segment-status" aria-live="polite" hidden></div>
+      <div class="dashcam-segment-bar" hidden>
+        <button class="segment-step action-prev-segment" type="button" title="Previous segment (Shift + \u2190)" aria-label="Previous segment"><i class="bi bi-skip-start-fill"></i></button>
+        <select class="segment-select" aria-label="Jump to segment"></select>
+        <button class="segment-step action-next-segment" type="button" title="Next segment (Shift + \u2192)" aria-label="Next segment"><i class="bi bi-skip-end-fill"></i></button>
+      </div>
       <div class="dashcam-camera-selector" aria-label="Camera selector">
         <button class="camera-button" data-camera="forward" type="button" disabled hidden>Forward</button>
         <button class="camera-button" data-camera="wide" type="button" disabled hidden>Wide</button>
@@ -305,7 +317,10 @@ async function openOverlay(route) {
 
   const video = overlay.querySelector("video")
   const playerState = overlay.querySelector(".dashcam-player-state")
-  const statusStrip = overlay.querySelector(".dashcam-segment-status")
+  const segmentBar = overlay.querySelector(".dashcam-segment-bar")
+  const segmentSelect = overlay.querySelector(".segment-select")
+  const prevSegmentButton = overlay.querySelector(".action-prev-segment")
+  const nextSegmentButton = overlay.querySelector(".action-next-segment")
   const downloadButton = overlay.querySelector(".action-download")
   const logsButton = overlay.querySelector(".action-logs")
   const cameraButtons = [...overlay.querySelectorAll(".camera-button")]
@@ -313,27 +328,130 @@ async function openOverlay(route) {
   let current = 0
   let selectedCamera = null
   let logsData = null
+  let qualityToken = 0
+  let warmedSegment = null
+  let upgradeTimer = null
 
   const setPlayerMessage = (message, isError = false) => {
     playerState.textContent = message
     playerState.hidden = !message
     playerState.classList.toggle("error", isError)
   }
-  const updateSegmentStatus = () => {
-    const status = getSegmentStatus(segments, current)
-    statusStrip.textContent = status
-    statusStrip.hidden = !status
+  const syncSegmentControls = () => {
+    segmentSelect.value = String(current)
+    segmentSelect.disabled = segments.length < 2
+    prevSegmentButton.disabled = current <= 0
+    nextSegmentButton.disabled = current >= segments.length - 1
   }
-  const playCurrentSegment = () => {
-    if (!segments[current] || !selectedCamera) return
-    updateSegmentStatus()
-    setPlayerMessage("Loading video…")
-    video.src = cameraVideoUrl(segments[current], selectedCamera)
+  const buildSegmentPicker = () => {
+    segmentSelect.innerHTML = getSegmentOptions(segments)
+      .map(option => `<option value="${option.index}">${escapeHtml(option.label)}</option>`)
+      .join("")
+    segmentBar.hidden = !segments.length
+  }
+  const swapSource = (url, { message } = {}) => {
+    const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
+    const shouldResume = !video.paused && !video.ended
+    video.addEventListener("loadedmetadata", () => {
+      if (playbackTime > 0) {
+        try {
+          video.currentTime = Math.min(playbackTime, Number.isFinite(video.duration) ? video.duration : playbackTime)
+        } catch (_) {}
+      }
+      if (shouldResume) video.play().catch(() => {})
+    }, { once: true })
+    if (message) setPlayerMessage(message)
+    video.src = url
     video.load()
-    video.play().catch(() => {})
+  }
+
+  // Full-res needs a device-side remux, so wait for it behind playback rather than in front.
+  const requestFullQuality = (segmentUrl, camera, attempt = 0) => {
+    const token = ++qualityToken
+    const fullUrl = cameraVideoUrl(segmentUrl, camera)
+    const stillCurrent = () =>
+      token === qualityToken && segments[current] === segmentUrl && selectedCamera === camera && !!overlay
+    fetch(fullUrl, { method: "HEAD" })
+      .then(response => {
+        if (!stillCurrent()) return
+        if (response.ok) {
+          swapSource(fullUrl)
+          return
+        }
+        // 503 means the remux is queued behind another one; check back a few times.
+        if (response.status === 503 && attempt < FULL_QUALITY_RETRIES) {
+          setTimeout(() => {
+            if (stillCurrent()) requestFullQuality(segmentUrl, camera, attempt + 1)
+          }, FULL_QUALITY_RETRY_MS)
+        }
+      })
+      .catch(() => {})
+  }
+
+  overlay._cancelUpgrade = () => {
+    qualityToken += 1
+    clearTimeout(upgradeTimer)
+  }
+
+  const upgradeToFullQuality = (segmentUrl, camera) => {
+    qualityToken += 1
+    clearTimeout(upgradeTimer)
+    upgradeTimer = setTimeout(() => {
+      if (segments[current] === segmentUrl && selectedCamera === camera && overlay) {
+        requestFullQuality(segmentUrl, camera)
+      }
+    }, FULL_QUALITY_SETTLE_MS)
+  }
+
+  const warmNextSegment = () => {
+    const nextUrl = segments[current + 1]
+    if (!nextUrl || !selectedCamera || !supportsLowQuality(selectedCamera)) return
+    if (warmedSegment === nextUrl) return
+    warmedSegment = nextUrl
+    // Only the ffmpeg-free stream is warmed; never transcode a segment nobody watches.
+    fetch(cameraVideoUrl(nextUrl, selectedCamera, "low"), { method: "HEAD" }).catch(() => {})
+  }
+
+  const playCurrentSegment = (autoplay = true) => {
+    if (!segments[current] || !selectedCamera) return
+    syncSegmentControls()
+    setPlayerMessage("Loading video…")
+    const segmentUrl = segments[current]
+    const camera = selectedCamera
+    const useLowFirst = supportsLowQuality(camera)
+    qualityToken += 1
+    video.src = cameraVideoUrl(segmentUrl, camera, useLowFirst ? "low" : undefined)
+    video.load()
+    if (autoplay) video.play().catch(() => {})
+    if (useLowFirst) upgradeToFullQuality(segmentUrl, camera)
+    warmNextSegment()
+  }
+  const goToSegment = index => {
+    if (!segments.length) return
+    const target = Math.min(Math.max(index, 0), segments.length - 1)
+    if (target === current) {
+      syncSegmentControls()
+      return
+    }
+    const keepPlaying = video.ended || (!video.paused && !video.error)
+    current = target
+    warmedSegment = null
+    playCurrentSegment(keepPlaying)
   }
   const closeOnEscape = event => {
-    if (event.key === "Escape" && !document.querySelector(".route-logs-dialog")) closeOverlay()
+    if (document.querySelector(".route-logs-dialog")) return
+    if (event.key === "Escape") {
+      closeOverlay()
+      return
+    }
+    if (!event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return
+    if (event.key === "ArrowLeft") {
+      event.preventDefault()
+      goToSegment(current - 1)
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault()
+      goToSegment(current + 1)
+    }
   }
 
   overlay.addEventListener("click", event => { if (event.target === overlay) closeOverlay() })
@@ -358,30 +476,23 @@ async function openOverlay(route) {
   video.addEventListener("playing", () => setPlayerMessage(""))
   video.addEventListener("waiting", () => setPlayerMessage("Loading video…"))
   video.addEventListener("error", () => setPlayerMessage("This segment could not be played.", true))
-  video.addEventListener("ended", () => {
-    if (current + 1 >= segments.length) return
-    current += 1
-    playCurrentSegment()
-  })
+  video.addEventListener("ended", () => goToSegment(current + 1))
+
+  prevSegmentButton.onclick = () => goToSegment(current - 1)
+  nextSegmentButton.onclick = () => goToSegment(current + 1)
+  segmentSelect.onchange = () => goToSegment(Number(segmentSelect.value))
 
   for (const button of cameraButtons) {
     button.addEventListener("click", () => {
       if (button.disabled || button.dataset.camera === selectedCamera || !segments[current]) return
-      const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
-      const shouldResume = !video.paused && !video.ended
       selectedCamera = button.dataset.camera
       cameraButtons.forEach(candidate => candidate.classList.toggle("active", candidate === button))
-      video.addEventListener("loadedmetadata", () => {
-        if (playbackTime > 0) {
-          try {
-            video.currentTime = Math.min(playbackTime, Number.isFinite(video.duration) ? video.duration : playbackTime)
-          } catch (_) {}
-        }
-        if (shouldResume) video.play().catch(() => {})
-      }, { once: true })
-      setPlayerMessage("Switching camera…")
-      video.src = cameraVideoUrl(segments[current], selectedCamera)
-      video.load()
+      const segmentUrl = segments[current]
+      const camera = selectedCamera
+      const useLowFirst = supportsLowQuality(camera)
+      qualityToken += 1
+      swapSource(cameraVideoUrl(segmentUrl, camera, useLowFirst ? "low" : undefined), { message: "Switching camera…" })
+      if (useLowFirst) upgradeToFullQuality(segmentUrl, camera)
     })
   }
 
@@ -402,6 +513,7 @@ async function openOverlay(route) {
       button.classList.toggle("active", button.dataset.camera === selectedCamera)
     }
     downloadButton.disabled = false
+    buildSegmentPicker()
     playCurrentSegment()
   } catch (error) {
     cameraButtons.forEach(button => { button.disabled = true })
@@ -411,6 +523,7 @@ async function openOverlay(route) {
 
 function closeOverlay() {
   if (!overlay) return
+  overlay._cancelUpgrade?.()
   document.removeEventListener("keydown", overlay._closeOnEscape)
   overlay.remove()
   overlay = null
@@ -521,8 +634,7 @@ export function RouteRecordings() {
 
         ${() => {
           const view = buildRouteView(state.routes, { preservedOnly: state.showPreservedOnly, searchQuery: state.searchQuery, sortOrder: state.sortOrder })
-          const groups = groupRoutesByDate(view.visible)
-          const isGrid = state.viewMode === "grid"
+          const groups = groupRoutesForView(view.visible, state.sortOrder)
 
           return html`
             <div class="dashcam-results-summary" aria-live="polite">
@@ -540,13 +652,12 @@ export function RouteRecordings() {
                     <h2>${group.label}</h2>
                     <span class="dashcam-date-group-count">${group.routes.length} ${group.routes.length === 1 ? "drive" : "drives"}</span>
                   </div>
-                  ${isGrid ? html`
-                    <div class="screen-recordings-grid dashcam-routes-grid">
+                  ${() => state.viewMode === "grid" ? html`<div class="screen-recordings-grid dashcam-routes-grid">
                       ${group.routes.map(route => html`
-                        <article class="recording-card dashcam-route-card ${route.is_preserved ? "is-preserved" : ""}" @click="${() => { state.selectedRoute = route }}">
+                        <article class="${() => `recording-card dashcam-route-card ${route.is_preserved ? "is-preserved" : ""}`}" @click="${() => { state.selectedRoute = route }}">
                           <div class="dashcam-card-top-bar">
-                            <button class="btn-route-action btn-preserve ${route.is_preserved ? "active" : ""}" type="button" aria-label="${route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${route.is_preserved ? "Preserved (click to unpreserve)" : "Click to preserve"}" @click="${event => togglePreserved(route, event)}">
-                              <i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>
+                            <button class="${() => `btn-route-action btn-preserve ${route.is_preserved ? "active" : ""}`}" type="button" aria-label="${() => route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${() => route.is_preserved ? "Preserved (click to unpreserve)" : "Click to preserve"}" @click="${event => togglePreserved(route, event)}">
+                              <i class="${() => `bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}`}"></i>
                             </button>
                             <span class="meta-pill id-pill" title="Route ID: ${route.name}"><i class="bi bi-hash"></i>${route.name.split("--").slice(1).join("--") || route.name}</span>
                           </div>
@@ -581,11 +692,9 @@ export function RouteRecordings() {
                             </div>
                           </div>
                         </article>`)}
-                    </div>
-                  ` : html`
-                    <div class="dashcam-routes-list">
+                    </div>` : html`<div class="dashcam-routes-list">
                       ${group.routes.map(route => html`
-                        <article class="dashcam-route-row ${route.is_preserved ? "is-preserved" : ""}" @click="${() => { state.selectedRoute = route }}">
+                        <article class="${() => `dashcam-route-row ${route.is_preserved ? "is-preserved" : ""}`}" @click="${() => { state.selectedRoute = route }}">
                           <div class="dashcam-mini-preview">
                             <span class="dashcam-mini-fallback"><i class="bi bi-camera-video"></i></span>
                             <img src="${route.png}" class="dashcam-mini-img" loading="lazy" alt="" @error="${thumbnailFailed}">
@@ -600,7 +709,7 @@ export function RouteRecordings() {
                             <div class="dashcam-route-meta-pills">
                               <span class="meta-pill duration-pill" title="Estimated duration"><i class="bi bi-clock"></i> ${formatApproxDuration(route.approxDurationSeconds)}</span>
                               <span class="meta-pill segments-pill" title="Segments recorded"><i class="bi bi-collection-play"></i> ${route.segmentCount} segment${route.segmentCount === 1 ? "" : "s"}</span>
-                              ${route.is_preserved ? html`<span class="meta-pill preserved-pill" title="Preserved from deletion"><i class="bi bi-heart-fill"></i> Preserved</span>` : ""}
+                              ${() => route.is_preserved ? html`<span class="meta-pill preserved-pill" title="Preserved from deletion"><i class="bi bi-heart-fill"></i> Preserved</span>` : ""}
                               <span class="meta-pill id-pill" title="Route ID: ${route.name}"><i class="bi bi-hash"></i>${route.name.split("--").slice(1).join("--") || route.name}</span>
                             </div>
                           </div>
@@ -608,8 +717,8 @@ export function RouteRecordings() {
                             <button class="btn-route-action btn-play" type="button" title="Play recording" @click="${() => { state.selectedRoute = route }}">
                               <i class="bi bi-play-fill"></i> <span>Play</span>
                             </button>
-                            <button class="btn-route-action btn-preserve ${route.is_preserved ? "active" : ""}" type="button" aria-label="${route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${route.is_preserved ? "Preserved (click to unpreserve)" : "Click to preserve"}" @click="${event => togglePreserved(route, event)}">
-                              <i class="bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}"></i>
+                            <button class="${() => `btn-route-action btn-preserve ${route.is_preserved ? "active" : ""}`}" type="button" aria-label="${() => route.is_preserved ? "Remove preservation" : "Preserve route"}" title="${() => route.is_preserved ? "Preserved (click to unpreserve)" : "Click to preserve"}" @click="${event => togglePreserved(route, event)}">
+                              <i class="${() => `bi ${route.is_preserved ? "bi-heart-fill" : "bi-heart"}`}"></i>
                             </button>
                             <button class="btn-route-action btn-icon" type="button" title="View & download logs" @click="${event => openLogsFromRow(route, event)}">
                               <i class="bi bi-file-earmark-arrow-down"></i>

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -12,6 +12,7 @@ import {
   groupRoutesForView,
   MAX_RENDERED_ROUTES,
   normalizeRoute,
+  routeMetadataErrorMessage,
   routeViewRenderKey,
 } from "/assets/components/recordings/dashcam_routes_helpers.js"
 
@@ -738,8 +739,8 @@ async function openOverlay(route) {
 
   try {
     const response = await fetch(`/api/routes/${route.name}`)
-    if (!response.ok) throw new Error(`Route metadata request failed (${response.status})`)
-    const data = await response.json()
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(routeMetadataErrorMessage(response.status, data?.error))
     segments = Array.isArray(data.segment_urls) ? data.segment_urls.filter(url => typeof url === "string") : []
     const availableCameras = ["forward", "wide", "driver"].filter(camera => data.available_cameras?.includes(camera))
     if (!segments.length) throw new Error("No video segments are stored for this route")
@@ -884,12 +885,15 @@ export function RouteRecordings() {
           const view = buildRouteView(state.routes, { preservedOnly: state.showPreservedOnly, searchQuery: state.searchQuery, sortOrder: state.sortOrder })
           const groups = groupRoutesForView(view.visible, state.sortOrder)
           const renderKey = routeViewRenderKey(view.visible, state.sortOrder, state.viewMode)
+          const hasActiveSearch = Boolean(state.searchQuery.trim())
 
           return html`
-            <div class="dashcam-results-summary" aria-live="polite">
-              <span>${view.matching.length} matching drive${view.matching.length === 1 ? "" : "s"}</span>
-              ${state.loading ? html`<span>Loading ${state.progress} of ${state.total}</span>` : html`<span>${state.routes.length} total local</span>`}
-            </div>
+            ${state.loading || hasActiveSearch ? html`
+              <div class="dashcam-results-summary" aria-live="polite">
+                ${hasActiveSearch ? html`<span>${view.matching.length} matching drive${view.matching.length === 1 ? "" : "s"}</span>` : ""}
+                ${state.loading ? html`<span>Loading routes</span>` : ""}
+              </div>
+            ` : ""}
             ${state.error ? html`<p class="screen-recordings-message dashcam-error">${state.error}</p>` : ""}
             ${state.isDeletingAll ? html`<p class="screen-recordings-message">Deleting routes&hellip;</p>` : ""}
             ${!view.visible.length && state.loading ? html`<div class="dashcam-loading"><span></span><p>Finding local routes&hellip;</p></div>` : ""}

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes.js
@@ -301,6 +301,7 @@ async function openOverlay(route) {
       </header>
       <div class="dashcam-video-shell">
         <video controls muted playsinline preload="metadata"></video>
+        <canvas class="dashcam-transition-frame" aria-hidden="true" hidden></canvas>
         <div class="dashcam-player-state" role="status">Loading route metadata&hellip;</div>
       </div>
       <div class="dashcam-player-toolbar">
@@ -324,6 +325,7 @@ async function openOverlay(route) {
   document.body.appendChild(overlay)
 
   const video = overlay.querySelector("video")
+  const transitionFrame = overlay.querySelector(".dashcam-transition-frame")
   const playerState = overlay.querySelector(".dashcam-player-state")
   const segmentBar = overlay.querySelector(".dashcam-segment-bar")
   const segmentSelect = overlay.querySelector(".segment-select")
@@ -341,6 +343,7 @@ async function openOverlay(route) {
   let qualityToken = 0
   let upgradeController = null
   let upgradeTimer = null
+  let transitionActive = false
 
   const setPlayerMessage = (message, isError = false) => {
     playerState.textContent = message
@@ -359,9 +362,35 @@ async function openOverlay(route) {
       .join("")
     segmentBar.hidden = !segments.length
   }
-  const swapSource = (url, { message } = {}) => {
+
+  const finishTransition = () => {
+    transitionActive = false
+    transitionFrame.hidden = true
+  }
+  const holdCurrentFrame = () => {
+    if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA || !video.videoWidth || !video.videoHeight) return false
+    const context = transitionFrame.getContext("2d")
+    if (!context) return false
+    transitionFrame.width = video.videoWidth
+    transitionFrame.height = video.videoHeight
+    try {
+      context.drawImage(video, 0, 0, transitionFrame.width, transitionFrame.height)
+    } catch (_) {
+      return false
+    }
+    transitionActive = true
+    transitionFrame.hidden = false
+    setPlayerMessage("")
+    return true
+  }
+  const swapSource = (url, { message, seamless = false } = {}) => {
     const playbackTime = Number.isFinite(video.currentTime) ? video.currentTime : 0
     const shouldResume = !video.paused && !video.ended
+    const heldFrame = seamless && holdCurrentFrame()
+    // Never trade a working preview for a black frame. The prepared full stream can
+    // be attempted again later, while the low-resolution video keeps playing.
+    if (seamless && !heldFrame) return false
+    if (heldFrame) video.addEventListener("canplay", finishTransition, { once: true })
     video.addEventListener("loadedmetadata", () => {
       if (playbackTime > 0) {
         try {
@@ -370,9 +399,11 @@ async function openOverlay(route) {
       }
       if (shouldResume) video.play().catch(() => {})
     }, { once: true })
+    if (!heldFrame) finishTransition()
     if (message) setPlayerMessage(message)
     video.src = url
     video.load()
+    return true
   }
 
   const cancelUpgrade = () => {
@@ -393,14 +424,23 @@ async function openOverlay(route) {
     const fullUrl = cameraVideoUrl(segmentUrl, camera)
     const stillCurrent = () =>
       token === qualityToken && showingPreview && segments[current] === segmentUrl && selectedCamera === camera && !!overlay
+    const swapPreparedStream = (attempt = 0) => {
+      if (!stillCurrent()) return
+      if (swapSource(fullUrl, { seamless: true })) {
+        showingPreview = false
+        return
+      }
+      if (attempt < 5) {
+        upgradeTimer = setTimeout(() => swapPreparedStream(attempt + 1), 100)
+      }
+    }
 
     fetch(fullUrl, { method: "HEAD", signal: controller.signal })
       .then(response => {
         if (!stillCurrent()) return
         if (upgradeController === controller) upgradeController = null
         if (response.ok) {
-          showingPreview = false
-          swapSource(fullUrl)
+          swapPreparedStream()
           return
         }
         if (response.status === 503 && attempt < FULL_QUALITY_RETRIES) {
@@ -428,6 +468,7 @@ async function openOverlay(route) {
     const camera = selectedCamera
     if (!segmentUrl || !camera) return
     cancelUpgrade()
+    finishTransition()
     wantsPlayback = autoplay
     showingPreview = preview === undefined ? supportsLowQuality(camera) : preview
     setPlayerMessage(message || "Loading video…")
@@ -498,8 +539,11 @@ async function openOverlay(route) {
   })
   video.addEventListener("loadeddata", () => setPlayerMessage(""))
   video.addEventListener("playing", () => setPlayerMessage(""))
-  video.addEventListener("waiting", () => setPlayerMessage("Loading video…"))
+  video.addEventListener("waiting", () => {
+    if (!transitionActive) setPlayerMessage("Loading video…")
+  })
   video.addEventListener("error", () => {
+    finishTransition()
     // A dead preview drops through to the real stream rather than showing an error.
     if (showingPreview) {
       showingPreview = false

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -6,6 +6,16 @@ function validDate(value) {
   return Number.isNaN(date.getTime()) ? null : date
 }
 
+export function normalizeRouteSearchText(value) {
+  return String(value || "")
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase()
+    .replace(/(\d+)(?:st|nd|rd|th)\b/g, "$1")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+}
+
 export function formatRouteDate(value, locale) {
   const date = validDate(value)
   if (!date) return "Unknown date"
@@ -19,8 +29,17 @@ export function normalizeRoute(route, locale) {
   const timestamp = route?.timestamp == null ? null : String(route.timestamp)
   const startedAtDate = validDate(route?.startedAt)
   const timestampDate = validDate(timestamp)
-  const displayDate = formatRouteDate(startedAtDate || timestampDate, locale)
+  const routeDate = startedAtDate || timestampDate
+  const displayDate = formatRouteDate(routeDate, locale)
   const isCustomName = Boolean(route?.isCustomName) || Boolean(timestamp && !timestampDate)
+  const displayName = isCustomName ? timestamp : displayDate
+  const dateAliases = routeDate ? [
+    new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(routeDate),
+    new Intl.DateTimeFormat("en-US", { month: "long", day: "numeric", year: "numeric" }).format(routeDate),
+    new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(routeDate),
+    `${routeDate.getMonth() + 1}/${routeDate.getDate()}/${routeDate.getFullYear()}`,
+    `${routeDate.getFullYear()}-${routeDate.getMonth() + 1}-${routeDate.getDate()}`,
+  ] : []
 
   return {
     ...route,
@@ -29,8 +48,13 @@ export function normalizeRoute(route, locale) {
     startedAt: route?.startedAt || null,
     isCustomName,
     displayDate,
-    displayName: isCustomName ? timestamp : displayDate,
+    displayName,
     _startedAtMs: startedAtDate?.getTime() ?? timestampDate?.getTime() ?? null,
+    _searchValues: [
+      normalizeRouteSearchText(route?.name),
+      normalizeRouteSearchText(isCustomName ? displayName : ""),
+      ...dateAliases.map(normalizeRouteSearchText),
+    ].filter(Boolean),
   }
 }
 
@@ -96,11 +120,19 @@ export function sortRoutes(routes, sortOrder = "newest") {
 }
 
 export function routeMatchesSearch(route, searchQuery) {
-  const query = String(searchQuery || "").trim().toLocaleLowerCase()
-  if (!query) return true
-  return [route?.name, route?.timestamp, route?.displayName, route?.displayDate]
-    .filter(Boolean)
-    .some(value => String(value).toLocaleLowerCase().includes(query))
+  const queryTokens = normalizeRouteSearchText(searchQuery).split(" ").filter(Boolean)
+  if (!queryTokens.length) return true
+
+  const searchValues = Array.isArray(route?._searchValues) ? route._searchValues : [
+    route?.name,
+    route?.timestamp,
+    route?.displayName,
+    route?.displayDate,
+  ].map(normalizeRouteSearchText).filter(Boolean)
+  return searchValues.some(value => {
+    const searchTokens = value.split(" ").filter(Boolean)
+    return queryTokens.every(queryToken => searchTokens.some(searchToken => searchToken.includes(queryToken)))
+  })
 }
 
 export function buildRouteView(routes, options = {}) {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -1,4 +1,5 @@
 export const MAX_RENDERED_ROUTES = 250
+const SEARCH_MONTHS = ["january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december"]
 
 function validDate(value) {
   if (!value) return null
@@ -55,12 +56,12 @@ export function normalizeRoute(route, locale) {
     displayDate,
     displayName,
     _startedAtMs: startedAtDate?.getTime() ?? timestampDate?.getTime() ?? null,
-    _searchValues: [
-      normalizeRouteSearchText(route?.name),
-      normalizeRouteSearchText(isCustomName ? displayName : ""),
-      ...dateAliases.map(normalizeRouteSearchText),
-      ...timeAliases.map(normalizeRouteSearchText),
-    ].filter(Boolean),
+    _searchIndex: {
+      ids: [normalizeRouteSearchText(route?.name)].filter(Boolean),
+      titles: [normalizeRouteSearchText(isCustomName ? displayName : "")].filter(Boolean),
+      dates: dateAliases.map(normalizeRouteSearchText).filter(Boolean),
+      times: timeAliases.map(normalizeRouteSearchText).filter(Boolean),
+    },
   }
 }
 
@@ -126,16 +127,37 @@ export function sortRoutes(routes, sortOrder = "newest") {
 }
 
 export function routeMatchesSearch(route, searchQuery) {
+  const rawQuery = String(searchQuery || "").trim()
   const normalizedQuery = normalizeRouteSearchText(searchQuery)
   const queryTokens = normalizedQuery.split(" ").filter(Boolean)
   if (!queryTokens.length) return true
 
-  const searchValues = Array.isArray(route?._searchValues) ? route._searchValues : [
-    route?.name,
-    route?.timestamp,
-    route?.displayName,
-    route?.displayDate,
-  ].map(normalizeRouteSearchText).filter(Boolean)
+  const fallbackIndex = {
+    ids: [route?.name],
+    titles: [route?.timestamp, route?.displayName],
+    dates: [route?.displayDate],
+    times: [route?.displayDate],
+  }
+  const searchIndex = route?._searchIndex || Object.fromEntries(
+    Object.entries(fallbackIndex).map(([key, values]) => [key, values.map(normalizeRouteSearchText).filter(Boolean)]),
+  )
+
+  const hasMonth = queryTokens.some(token => token.length >= 3 && SEARCH_MONTHS.some(month => month.startsWith(token)))
+  const isDateQuery = hasMonth || /\d\s*[/-]\s*\d/.test(rawQuery) || /\d+(?:st|nd|rd|th)\b/i.test(rawQuery) || /^\d{4}$/.test(normalizedQuery)
+  const isTimeQuery = /^\d{1,2}$/.test(normalizedQuery) || /\d\s*:\s*\d/.test(rawQuery) || queryTokens.some(token => token === "am" || token === "pm")
+  const compactQuery = normalizedQuery.replaceAll(" ", "")
+  const isHexQuery = /^[0-9a-f]+$/.test(compactQuery)
+  const isIdQuery = rawQuery.includes("--") || (isHexQuery && (
+    compactQuery.length >= 8 || (compactQuery.length >= 4 && /\d/.test(compactQuery) && /[a-f]/.test(compactQuery))
+  ))
+  const valuesFor = key => Array.isArray(searchIndex[key]) ? searchIndex[key] : []
+  const searchValues = [
+    ...valuesFor("titles"),
+    ...(isDateQuery ? valuesFor("dates") : []),
+    ...(isTimeQuery ? valuesFor("times") : []),
+    ...(isIdQuery ? valuesFor("ids") : []),
+  ]
+
   return searchValues.some(value => {
     if (value.includes(normalizedQuery)) return true
     const searchTokens = value.split(" ").filter(Boolean)

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -40,6 +40,11 @@ export function normalizeRoute(route, locale) {
     `${routeDate.getMonth() + 1}/${routeDate.getDate()}/${routeDate.getFullYear()}`,
     `${routeDate.getFullYear()}-${routeDate.getMonth() + 1}-${routeDate.getDate()}`,
   ] : []
+  const timeAliases = routeDate ? [
+    new Intl.DateTimeFormat(locale, { hour: "numeric", minute: "2-digit" }).format(routeDate),
+    new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", hour12: true }).format(routeDate),
+    `${String(routeDate.getHours()).padStart(2, "0")}:${String(routeDate.getMinutes()).padStart(2, "0")}`,
+  ] : []
 
   return {
     ...route,
@@ -54,6 +59,7 @@ export function normalizeRoute(route, locale) {
       normalizeRouteSearchText(route?.name),
       normalizeRouteSearchText(isCustomName ? displayName : ""),
       ...dateAliases.map(normalizeRouteSearchText),
+      ...timeAliases.map(normalizeRouteSearchText),
     ].filter(Boolean),
   }
 }
@@ -120,7 +126,8 @@ export function sortRoutes(routes, sortOrder = "newest") {
 }
 
 export function routeMatchesSearch(route, searchQuery) {
-  const queryTokens = normalizeRouteSearchText(searchQuery).split(" ").filter(Boolean)
+  const normalizedQuery = normalizeRouteSearchText(searchQuery)
+  const queryTokens = normalizedQuery.split(" ").filter(Boolean)
   if (!queryTokens.length) return true
 
   const searchValues = Array.isArray(route?._searchValues) ? route._searchValues : [
@@ -130,8 +137,9 @@ export function routeMatchesSearch(route, searchQuery) {
     route?.displayDate,
   ].map(normalizeRouteSearchText).filter(Boolean)
   return searchValues.some(value => {
+    if (value.includes(normalizedQuery)) return true
     const searchTokens = value.split(" ").filter(Boolean)
-    return queryTokens.every(queryToken => searchTokens.some(searchToken => searchToken.includes(queryToken)))
+    return queryTokens.every(queryToken => searchTokens.some(searchToken => searchToken.startsWith(queryToken)))
   })
 }
 

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -34,7 +34,55 @@ export function normalizeRoute(route, locale) {
   }
 }
 
+export function formatTotalDuration(seconds) {
+  const totalMinutes = Math.max(0, Math.round(Number(seconds) / 60) || 0)
+  if (totalMinutes < 1) return "0 min"
+  if (totalMinutes < 60) return `${totalMinutes} min`
+  const hours = Math.floor(totalMinutes / 60)
+  const remaining = totalMinutes % 60
+  return remaining > 0 ? `${hours}h ${remaining}m` : `${hours}h`
+}
+
+export function computeRouteStats(routes = []) {
+  const list = Array.isArray(routes) ? routes : []
+  let totalDurationSeconds = 0
+  let preservedCount = 0
+  let totalSegments = 0
+
+  for (const route of list) {
+    if (route) {
+      if (Number.isFinite(route.approxDurationSeconds)) {
+        totalDurationSeconds += Math.max(0, route.approxDurationSeconds)
+      }
+      if (route.is_preserved) {
+        preservedCount += 1
+      }
+      if (Number.isFinite(route.segmentCount)) {
+        totalSegments += Math.max(0, route.segmentCount)
+      }
+    }
+  }
+
+  return {
+    count: list.length,
+    totalDurationSeconds,
+    formattedDuration: formatTotalDuration(totalDurationSeconds),
+    preservedCount,
+    totalSegments,
+  }
+}
+
 export function sortRoutes(routes, sortOrder = "newest") {
+  if (sortOrder === "longest" || sortOrder === "shortest") {
+    const direction = sortOrder === "longest" ? -1 : 1
+    return [...routes].sort((left, right) => {
+      const leftDur = Number.isFinite(left?.approxDurationSeconds) ? left.approxDurationSeconds : -1
+      const rightDur = Number.isFinite(right?.approxDurationSeconds) ? right.approxDurationSeconds : -1
+      if (leftDur !== rightDur) return (leftDur - rightDur) * direction
+      return String(left?.name || "").localeCompare(String(right?.name || ""))
+    })
+  }
+
   const direction = sortOrder === "oldest" ? 1 : -1
   return [...routes].sort((left, right) => {
     const leftTime = left?._startedAtMs

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -177,6 +177,11 @@ export function buildRouteView(routes, options = {}) {
   }
 }
 
+export function routeViewRenderKey(routes, sortOrder = "newest", viewMode = "list") {
+  const routeNames = Array.isArray(routes) ? routes.map(route => String(route?.name || "")).join(",") : ""
+  return `${viewMode}:${sortOrder}:${routeNames}`
+}
+
 function localDayKey(date) {
   return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -1,0 +1,129 @@
+export const MAX_RENDERED_ROUTES = 250
+
+function validDate(value) {
+  if (!value) return null
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function formatRouteDate(value, locale) {
+  const date = validDate(value)
+  if (!date) return "Unknown date"
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(date)
+}
+
+export function normalizeRoute(route, locale) {
+  const timestamp = route?.timestamp == null ? null : String(route.timestamp)
+  const startedAtDate = validDate(route?.startedAt)
+  const timestampDate = validDate(timestamp)
+  const displayDate = formatRouteDate(startedAtDate || timestampDate, locale)
+  const isCustomName = Boolean(route?.isCustomName) || Boolean(timestamp && !timestampDate)
+
+  return {
+    ...route,
+    name: String(route?.name || ""),
+    timestamp,
+    startedAt: route?.startedAt || null,
+    isCustomName,
+    displayDate,
+    displayName: isCustomName ? timestamp : displayDate,
+    _startedAtMs: startedAtDate?.getTime() ?? timestampDate?.getTime() ?? null,
+  }
+}
+
+export function sortRoutes(routes, sortOrder = "newest") {
+  const direction = sortOrder === "oldest" ? 1 : -1
+  return [...routes].sort((left, right) => {
+    const leftTime = left?._startedAtMs
+    const rightTime = right?._startedAtMs
+    if (leftTime == null && rightTime == null) return String(left?.name || "").localeCompare(String(right?.name || ""))
+    if (leftTime == null) return 1
+    if (rightTime == null) return -1
+    if (leftTime !== rightTime) return (leftTime - rightTime) * direction
+    return String(left?.name || "").localeCompare(String(right?.name || "")) * -direction
+  })
+}
+
+export function routeMatchesSearch(route, searchQuery) {
+  const query = String(searchQuery || "").trim().toLocaleLowerCase()
+  if (!query) return true
+  return [route?.name, route?.timestamp, route?.displayName, route?.displayDate]
+    .filter(Boolean)
+    .some(value => String(value).toLocaleLowerCase().includes(query))
+}
+
+export function buildRouteView(routes, options = {}) {
+  const matching = sortRoutes(
+    routes.filter(route => (!options.preservedOnly || route.is_preserved) && routeMatchesSearch(route, options.searchQuery)),
+    options.sortOrder,
+  )
+  return {
+    matching,
+    visible: matching.slice(0, MAX_RENDERED_ROUTES),
+    truncated: matching.length > MAX_RENDERED_ROUTES,
+  }
+}
+
+function localDayKey(date) {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
+}
+
+export function groupRoutesByDate(routes, now = new Date(), locale) {
+  const today = validDate(now) || new Date()
+  today.setHours(0, 0, 0, 0)
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const groups = []
+  const byKey = new Map()
+
+  for (const route of routes) {
+    const routeDate = route?._startedAtMs == null ? null : new Date(route._startedAtMs)
+    const key = routeDate ? localDayKey(routeDate) : "unknown"
+    let group = byKey.get(key)
+    if (!group) {
+      let label = "Unknown date"
+      if (routeDate) {
+        if (key === localDayKey(today)) label = "Today"
+        else if (key === localDayKey(yesterday)) label = "Yesterday"
+        else label = new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(routeDate)
+      }
+      group = { key, label, routes: [] }
+      byKey.set(key, group)
+      groups.push(group)
+    }
+    group.routes.push(route)
+  }
+  return groups
+}
+
+export function formatApproxDuration(seconds) {
+  const minutes = Math.max(0, Math.round(Number(seconds) / 60) || 0)
+  if (minutes < 1) return "Less than 1 min"
+  if (minutes < 60) return `About ${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  const remaining = minutes % 60
+  return `About ${hours} hr${remaining ? ` ${remaining} min` : ""}`
+}
+
+export function parseStoredSegmentNumber(segmentUrl) {
+  const cleanPath = String(segmentUrl || "").split(/[?#]/, 1)[0]
+  const match = cleanPath.match(/--(\d+)\/?$/)
+  if (!match) return null
+  const value = Number(match[1])
+  return Number.isSafeInteger(value) ? value : null
+}
+
+export function getSegmentStatus(segmentUrls, playbackIndex) {
+  if (!Array.isArray(segmentUrls) || !Number.isInteger(playbackIndex) || playbackIndex < 0 || playbackIndex >= segmentUrls.length) return ""
+  const segmentNumber = parseStoredSegmentNumber(segmentUrls[playbackIndex])
+  if (segmentNumber == null) return ""
+  return `Segment ${segmentNumber} · ${playbackIndex + 1} of ${segmentUrls.length}`
+}
+
+export function cameraVideoUrl(segmentUrl, camera) {
+  const separator = String(segmentUrl).includes("?") ? "&" : "?"
+  return `${segmentUrl}${separator}camera=${encodeURIComponent(camera)}`
+}

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -151,18 +151,20 @@ export function routeMatchesSearch(route, searchQuery) {
     compactQuery.length >= 8 || (compactQuery.length >= 4 && /\d/.test(compactQuery) && /[a-f]/.test(compactQuery))
   ))
   const valuesFor = key => Array.isArray(searchIndex[key]) ? searchIndex[key] : []
-  const searchValues = [
-    ...valuesFor("titles"),
-    ...(isDateQuery ? valuesFor("dates") : []),
-    ...(isTimeQuery ? valuesFor("times") : []),
-    ...(isIdQuery ? valuesFor("ids") : []),
-  ]
-
-  return searchValues.some(value => {
+  const matchesValue = (value, dateValue = false) => {
     if (value.includes(normalizedQuery)) return true
     const searchTokens = value.split(" ").filter(Boolean)
-    return queryTokens.every(queryToken => searchTokens.some(searchToken => searchToken.startsWith(queryToken)))
-  })
+    return queryTokens.every(queryToken => searchTokens.some(searchToken => {
+      // In a date query, "20" is a day prefix, not a match for the year "2026".
+      if (dateValue && /^\d{1,2}$/.test(queryToken) && /^\d{4}$/.test(searchToken)) return false
+      return searchToken.startsWith(queryToken)
+    }))
+  }
+
+  return valuesFor("titles").some(value => matchesValue(value))
+    || (isDateQuery && valuesFor("dates").some(value => matchesValue(value, true)))
+    || (isTimeQuery && valuesFor("times").some(value => matchesValue(value)))
+    || (isIdQuery && valuesFor("ids").some(value => matchesValue(value)))
 }
 
 export function buildRouteView(routes, options = {}) {

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -195,7 +195,13 @@ export function cameraVideoUrl(segmentUrl, camera, quality) {
   return quality ? `${url}&quality=${encodeURIComponent(quality)}` : url
 }
 
-// qcamera.ts only exists for the road camera, so the instant-start tier is forward-only.
+// loggerd only writes qcamera.ts alongside the road camera.
 export function supportsLowQuality(camera) {
   return camera === "forward"
+}
+
+// qcamera is 526x330. Only a positively taller frame proves the real stream is already
+// playing; an unknown height upgrades rather than stranding the viewer on the preview.
+export function shouldUpgradeFromHeight(height) {
+  return !(Number.isFinite(height) && height > 400)
 }

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -264,6 +264,14 @@ export function cameraVideoUrl(segmentUrl, camera, quality) {
   return quality ? `${url}&quality=${encodeURIComponent(quality)}` : url
 }
 
+export function routeMetadataErrorMessage(status, serverError) {
+  if (status === 404) {
+    return "This route is no longer available on this device. Its local video segments may have been deleted or moved."
+  }
+  const detail = String(serverError || "").trim()
+  return detail || `Could not load route details (${status}).`
+}
+
 // loggerd only writes qcamera.ts alongside the road camera.
 export function supportsLowQuality(camera) {
   return camera === "forward"

--- a/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
+++ b/starpilot/system/the_galaxy/assets/components/recordings/dashcam_routes_helpers.js
@@ -147,6 +147,16 @@ export function groupRoutesByDate(routes, now = new Date(), locale) {
   return groups
 }
 
+export function groupRoutesForView(routes, sortOrder = "newest", now, locale) {
+  // Date headers would scramble a duration sort, so show one flat group instead.
+  if (sortOrder === "longest" || sortOrder === "shortest") {
+    const list = Array.isArray(routes) ? [...routes] : []
+    if (!list.length) return []
+    return [{ key: sortOrder, label: sortOrder === "longest" ? "Longest first" : "Shortest first", routes: list }]
+  }
+  return groupRoutesByDate(routes, now, locale)
+}
+
 export function formatApproxDuration(seconds) {
   const minutes = Math.max(0, Math.round(Number(seconds) / 60) || 0)
   if (minutes < 1) return "Less than 1 min"
@@ -168,10 +178,24 @@ export function getSegmentStatus(segmentUrls, playbackIndex) {
   if (!Array.isArray(segmentUrls) || !Number.isInteger(playbackIndex) || playbackIndex < 0 || playbackIndex >= segmentUrls.length) return ""
   const segmentNumber = parseStoredSegmentNumber(segmentUrls[playbackIndex])
   if (segmentNumber == null) return ""
-  return `Segment ${segmentNumber} · ${playbackIndex + 1} of ${segmentUrls.length}`
+  return `Segment ${segmentNumber}`
 }
 
-export function cameraVideoUrl(segmentUrl, camera) {
+export function getSegmentOptions(segmentUrls) {
+  if (!Array.isArray(segmentUrls)) return []
+  return segmentUrls.map((_, index) => ({
+    index,
+    label: getSegmentStatus(segmentUrls, index) || `Clip ${index + 1}`,
+  }))
+}
+
+export function cameraVideoUrl(segmentUrl, camera, quality) {
   const separator = String(segmentUrl).includes("?") ? "&" : "?"
-  return `${segmentUrl}${separator}camera=${encodeURIComponent(camera)}`
+  const url = `${segmentUrl}${separator}camera=${encodeURIComponent(camera)}`
+  return quality ? `${url}&quality=${encodeURIComponent(quality)}` : url
+}
+
+// qcamera.ts only exists for the road camera, so the instant-start tier is forward-only.
+export function supportsLowQuality(camera) {
+  return camera === "forward"
 }

--- a/starpilot/system/the_galaxy/assets/js/utils.js
+++ b/starpilot/system/the_galaxy/assets/js/utils.js
@@ -38,6 +38,20 @@ export function parseErrorLogToDate(filename) {
 }
 
 /**
+ * Escape a value for interpolation into an HTML string
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+/**
  * Capitalize the first character of a string
  * @param {string} str
  * @returns {string}

--- a/starpilot/system/the_galaxy/tests/test_dashboard_stats.py
+++ b/starpilot/system/the_galaxy/tests/test_dashboard_stats.py
@@ -59,6 +59,8 @@ sys.modules.setdefault("openpilot.starpilot.assets.theme_manager", theme_manager
 
 import utilities
 
+_REAL_COMMON_PARAMS_MODULE = sys.modules.get("openpilot.common.params")
+
 for _module_name, _module in _INITIAL_MODULES.items():
   if _module is None:
     sys.modules.pop(_module_name, None)
@@ -86,6 +88,8 @@ def _simple_module(name, **attrs):
 
 
 def _install_server_import_stubs():
+  if _REAL_COMMON_PARAMS_MODULE is not None:
+    sys.modules["openpilot.common.params"] = _REAL_COMMON_PARAMS_MODULE
   sys.modules["openpilot.system.loggerd.config"] = loggerd_config
   sys.modules["openpilot.system.loggerd.deleter"] = loggerd_deleter
   sys.modules["openpilot.system.loggerd.uploader"] = loggerd_uploader
@@ -130,6 +134,14 @@ def _install_server_import_stubs():
   )
 
   sys.modules["openpilot.common.realtime"] = _simple_module("openpilot.common.realtime", DT_HW=0.01)
+  sys.modules["openpilot.common.swaglog"] = _simple_module(
+    "openpilot.common.swaglog",
+    cloudlog=SimpleNamespace(
+      error=lambda *args, **kwargs: None,
+      exception=lambda *args, **kwargs: None,
+      info=lambda *args, **kwargs: None,
+    ),
+  )
   sys.modules["openpilot.common.time_helpers"] = _simple_module("openpilot.common.time_helpers", system_time_valid=lambda: True)
   sys.modules["openpilot.system.hardware"] = _simple_module(
     "openpilot.system.hardware",
@@ -149,6 +161,15 @@ def _install_server_import_stubs():
     get_longitudinal_maneuver_support=lambda *args, **kwargs: {},
   )
   sys.modules["panda"] = _simple_module("panda", Panda=lambda *args, **kwargs: SimpleNamespace(can_send=lambda *send_args, **send_kwargs: None))
+  msgq_module = _simple_module("msgq")
+  msgq_visionipc = _simple_module(
+    "msgq.visionipc",
+    VisionIpcClient=lambda *args, **kwargs: SimpleNamespace(connect=lambda *connect_args: False),
+    VisionStreamType=SimpleNamespace(VISION_STREAM_DRIVER=0),
+  )
+  msgq_module.visionipc = msgq_visionipc
+  sys.modules["msgq"] = msgq_module
+  sys.modules["msgq.visionipc"] = msgq_visionipc
 
   model_manager.is_builtin_model_key = lambda value: False
   model_manager.model_key_aliases = lambda value: [value]
@@ -337,17 +358,16 @@ class FakeDashboardAnalyzerProcess:
 
 
 def test_route_inventory_counts_segments_without_video_probing(monkeypatch):
-  segments = [
-    SimpleNamespace(route_name=SimpleNamespace(time_str="route-new")),
-    SimpleNamespace(route_name=SimpleNamespace(time_str="route-new")),
-    SimpleNamespace(route_name=SimpleNamespace(time_str="route-new")),
-    SimpleNamespace(route_name=SimpleNamespace(time_str="route-old")),
-  ]
+  def segment(time_str, segment_num):
+    return SimpleNamespace(route_name=SimpleNamespace(time_str=time_str), segment_num=segment_num)
+
+  # route-new has aged out of its first two segments, so it no longer starts at --0.
+  segments = [segment("route-new", 4), segment("route-new", 2), segment("route-new", 3), segment("route-old", 0)]
   monkeypatch.setattr(utilities, "get_all_segment_names", lambda _path: segments)
 
-  assert utilities.get_routes_with_segment_counts("/tmp/routes") == [
-    ("route-old", 1),
-    ("route-new", 3),
+  assert utilities.get_routes_with_segment_details("/tmp/routes") == [
+    ("route-old", {"segmentCount": 1, "firstSegmentNum": 0}),
+    ("route-new", {"segmentCount": 3, "firstSegmentNum": 2}),
   ]
 
 

--- a/starpilot/system/the_galaxy/tests/test_dashboard_stats.py
+++ b/starpilot/system/the_galaxy/tests/test_dashboard_stats.py
@@ -1091,6 +1091,28 @@ def test_clear_dashboard_route_history_keeps_durable_records(tmp_path, monkeypat
   assert stats["modelUsage"]["orion"]["drives"] == 3
 
 
+def test_clear_dashboard_route_history_can_retain_preserved_routes(tmp_path, monkeypatch):
+  monkeypatch.setattr(utilities, "DASHBOARD_PARAMS_DIR", tmp_path)
+  params = FakeParams({
+    utilities.DASHBOARD_PERSISTENT_STATS_PARAM: {
+      "routes": {
+        "0000006a--9f0a7bdf9c": {"date": "2026-06-15T08:00:00"},
+        "0000006b--9f0a7bdf9d": {"date": "2026-06-16T08:00:00"},
+      },
+      "ignoredRoutes": ["0000006a--9f0a7bdf9c", "0000006b--9f0a7bdf9d"],
+      "personalRecords": {"cleanDriveStreak": {"drives": 4}},
+    },
+  })
+
+  removed = utilities.clear_dashboard_route_history(params, retained_route_names={"0000006a--9f0a7bdf9c"})
+
+  assert removed == 1
+  stats = utilities._load_dashboard_persistent_stats(params)
+  assert list(stats["routes"]) == ["0000006a--9f0a7bdf9c"]
+  assert stats["ignoredRoutes"] == ["0000006a--9f0a7bdf9c"]
+  assert stats["personalRecords"]["cleanDriveStreak"]["drives"] == 4
+
+
 def test_lightweight_routes_surface_recent_drives_without_log_analysis(monkeypatch):
   utilities._invalidate_dashboard_cache()
   now = utilities.datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 import io
+import os
 from pathlib import Path
 import threading
 import time
@@ -391,19 +392,64 @@ def test_preserve_limit_counts_routes_not_segments(monkeypatch, tmp_path):
   assert client.post("/api/routes/00000099--9f0a7bdf9c/preserve").status_code == 400
 
 
+def test_video_cache_evicts_oldest_instead_of_wiping_everything(monkeypatch, tmp_path):
+  """A tight disk used to delete every cached mp4, so playback re-muxed on every request."""
+  cache = tmp_path / "video_cache"
+  cache.mkdir()
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_PATH", cache)
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_MAX_BYTES", 300)
+
+  for index in range(4):
+    entry = cache / f"{index}.mp4"
+    entry.write_bytes(b"x" * 100)
+    os.utime(entry, (1000 + index, 1000 + index))
+
+  utilities._prune_video_cache()
+
+  survivors = sorted(path.name for path in cache.glob("*.mp4"))
+  # Budget is 300 bytes of 400 used, so only the oldest goes.
+  assert survivors == ["1.mp4", "2.mp4", "3.mp4"]
+
+
+def test_video_cache_never_evicts_the_entry_being_written(monkeypatch, tmp_path):
+  cache = tmp_path / "video_cache"
+  cache.mkdir()
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_PATH", cache)
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_MAX_BYTES", 50)
+
+  for index in range(3):
+    entry = cache / f"{index}.mp4"
+    entry.write_bytes(b"x" * 100)
+    os.utime(entry, (1000 + index, 1000 + index))
+
+  keep = cache / "0.mp4"
+  utilities._prune_video_cache(keep_path=keep)
+
+  assert keep.exists()
+
+
+def _stub_remux(monkeypatch, tmp_path, payload=b"wrapped-video"):
+  """Stand in for the ffmpeg remux, returning a real file so send_file can stream it."""
+  wrapped = tmp_path / "wrapped.mp4"
+  wrapped.write_bytes(payload)
+  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_to_path", lambda path: wrapped)
+  return wrapped
+
+
 def test_sparse_route_metadata_and_video_downloads(monkeypatch, tmp_path):
   segments = [_make_segment(tmp_path, segment_num=number) for number in (0, 3, 11)]
   for segment in segments:
     (segment / "fcamera.hevc").write_bytes(b"hevc")
-  monkeypatch.setattr(utilities, "get_video_duration", lambda path: 60)
   monkeypatch.setattr(utilities, "get_route_start_time", lambda path: datetime(2026, 8, 26, tzinfo=timezone.utc))
-  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_process_builder", lambda path: io.BytesIO(b"wrapped-video"))
+  _stub_remux(monkeypatch, tmp_path)
   monkeypatch.setattr(utilities, "ffmpeg_concat_segments_to_mp4", lambda paths, cache_key=None: io.BytesIO(b"combined-video"))
   client = _make_client(monkeypatch, tmp_path)
 
   metadata = client.get(f"/api/routes/{ROUTE_NAME}")
   assert metadata.status_code == 200
   assert metadata.get_json()["segment_urls"] == [f"/video/{ROUTE_NAME}--{number}" for number in (0, 3, 11)]
+  # One minute per segment, without probing each one with ffprobe.
+  assert metadata.get_json()["total_duration"] == 180
 
   segment_video = client.get(f"/video/{ROUTE_NAME}--3?camera=forward")
   assert segment_video.status_code == 200
@@ -414,3 +460,99 @@ def test_sparse_route_metadata_and_video_downloads(monkeypatch, tmp_path):
   assert combined_video.status_code == 200
   assert combined_video.mimetype == "video/mp4"
   assert combined_video.data == b"combined-video"
+
+
+def test_route_metadata_never_probes_segments_with_ffprobe(monkeypatch, tmp_path):
+  """Probing each segment put one subprocess per segment in front of playback."""
+  for number in (0, 1, 2):
+    segment = _make_segment(tmp_path, segment_num=number)
+    (segment / "fcamera.hevc").write_bytes(b"hevc")
+
+  def explode(path):
+    raise AssertionError(f"ffprobe must stay off the route metadata path: {path}")
+
+  monkeypatch.setattr(utilities, "get_video_duration", explode)
+  monkeypatch.setattr(utilities, "get_route_start_time", lambda path: datetime(2026, 8, 26, tzinfo=timezone.utc))
+  client = _make_client(monkeypatch, tmp_path)
+
+  metadata = client.get(f"/api/routes/{ROUTE_NAME}")
+  assert metadata.status_code == 200
+  assert metadata.get_json()["total_duration"] == 180
+
+
+def test_low_quality_serves_qcamera_without_touching_ffmpeg(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  (segment / "qcamera.ts").write_bytes(b"qcamera-bytes")
+
+  def explode(path):
+    raise AssertionError(f"the low quality tier must not remux: {path}")
+
+  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_to_path", explode)
+  client = _make_client(monkeypatch, tmp_path)
+
+  low = client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low")
+  assert low.status_code == 200
+  assert low.data == b"qcamera-bytes"
+
+
+def test_low_quality_falls_back_when_qcamera_is_missing(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  _stub_remux(monkeypatch, tmp_path)
+  client = _make_client(monkeypatch, tmp_path)
+
+  # No qcamera.ts on disk, and the driver camera never has one.
+  assert client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low").status_code == 404
+  assert client.get(f"/video/{ROUTE_NAME}--0?camera=driver&quality=low").status_code == 404
+
+  full = client.get(f"/video/{ROUTE_NAME}--0?camera=forward")
+  assert full.status_code == 200
+  assert full.data == b"wrapped-video"
+
+
+def test_segment_video_supports_range_requests(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  _stub_remux(monkeypatch, tmp_path, payload=b"0123456789")
+  client = _make_client(monkeypatch, tmp_path)
+
+  partial = client.get(f"/video/{ROUTE_NAME}--0?camera=forward", headers={"Range": "bytes=2-5"})
+  assert partial.status_code == 206
+  assert partial.data == b"2345"
+  assert partial.headers["Content-Range"] == "bytes 2-5/10"
+
+  # A malformed range used to raise inside the hand-rolled parser.
+  assert client.get(f"/video/{ROUTE_NAME}--0?camera=forward", headers={"Range": "bytes=abc"}).status_code in (200, 416)
+
+
+def test_concurrent_requests_for_one_segment_share_a_single_remux(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  wrapped = tmp_path / "wrapped.mp4"
+  wrapped.write_bytes(b"wrapped-video")
+
+  calls = []
+  started = threading.Event()
+
+  def slow_remux(path):
+    calls.append(path)
+    started.set()
+    time.sleep(0.3)
+    return wrapped
+
+  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_to_path", slow_remux)
+  client = _make_client(monkeypatch, tmp_path)
+
+  results = []
+  def fetch():
+    results.append(client.get(f"/video/{ROUTE_NAME}--0?camera=forward").status_code)
+
+  threads = [threading.Thread(target=fetch) for _ in range(4)]
+  for thread in threads:
+    thread.start()
+  for thread in threads:
+    thread.join()
+
+  assert results == [200, 200, 200, 200]
+  assert len(calls) == 1

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
@@ -1,0 +1,416 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+import io
+from pathlib import Path
+import threading
+import time
+
+import pytest
+
+from test_dashboard_stats import FakeParams, MODULE_DIR, _install_server_import_stubs
+
+
+def _load_server_module():
+  import importlib.util
+  import sys
+
+  _install_server_import_stubs()
+  spec = importlib.util.spec_from_file_location("dashcam_routes_server", MODULE_DIR / "the_galaxy.py")
+  module = importlib.util.module_from_spec(spec)
+  sys.modules["dashcam_routes_server"] = module
+  spec.loader.exec_module(module)
+  return module
+
+
+the_galaxy = _load_server_module()
+utilities = the_galaxy.utilities
+ROUTE_NAME = "0000006a--9f0a7bdf9c"
+
+
+def _make_segment(root, route_name=ROUTE_NAME, segment_num=0):
+  segment = root / f"{route_name}--{segment_num}"
+  segment.mkdir(parents=True)
+  return segment
+
+
+def _make_client(monkeypatch, root):
+  assert the_galaxy._import_galaxy_web_symbols()
+  monkeypatch.setattr(the_galaxy, "FOOTAGE_PATHS", [str(root) + "/"])
+  monkeypatch.setattr(the_galaxy, "params", FakeParams())
+  app = the_galaxy.Flask(
+    f"dashcam_routes_{time.monotonic_ns()}",
+    template_folder=str(MODULE_DIR / "templates"),
+    static_folder=str(MODULE_DIR / "assets"),
+  )
+  the_galaxy.setup(app)
+  return app.test_client()
+
+
+def test_process_route_is_metadata_only_and_retains_fields(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=3)
+  (segment / "qlog.zst").write_bytes(b"log")
+  (segment / "Morning school run").touch()
+  started_at = datetime(2026, 8, 26, 15, 30, tzinfo=timezone.utc)
+  monkeypatch.setattr(utilities, "get_route_start_time", lambda path: started_at)
+  monkeypatch.setattr(utilities, "has_preserve_attr", lambda path: True)
+  monkeypatch.setattr(utilities, "video_to_png", lambda *args: (_ for _ in ()).throw(AssertionError("preview generation must stay lazy")))
+
+  result = utilities.process_route(str(tmp_path), ROUTE_NAME, segment_count=4, first_segment_num=3)
+
+  assert result == {
+    "name": ROUTE_NAME,
+    "png": f"/thumbnails/{ROUTE_NAME}--3/preview.png",
+    "timestamp": "Morning school run",
+    "startedAt": "2026-08-26T15:30:00Z",
+    "isCustomName": True,
+    "is_preserved": True,
+    "segmentCount": 4,
+    "approxDurationSeconds": 240,
+  }
+
+
+def test_process_route_uses_display_timestamp_without_losing_started_at(monkeypatch, tmp_path):
+  _make_segment(tmp_path)
+  started_at = datetime(2026, 8, 26, 15, 30, tzinfo=timezone.utc)
+  monkeypatch.setattr(utilities, "get_route_start_time", lambda path: started_at)
+
+  result = utilities.process_route(str(tmp_path), ROUTE_NAME, segment_count=1)
+
+  assert result["timestamp"] == started_at.isoformat()
+  assert result["startedAt"] == "2026-08-26T15:30:00Z"
+  assert result["isCustomName"] is False
+
+
+def test_route_scan_deduplicates_using_footage_root_priority(monkeypatch):
+  first = "/priority/"
+  second = "/fallback/"
+  details = {
+    first: [(ROUTE_NAME, {"segmentCount": 2, "firstSegmentNum": 1})],
+    second: [
+      (ROUTE_NAME, {"segmentCount": 8, "firstSegmentNum": 0}),
+      ("0000006b--9f0a7bdf9d", {"segmentCount": 1, "firstSegmentNum": 4}),
+    ],
+  }
+  monkeypatch.setattr(utilities, "get_routes_with_segment_details", lambda path: details[path])
+
+  entries = the_galaxy._route_scan_entries([first, second])
+
+  assert entries == [
+    (first, ROUTE_NAME, 2, 1),
+    (second, "0000006b--9f0a7bdf9d", 1, 4),
+  ]
+
+
+def test_route_metadata_stream_batches_eight_with_progress_and_retained_fields():
+  entries = [
+    ("/routes/", f"{index:08x}--{index:010x}", index + 1, index % 3)
+    for index in range(18)
+  ]
+
+  def process(path, name, segment_count, first_segment_num):
+    return {
+      "name": name,
+      "png": f"/thumbnails/{name}--{first_segment_num}/preview.png",
+      "timestamp": f"Route {segment_count}",
+      "startedAt": "2026-08-26T15:30:00Z",
+      "isCustomName": True,
+      "is_preserved": False,
+      "segmentCount": segment_count,
+      "approxDurationSeconds": segment_count * 60,
+    }
+
+  events = list(the_galaxy._route_metadata_events(entries, "dongle", process))
+
+  assert events[0] == {"routes": [], "progress": 0, "total": 18, "connectDongleId": "dongle"}
+  assert [len(event["routes"]) for event in events[1:]] == [8, 8, 2]
+  assert [event["progress"] for event in events[1:]] == [8, 16, 18]
+  assert all(event["total"] == 18 for event in events)
+  results = [route for event in events[1:] for route in event["routes"]]
+  assert len(results) == 18
+  assert all({
+    "name", "png", "timestamp", "startedAt", "isCustomName",
+    "is_preserved", "segmentCount", "approxDurationSeconds",
+  } <= result.keys() for result in results)
+
+
+def test_route_metadata_stream_cancels_queued_work_when_closed():
+  entries = [("/routes/", f"{index:08x}--{index:010x}", 1, 0) for index in range(40)]
+  release = threading.Event()
+  started = []
+  lock = threading.Lock()
+
+  def process(path, name, segment_count, first_segment_num):
+    index = int(name.split("--", 1)[0], 16)
+    with lock:
+      started.append(index)
+    if index >= 8:
+      release.wait(timeout=2)
+    return {"name": name}
+
+  stream = the_galaxy._route_metadata_events(entries, process_route=process)
+  next(stream)
+  batch = next(stream)
+  assert len(batch["routes"]) == 8
+  stream.close()
+  release.set()
+  time.sleep(0.1)
+
+  # At most four already-running workers continue; the remaining queue is cancelled.
+  assert len(started) <= 12
+
+
+def test_thumbnail_path_validation_is_strict(tmp_path):
+  _make_segment(tmp_path)
+  valid = f"{ROUTE_NAME}--0/preview.png"
+
+  assert the_galaxy._resolve_route_thumbnail(valid, [tmp_path]) == tmp_path / f"{ROUTE_NAME}--0" / "preview.png"
+  for invalid in (
+    "../preview.png",
+    f"{ROUTE_NAME}--0/qcamera.ts",
+    f"{ROUTE_NAME}--0/subdir/preview.png",
+    f"{ROUTE_NAME}--nope/preview.png",
+    f"/{ROUTE_NAME}--0/preview.png",
+    f"{ROUTE_NAME}--0\\preview.png",
+  ):
+    assert the_galaxy._resolve_route_thumbnail(invalid, [tmp_path]) is None
+
+
+def test_thumbnail_path_validation_rejects_symlinks_outside_the_footage_root(tmp_path):
+  footage_root = tmp_path / "footage"
+  outside_segment = tmp_path / "outside"
+  footage_root.mkdir()
+  outside_segment.mkdir()
+  (footage_root / f"{ROUTE_NAME}--0").symlink_to(outside_segment, target_is_directory=True)
+
+  assert the_galaxy._resolve_route_thumbnail(f"{ROUTE_NAME}--0/preview.png", [footage_root]) is None
+
+
+def test_thumbnail_generation_is_lazy_and_reuses_completed_preview(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  (segment / "qcamera.ts").write_bytes(b"video")
+  calls = []
+
+  def generate(source, output):
+    calls.append((Path(source), Path(output)))
+    Path(output).write_bytes(b"png")
+    return True
+
+  monkeypatch.setattr(utilities, "video_to_png", generate)
+  relative_path = f"{ROUTE_NAME}--0/preview.png"
+
+  first = the_galaxy._get_or_create_route_thumbnail(relative_path, [tmp_path])
+  second = the_galaxy._get_or_create_route_thumbnail(relative_path, [tmp_path])
+
+  assert first == second == segment / "preview.png"
+  assert len(calls) == 1
+  assert calls[0][0] == segment / "qcamera.ts"
+
+
+def test_thumbnail_failure_returns_none_and_does_not_cache_partial_file(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  (segment / "qcamera.ts").write_bytes(b"video")
+  monkeypatch.setattr(utilities, "video_to_png", lambda source, output: False)
+
+  result = the_galaxy._get_or_create_route_thumbnail(f"{ROUTE_NAME}--0/preview.png", [tmp_path])
+
+  assert result is None
+  assert not (segment / "preview.png").exists()
+
+
+def test_duplicate_thumbnail_requests_share_one_generation_job(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  (segment / "qcamera.ts").write_bytes(b"video")
+  release = threading.Event()
+  started = threading.Event()
+  calls = []
+
+  def generate(preview_path):
+    calls.append(preview_path)
+    started.set()
+    release.wait(timeout=2)
+    preview_path.write_bytes(b"png")
+    return preview_path
+
+  monkeypatch.setattr(the_galaxy, "_generate_route_thumbnail", generate)
+  relative_path = f"{ROUTE_NAME}--0/preview.png"
+  with ThreadPoolExecutor(max_workers=2) as callers:
+    first = callers.submit(the_galaxy._get_or_create_route_thumbnail, relative_path, [tmp_path])
+    assert started.wait(timeout=1)
+    second = callers.submit(the_galaxy._get_or_create_route_thumbnail, relative_path, [tmp_path])
+    time.sleep(0.05)
+    release.set()
+    assert first.result(timeout=1) == segment / "preview.png"
+    assert second.result(timeout=1) == segment / "preview.png"
+
+  assert len(calls) == 1
+  assert the_galaxy._ROUTE_THUMBNAIL_EXECUTOR._max_workers == 2
+
+
+def test_timed_out_thumbnail_job_stays_deduplicated_until_completion(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  (segment / "qcamera.ts").write_bytes(b"video")
+  release = threading.Event()
+  started = threading.Event()
+  calls = []
+
+  def generate(preview_path):
+    calls.append(preview_path)
+    started.set()
+    release.wait(timeout=2)
+    preview_path.write_bytes(b"png")
+    return preview_path
+
+  monkeypatch.setattr(the_galaxy, "_generate_route_thumbnail", generate)
+  monkeypatch.setattr(the_galaxy, "ROUTE_THUMBNAIL_WAIT_SECONDS", 0.01)
+  relative_path = f"{ROUTE_NAME}--0/preview.png"
+  preview_key = str((tmp_path / f"{ROUTE_NAME}--0" / "preview.png").resolve())
+
+  assert the_galaxy._get_or_create_route_thumbnail(relative_path, [tmp_path]) is None
+  assert started.is_set()
+  assert preview_key in the_galaxy._ROUTE_THUMBNAIL_FUTURES
+
+  # A retry while the original job is still running must reuse that job.
+  assert the_galaxy._get_or_create_route_thumbnail(relative_path, [tmp_path]) is None
+  assert len(calls) == 1
+
+  release.set()
+  for _ in range(100):
+    if preview_key not in the_galaxy._ROUTE_THUMBNAIL_FUTURES:
+      break
+    time.sleep(0.01)
+
+  assert preview_key not in the_galaxy._ROUTE_THUMBNAIL_FUTURES
+  assert the_galaxy._get_or_create_route_thumbnail(relative_path, [tmp_path]) == segment / "preview.png"
+  assert len(calls) == 1
+
+
+def test_routes_endpoint_uses_sse_no_buffering_headers(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  (segment / "qlog.zst").write_bytes(b"log")
+  monkeypatch.setattr(utilities, "get_route_start_time", lambda path: datetime(2026, 8, 26, tzinfo=timezone.utc))
+  client = _make_client(monkeypatch, tmp_path)
+
+  response = client.get("/api/routes")
+
+  assert response.status_code == 200
+  assert response.mimetype == "text/event-stream"
+  assert response.headers["X-Accel-Buffering"] == "no"
+  assert "no-cache" in response.headers["Cache-Control"]
+  assert b'"progress": 1' in response.data
+  assert b'"startedAt": "2026-08-26T00:00:00Z"' in response.data
+
+
+def test_thumbnail_endpoint_sets_cache_headers(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  preview = segment / "preview.png"
+  preview.write_bytes(b"not-a-real-png-but-send-file-does-not-mind")
+  client = _make_client(monkeypatch, tmp_path)
+
+  response = client.get(f"/thumbnails/{ROUTE_NAME}--0/preview.png")
+
+  assert response.status_code == 200
+  assert response.mimetype == "image/png"
+  assert response.headers["Cache-Control"] == f"public, max-age={the_galaxy.ROUTE_THUMBNAIL_CACHE_SECONDS}"
+  assert response.data == preview.read_bytes()
+
+
+def test_rename_and_reset_keep_logs_and_use_both_reset_urls(monkeypatch, tmp_path):
+  segments = [_make_segment(tmp_path, segment_num=number) for number in (0, 3)]
+  for segment in segments:
+    (segment / "qlog.zst").write_bytes(b"log")
+    (segment / "Old_name").touch()
+  monkeypatch.setattr(utilities, "get_route_start_time", lambda path: datetime(2026, 8, 26, tzinfo=timezone.utc))
+  client = _make_client(monkeypatch, tmp_path)
+
+  renamed = client.post("/api/routes/rename", json={"old": ROUTE_NAME, "new": "New name"})
+  assert renamed.status_code == 200
+  assert all((segment / "New_name").exists() for segment in segments)
+  assert all((segment / "qlog.zst").read_bytes() == b"log" for segment in segments)
+
+  reset = client.post("/api/routes/reset_name", json={"name": ROUTE_NAME})
+  assert reset.status_code == 200
+  assert reset.get_json()["timestamp"].startswith("2026-08-26")
+  assert all(not (segment / "New_name").exists() for segment in segments)
+  assert all((segment / "qlog.zst").exists() for segment in segments)
+
+  # The legacy URL remains available for older clients.
+  for segment in segments:
+    (segment / "Another_name").touch()
+  assert client.post("/api/routes/clear_name", json={"name": ROUTE_NAME}).status_code == 200
+
+
+def test_preserve_unpreserve_and_delete_route_endpoints(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path)
+  client = _make_client(monkeypatch, tmp_path)
+  attributes = set()
+  deleted = []
+  monkeypatch.setattr(the_galaxy, "PRESERVE_COUNT", 10)
+  monkeypatch.setattr(the_galaxy.os, "listxattr", lambda path: list(attributes), raising=False)
+  monkeypatch.setattr(the_galaxy.os, "getxattr", lambda path, name: the_galaxy.PRESERVE_ATTR_VALUE, raising=False)
+  monkeypatch.setattr(the_galaxy.os, "setxattr", lambda path, name, value: attributes.add(name), raising=False)
+  monkeypatch.setattr(the_galaxy.os, "removexattr", lambda path, name: attributes.discard(name), raising=False)
+  monkeypatch.setattr(the_galaxy, "delete_file", deleted.append)
+
+  assert client.post(f"/api/routes/{ROUTE_NAME}/preserve").status_code == 200
+  assert the_galaxy.PRESERVE_ATTR_NAME in attributes
+  assert client.delete(f"/api/routes/{ROUTE_NAME}/preserve").status_code == 200
+  assert the_galaxy.PRESERVE_ATTR_NAME not in attributes
+  assert client.delete(f"/api/routes/{ROUTE_NAME}").status_code == 200
+  assert deleted == [str(segment)]
+
+
+def test_preserve_follows_the_first_surviving_segment(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=3)  # --0 and --1 already aged out
+  client = _make_client(monkeypatch, tmp_path)
+  attributes = {}
+  monkeypatch.setattr(the_galaxy, "PRESERVE_COUNT", 10)
+  monkeypatch.setattr(the_galaxy.os, "listxattr", lambda path: list(attributes.get(str(path), ())), raising=False)
+  monkeypatch.setattr(the_galaxy.os, "getxattr", lambda path, name: the_galaxy.PRESERVE_ATTR_VALUE, raising=False)
+  monkeypatch.setattr(the_galaxy.os, "setxattr", lambda path, name, value: attributes.setdefault(str(path), set()).add(name), raising=False)
+  monkeypatch.setattr(the_galaxy.os, "removexattr", lambda path, name: attributes[str(path)].discard(name), raising=False)
+
+  assert client.post(f"/api/routes/{ROUTE_NAME}/preserve").status_code == 200
+  assert attributes == {str(segment): {the_galaxy.PRESERVE_ATTR_NAME}}
+  assert utilities.process_route(str(tmp_path) + "/", ROUTE_NAME, 1, 3)["is_preserved"] is True
+
+  assert client.delete(f"/api/routes/{ROUTE_NAME}/preserve").status_code == 200
+  assert attributes[str(segment)] == set()
+
+
+def test_preserve_limit_counts_routes_not_segments(monkeypatch, tmp_path):
+  for segment_num in (5, 6, 7):
+    _make_segment(tmp_path, segment_num=segment_num)
+  client = _make_client(monkeypatch, tmp_path)
+  monkeypatch.setattr(the_galaxy, "PRESERVE_COUNT", 1)
+  monkeypatch.setattr(the_galaxy.os, "listxattr", lambda path: [the_galaxy.PRESERVE_ATTR_NAME], raising=False)
+  monkeypatch.setattr(the_galaxy.os, "getxattr", lambda path, name: the_galaxy.PRESERVE_ATTR_VALUE, raising=False)
+  monkeypatch.setattr(the_galaxy.os, "setxattr", lambda path, name, value: None, raising=False)
+
+  # Three preserved segments belong to one route, so the cap of 1 is not already spent on it.
+  assert client.post(f"/api/routes/{ROUTE_NAME}/preserve").status_code == 200
+  assert client.post("/api/routes/00000099--9f0a7bdf9c/preserve").status_code == 400
+
+
+def test_sparse_route_metadata_and_video_downloads(monkeypatch, tmp_path):
+  segments = [_make_segment(tmp_path, segment_num=number) for number in (0, 3, 11)]
+  for segment in segments:
+    (segment / "fcamera.hevc").write_bytes(b"hevc")
+  monkeypatch.setattr(utilities, "get_video_duration", lambda path: 60)
+  monkeypatch.setattr(utilities, "get_route_start_time", lambda path: datetime(2026, 8, 26, tzinfo=timezone.utc))
+  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_process_builder", lambda path: io.BytesIO(b"wrapped-video"))
+  monkeypatch.setattr(utilities, "ffmpeg_concat_segments_to_mp4", lambda paths, cache_key=None: io.BytesIO(b"combined-video"))
+  client = _make_client(monkeypatch, tmp_path)
+
+  metadata = client.get(f"/api/routes/{ROUTE_NAME}")
+  assert metadata.status_code == 200
+  assert metadata.get_json()["segment_urls"] == [f"/video/{ROUTE_NAME}--{number}" for number in (0, 3, 11)]
+
+  segment_video = client.get(f"/video/{ROUTE_NAME}--3?camera=forward")
+  assert segment_video.status_code == 200
+  assert segment_video.mimetype == "video/mp4"
+  assert segment_video.data == b"wrapped-video"
+
+  combined_video = client.get(f"/video/{ROUTE_NAME}/combined?camera=forward")
+  assert combined_video.status_code == 200
+  assert combined_video.mimetype == "video/mp4"
+  assert combined_video.data == b"combined-video"

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 import io
 import os
 from pathlib import Path
+import subprocess
 import threading
 import time
 
@@ -480,35 +481,162 @@ def test_route_metadata_never_probes_segments_with_ffprobe(monkeypatch, tmp_path
   assert metadata.get_json()["total_duration"] == 180
 
 
-def test_low_quality_serves_qcamera_without_touching_ffmpeg(monkeypatch, tmp_path):
+def test_low_quality_serves_the_wrapped_qcamera_preview(monkeypatch, tmp_path):
+  """qcamera.ts is tiny, but it still needs the mp4 wrap - MPEG-TS will not play in a <video>."""
   segment = _make_segment(tmp_path, segment_num=0)
   (segment / "fcamera.hevc").write_bytes(b"hevc")
-  (segment / "qcamera.ts").write_bytes(b"qcamera-bytes")
+  (segment / "qcamera.ts").write_bytes(b"ts")
 
-  def explode(path):
-    raise AssertionError(f"the low quality tier must not remux: {path}")
+  preview_mp4 = tmp_path / "preview.mp4"
+  preview_mp4.write_bytes(b"preview-video")
+  full_mp4 = tmp_path / "full.mp4"
+  full_mp4.write_bytes(b"full-video")
 
-  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_to_path", explode)
+  wrapped = []
+  def wrap(path):
+    wrapped.append(os.path.basename(str(path)))
+    return preview_mp4 if str(path).endswith("qcamera.ts") else full_mp4
+
+  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_to_path", wrap)
   client = _make_client(monkeypatch, tmp_path)
 
   low = client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low")
   assert low.status_code == 200
-  assert low.data == b"qcamera-bytes"
+  assert low.mimetype == "video/mp4"
+  assert low.data == b"preview-video"
+
+  full = client.get(f"/video/{ROUTE_NAME}--0?camera=forward")
+  assert full.data == b"full-video"
+  assert wrapped == ["qcamera.ts", "fcamera.hevc"]
 
 
-def test_low_quality_falls_back_when_qcamera_is_missing(monkeypatch, tmp_path):
+def test_low_quality_falls_through_to_the_full_stream_when_qcamera_is_missing(monkeypatch, tmp_path):
+  """The player always asks for the preview, so a missing one must never be an error."""
   segment = _make_segment(tmp_path, segment_num=0)
   (segment / "fcamera.hevc").write_bytes(b"hevc")
   _stub_remux(monkeypatch, tmp_path)
   client = _make_client(monkeypatch, tmp_path)
 
-  # No qcamera.ts on disk, and the driver camera never has one.
-  assert client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low").status_code == 404
-  assert client.get(f"/video/{ROUTE_NAME}--0?camera=driver&quality=low").status_code == 404
+  low = client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low")
+  assert low.status_code == 200
+  assert low.data == b"wrapped-video"
 
-  full = client.get(f"/video/{ROUTE_NAME}--0?camera=forward")
-  assert full.status_code == 200
-  assert full.data == b"wrapped-video"
+
+def test_low_quality_falls_through_when_the_preview_cannot_be_wrapped(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  (segment / "qcamera.ts").write_bytes(b"ts")
+
+  full_mp4 = tmp_path / "full.mp4"
+  full_mp4.write_bytes(b"full-video")
+
+  def wrap(path):
+    if str(path).endswith("qcamera.ts"):
+      raise ValueError("corrupt preview")
+    return full_mp4
+
+  monkeypatch.setattr(utilities, "ffmpeg_mp4_wrap_to_path", wrap)
+  client = _make_client(monkeypatch, tmp_path)
+
+  low = client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low")
+  assert low.status_code == 200
+  assert low.data == b"full-video"
+
+
+def test_only_the_road_camera_has_a_preview(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "ecamera.hevc").write_bytes(b"hevc")
+  (segment / "qcamera.ts").write_bytes(b"ts")
+  _stub_remux(monkeypatch, tmp_path)
+  client = _make_client(monkeypatch, tmp_path)
+
+  wide = client.get(f"/video/{ROUTE_NAME}--0?camera=wide&quality=low")
+  assert wide.data == b"wrapped-video"
+
+
+def test_preview_timeout_does_not_wait_again_for_the_full_stream(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  (segment / "qcamera.ts").write_bytes(b"ts")
+  calls = []
+
+  def not_ready(path):
+    calls.append(Path(path).name)
+    return None
+
+  monkeypatch.setattr(the_galaxy, "_get_or_create_segment_mp4", not_ready)
+  client = _make_client(monkeypatch, tmp_path)
+
+  response = client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low")
+  assert response.status_code == 503
+  assert calls == ["qcamera.ts"]
+
+
+def test_in_progress_segment_is_not_playable(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  (segment / "qcamera.ts").write_bytes(b"ts")
+  (segment / "rlog.lock").touch()
+  client = _make_client(monkeypatch, tmp_path)
+
+  response = client.get(f"/video/{ROUTE_NAME}--0?camera=forward&quality=low")
+  assert response.status_code == 409
+  assert "still being recorded" in response.get_json()["error"]
+
+
+def test_completed_segment_remux_reuses_the_disk_cache(monkeypatch, tmp_path):
+  source = tmp_path / "fcamera.hevc"
+  source.write_bytes(b"hevc")
+  os.utime(source, (1000, 1000))
+  cache = tmp_path / "video_cache"
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_PATH", cache)
+  calls = []
+
+  def wrap(command, check, timeout):
+    calls.append(timeout)
+    Path(command[-1]).write_bytes(b"mp4")
+
+  monkeypatch.setattr(utilities.subprocess, "run", wrap)
+  first = utilities.ffmpeg_mp4_wrap_to_path(source)
+  second = utilities.ffmpeg_mp4_wrap_to_path(source)
+
+  assert first == second
+  assert len(calls) == 1
+  assert 0 < calls[0] <= utilities.VIDEO_REMUX_TIMEOUT_SECONDS
+
+
+def test_segment_remux_timeout_is_bounded_and_removes_partial_output(monkeypatch, tmp_path):
+  source = tmp_path / "fcamera.hevc"
+  source.write_bytes(b"hevc")
+  cache = tmp_path / "video_cache"
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_PATH", cache)
+  timeouts = []
+
+  def timeout(command, check, timeout):
+    timeouts.append(timeout)
+    Path(command[-1]).write_bytes(b"partial")
+    raise subprocess.TimeoutExpired(command, timeout)
+
+  monkeypatch.setattr(utilities.subprocess, "run", timeout)
+
+  with pytest.raises(ValueError, match="Timed out processing video file"):
+    utilities.ffmpeg_mp4_wrap_to_path(source)
+
+  assert len(timeouts) == 1
+  assert 0 < timeouts[0] <= utilities.VIDEO_REMUX_TIMEOUT_SECONDS
+  assert not list(cache.glob("*.mp4"))
+
+
+def test_segment_video_falls_back_across_cameras(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  _stub_remux(monkeypatch, tmp_path)
+  client = _make_client(monkeypatch, tmp_path)
+
+  assert client.get(f"/video/{ROUTE_NAME}--0?camera=forward").data == b"wrapped-video"
+  # No ecamera.hevc on disk for this segment.
+  assert client.get(f"/video/{ROUTE_NAME}--0?camera=wide").status_code == 404
+  assert client.get("/video/not-a-segment?camera=forward").status_code == 400
 
 
 def test_segment_video_supports_range_requests(monkeypatch, tmp_path):
@@ -524,6 +652,18 @@ def test_segment_video_supports_range_requests(monkeypatch, tmp_path):
 
   # A malformed range used to raise inside the hand-rolled parser.
   assert client.get(f"/video/{ROUTE_NAME}--0?camera=forward", headers={"Range": "bytes=abc"}).status_code in (200, 416)
+
+
+def test_head_request_prepares_full_quality_without_sending_the_body(monkeypatch, tmp_path):
+  segment = _make_segment(tmp_path, segment_num=0)
+  (segment / "fcamera.hevc").write_bytes(b"hevc")
+  _stub_remux(monkeypatch, tmp_path)
+  client = _make_client(monkeypatch, tmp_path)
+
+  prepared = client.head(f"/video/{ROUTE_NAME}--0?camera=forward")
+  assert prepared.status_code == 200
+  assert prepared.mimetype == "video/mp4"
+  assert prepared.data == b""
 
 
 def test_concurrent_requests_for_one_segment_share_a_single_remux(monkeypatch, tmp_path):

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
@@ -326,6 +326,7 @@ def test_rename_and_reset_keep_logs_and_use_both_reset_urls(monkeypatch, tmp_pat
 
   renamed = client.post("/api/routes/rename", json={"old": ROUTE_NAME, "new": "New name"})
   assert renamed.status_code == 200
+  assert renamed.get_json()["name"] == "New_name"
   assert all((segment / "New_name").exists() for segment in segments)
   assert all((segment / "qlog.zst").read_bytes() == b"log" for segment in segments)
 

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
@@ -487,6 +487,46 @@ def test_video_cache_never_evicts_the_entry_being_written(monkeypatch, tmp_path)
   assert keep.exists()
 
 
+def test_combined_video_streams_fragmented_mp4_without_a_full_cache_file(monkeypatch, tmp_path):
+  cache = tmp_path / "video_cache"
+  first = tmp_path / "first.hevc"
+  second = tmp_path / "second.hevc"
+  first.write_bytes(b"first")
+  second.write_bytes(b"second")
+  monkeypatch.setattr(utilities, "VIDEO_CACHE_PATH", cache)
+  captured = {}
+
+  class FakeProcess:
+    def __init__(self):
+      self.stdout = io.BytesIO(b"streamed-video")
+      self.returncode = None
+
+    def wait(self, timeout=None):
+      self.returncode = 0
+      return 0
+
+    def poll(self):
+      return self.returncode
+
+  def popen(command, **kwargs):
+    captured["command"] = command
+    list_path = Path(command[command.index("-i") + 1])
+    captured["list_path"] = list_path
+    captured["list_contents"] = list_path.read_text()
+    return FakeProcess()
+
+  monkeypatch.setattr(utilities.subprocess, "Popen", popen)
+
+  payload = b"".join(utilities.ffmpeg_stream_concatenated_mp4([first, second], chunk_size=4))
+
+  assert payload == b"streamed-video"
+  assert "frag_keyframe+empty_moov+default_base_moof" in captured["command"]
+  assert captured["command"][-1] == "pipe:1"
+  assert captured["list_contents"] == f"file '{first}'\nfile '{second}'\n"
+  assert not captured["list_path"].exists()
+  assert not list(cache.glob("*.mp4"))
+
+
 def _stub_remux(monkeypatch, tmp_path, payload=b"wrapped-video"):
   """Stand in for the ffmpeg remux, returning a real file so send_file can stream it."""
   wrapped = tmp_path / "wrapped.mp4"
@@ -501,7 +541,7 @@ def test_sparse_route_metadata_and_video_downloads(monkeypatch, tmp_path):
     (segment / "fcamera.hevc").write_bytes(b"hevc")
   monkeypatch.setattr(utilities, "get_route_start_time", lambda path: datetime(2026, 8, 26, tzinfo=timezone.utc))
   _stub_remux(monkeypatch, tmp_path)
-  monkeypatch.setattr(utilities, "ffmpeg_concat_segments_to_mp4", lambda paths, cache_key=None: io.BytesIO(b"combined-video"))
+  monkeypatch.setattr(utilities, "ffmpeg_stream_concatenated_mp4", lambda paths: iter((b"combined-", b"video")))
   client = _make_client(monkeypatch, tmp_path)
 
   metadata = client.get(f"/api/routes/{ROUTE_NAME}")
@@ -519,6 +559,7 @@ def test_sparse_route_metadata_and_video_downloads(monkeypatch, tmp_path):
   assert combined_video.status_code == 200
   assert combined_video.mimetype == "video/mp4"
   assert combined_video.data == b"combined-video"
+  assert combined_video.headers["X-Accel-Buffering"] == "no"
 
 
 def test_route_metadata_never_probes_segments_with_ffprobe(monkeypatch, tmp_path):

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes.py
@@ -393,6 +393,63 @@ def test_preserve_limit_counts_routes_not_segments(monkeypatch, tmp_path):
   assert client.post("/api/routes/00000099--9f0a7bdf9c/preserve").status_code == 400
 
 
+def test_delete_all_non_preserved_keeps_entire_preserved_route_across_roots(monkeypatch, tmp_path):
+  standard = tmp_path / "standard"
+  high_resolution = tmp_path / "high_resolution"
+  preserved_route = ROUTE_NAME
+  ordinary_route = "0000006b--9f0a7bdf9d"
+  preserved_marker = _make_segment(standard, preserved_route, 3)
+  preserved_other_root = _make_segment(high_resolution, preserved_route, 4)
+  ordinary_standard = _make_segment(standard, ordinary_route, 0)
+  ordinary_other_root = _make_segment(high_resolution, ordinary_route, 1)
+  unrelated = high_resolution / "video_cache"
+  unrelated.mkdir()
+
+  client = _make_client(monkeypatch, standard)
+  monkeypatch.setattr(the_galaxy, "FOOTAGE_PATHS", [str(standard), str(high_resolution)])
+  monkeypatch.setattr(utilities, "has_preserve_attr", lambda path: path == str(preserved_marker))
+  monkeypatch.setattr(utilities, "stop_dashboard_background_analysis", lambda: None)
+  monkeypatch.setattr(the_galaxy, "delete_file", lambda path: Path(path).rmdir())
+  history_calls = []
+  monkeypatch.setattr(utilities, "clear_dashboard_route_history", lambda params, retained_route_names=None: history_calls.append(retained_route_names) or 1)
+  factory_delete_calls = []
+  monkeypatch.setattr(the_galaxy, "_run_factory_reset_delete", factory_delete_calls.append)
+
+  response = client.delete("/api/routes/delete_all?include_preserved=false")
+
+  assert response.status_code == 200
+  assert response.get_json()["deletedRoutes"] == 1
+  assert response.get_json()["preservedRoutes"] == 1
+  assert preserved_marker.is_dir()
+  assert preserved_other_root.is_dir()
+  assert not ordinary_standard.exists()
+  assert not ordinary_other_root.exists()
+  assert unrelated.is_dir()
+  assert history_calls == [{preserved_route}]
+  assert factory_delete_calls == []
+
+
+def test_delete_all_including_preserved_keeps_existing_full_wipe_behavior(monkeypatch, tmp_path):
+  first_root = tmp_path / "standard"
+  second_root = tmp_path / "high_resolution"
+  _make_segment(first_root)
+  _make_segment(second_root)
+  client = _make_client(monkeypatch, first_root)
+  monkeypatch.setattr(the_galaxy, "FOOTAGE_PATHS", [str(first_root) + "/", str(second_root), str(first_root)])
+  monkeypatch.setattr(utilities, "stop_dashboard_background_analysis", lambda: None)
+  history_calls = []
+  monkeypatch.setattr(utilities, "clear_dashboard_route_history", lambda params, retained_route_names=None: history_calls.append(retained_route_names) or 2)
+  factory_delete_calls = []
+  monkeypatch.setattr(the_galaxy, "_run_factory_reset_delete", factory_delete_calls.append)
+
+  response = client.delete("/api/routes/delete_all?include_preserved=true")
+
+  assert response.status_code == 200
+  assert factory_delete_calls == [str(first_root), str(second_root)]
+  assert history_calls == [None]
+  assert "including preserved routes" in response.get_json()["message"]
+
+
 def test_video_cache_evicts_oldest_instead_of_wiping_everything(monkeypatch, tmp_path):
   """A tight disk used to delete every cached mp4, so playback re-muxed on every request."""
   cache = tmp_path / "video_cache"

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -82,7 +82,8 @@ def test_route_titles_and_custom_name_badges_are_reactive():
 def test_sort_order_select_and_route_items_are_keyed_and_reactive():
   source = COMPONENT_PATH.read_text(encoding="utf-8")
 
-  assert '<select value="${() => state.sortOrder}" @change="${event => { state.sortOrder = event.target.value }}">' in source
+  assert '<select value="${() => state.sortOrder}" @input="${changeSortOrder}" @change="${changeSortOrder}">' in source
+  assert "state.routes = [...state.routes]" in source
   assert ".key(group.key)" in source
   assert ".key(route.name)" in source
 
@@ -187,6 +188,27 @@ def test_search_indexes_the_displayed_time_for_every_route():
     ["0000006b--9f0a7bdf9d"],
     ["0000006a--9f0a7bdf9c"],
   ]
+
+
+def test_short_numeric_search_does_not_match_hidden_ids_or_unrelated_dates():
+  result = evaluate('''
+    const routes = [
+      route("00000012--9f0a7bdf9c", "2026-08-27T13:05:00Z", { timestamp: "Morning drive", isCustomName: true }),
+      route("0000006b--9f0a7bdf9d", "2026-12-12T13:05:00Z", { timestamp: "Afternoon drive", isCustomName: true }),
+      route("0000006c--9f0a7bdf9e", "2026-08-27T13:05:00Z", { timestamp: "Test_12", isCustomName: true }),
+    ]
+    return {
+      plainNumber: buildRouteView(routes, { searchQuery: "12" }).matching.map(item => item.name),
+      ordinalDate: buildRouteView(routes, { searchQuery: "dec 12th" }).matching.map(item => item.name),
+      explicitId: buildRouteView(routes, { searchQuery: "00000012" }).matching.map(item => item.name),
+    }
+  ''')
+
+  assert result == {
+    "plainNumber": ["0000006c--9f0a7bdf9e"],
+    "ordinalDate": ["0000006b--9f0a7bdf9d"],
+    "explicitId": ["00000012--9f0a7bdf9c"],
+  }
 
 
 def test_filters_preserved_routes_before_applying_the_render_limit():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -97,6 +97,9 @@ def test_player_shell_keeps_both_quality_levels_at_one_fixed_size():
   assert "height: 100% !important;" in source
   assert "width: 100% !important;" in source
   assert "object-fit: cover;" in source
+  assert ".dashcam-video-shell.qcamera-framing video" in source
+  assert "object-fit: fill;" in source
+  assert 'videoShell.classList.toggle("qcamera-framing", showingPreview)' in component
   assert "deferNativeControlsUntilInteraction(stagingVideo)" in component
   assert "stagingVideo.controls = true" not in component
 

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -88,10 +88,11 @@ def test_sort_order_select_and_route_items_are_keyed_and_reactive():
   assert ".key(route.name)" in source
 
 
-def test_player_shell_matches_low_quality_video_aspect_ratio():
+def test_player_shell_keeps_both_quality_levels_at_one_fixed_size():
   source = COMPONENT_CSS_PATH.read_text(encoding="utf-8")
 
   assert "aspect-ratio: 526 / 330;" in source
+  assert "object-fit: cover;" in source
 
 
 def test_groups_routes_into_today_yesterday_dates_and_unknown():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -15,6 +15,7 @@ import pytest
 
 HELPERS_PATH = Path(__file__).resolve().parent.parent / "assets" / "components" / "recordings" / "dashcam_routes_helpers.js"
 COMPONENT_PATH = HELPERS_PATH.with_name("dashcam_routes.js")
+COMPONENT_CSS_PATH = HELPERS_PATH.with_name("dashcam_routes.css")
 
 # node infers ESM from `export` syntax in a bare .js file from 22.7 on, so the helpers
 # need no package.json and stay a normal asset next to the component that imports them.
@@ -78,6 +79,12 @@ def test_route_titles_and_custom_name_badges_are_reactive():
   assert source.count('${() => route.isCustomName ? html`') >= 4
 
 
+def test_player_shell_matches_low_quality_video_aspect_ratio():
+  source = COMPONENT_CSS_PATH.read_text(encoding="utf-8")
+
+  assert "aspect-ratio: 526 / 330;" in source
+
+
 def test_groups_routes_into_today_yesterday_dates_and_unknown():
   groups = evaluate('''
     const routes = [
@@ -127,6 +134,33 @@ def test_searches_custom_names_displayed_dates_and_route_ids():
   ''')
 
   assert matches == [1, 1, 1, 0]
+
+
+def test_search_matches_partial_title_tokens_and_friendly_dates_as_the_user_types():
+  result = evaluate('''
+    const routes = [
+      route("0000006a--9f0a7bdf9c", "2026-08-27T08:00:00Z", { timestamp: "Test_31", isCustomName: true }),
+      route("0000006b--9f0a7bdf9d", "2026-08-28T08:00:00Z", { timestamp: "Morning drive", isCustomName: true }),
+      route("0000006c--9f0a7bdf9e", "2026-09-27T08:00:00Z", { timestamp: "Test_4", isCustomName: true }),
+    ]
+    return ["test", "test 3", "aug", "aug 2", "aug 27th", "8/27"]
+      .map(searchQuery => buildRouteView(routes, { searchQuery }).matching.map(item => item.name))
+  ''')
+
+  assert result == [
+    ["0000006c--9f0a7bdf9e", "0000006a--9f0a7bdf9c"],
+    ["0000006a--9f0a7bdf9c"],
+    ["0000006b--9f0a7bdf9d", "0000006a--9f0a7bdf9c"],
+    ["0000006b--9f0a7bdf9d", "0000006a--9f0a7bdf9c"],
+    ["0000006a--9f0a7bdf9c"],
+    ["0000006a--9f0a7bdf9c"],
+  ]
+
+
+def test_route_search_input_updates_on_every_keystroke():
+  source = COMPONENT_PATH.read_text(encoding="utf-8")
+
+  assert '@input="${event => { state.searchQuery = event.target.value }}"' in source
 
 
 def test_filters_preserved_routes_before_applying_the_render_limit():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -14,6 +14,7 @@ import subprocess
 import pytest
 
 HELPERS_PATH = Path(__file__).resolve().parent.parent / "assets" / "components" / "recordings" / "dashcam_routes_helpers.js"
+COMPONENT_PATH = HELPERS_PATH.with_name("dashcam_routes.js")
 
 # node infers ESM from `export` syntax in a bare .js file from 22.7 on, so the helpers
 # need no package.json and stay a normal asset next to the component that imports them.
@@ -67,6 +68,14 @@ def evaluate(snippet):
 def test_helpers_module_is_a_plain_js_asset():
   assert HELPERS_PATH.is_file()
   assert not list(HELPERS_PATH.parent.glob("*.mjs"))
+
+
+def test_route_titles_and_custom_name_badges_are_reactive():
+  source = COMPONENT_PATH.read_text(encoding="utf-8")
+
+  # Both grid and row views must subscribe directly to the renamed route fields.
+  assert source.count('${() => route.displayName}') >= 4
+  assert source.count('${() => route.isCustomName ? html`') >= 4
 
 
 def test_groups_routes_into_today_yesterday_dates_and_unknown():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -1,0 +1,186 @@
+"""Covers assets/components/recordings/dashcam_routes_helpers.js.
+
+The helpers are browser ES modules, so pytest drives them through node rather than
+re-implementing the date/sort/grouping rules in Python. Snippets run with helper
+exports in scope and return JSON, which keeps every assertion here in pytest.
+"""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+HELPERS_PATH = Path(__file__).resolve().parent.parent / "assets" / "components" / "recordings" / "dashcam_routes_helpers.js"
+
+# node infers ESM from `export` syntax in a bare .js file from 22.7 on, so the helpers
+# need no package.json and stay a normal asset next to the component that imports them.
+MIN_NODE_MAJOR = 23
+
+HARNESS = f'''
+import * as helpers from {json.dumps(HELPERS_PATH.as_uri())}
+const run = new Function(...Object.keys(helpers), process.env.DASHCAM_HELPER_SNIPPET)
+process.stdout.write(JSON.stringify(run(...Object.values(helpers)) ?? null))
+'''
+
+PRELUDE = '''
+const route = (name, startedAt, extra = {}) => normalizeRoute({
+  name,
+  startedAt,
+  timestamp: startedAt,
+  segmentCount: 1,
+  approxDurationSeconds: 60,
+  is_preserved: false,
+  ...extra,
+}, "en-US")
+'''
+
+
+def _node_binary():
+  node = shutil.which("node")
+  if node is None:
+    pytest.skip("node is not installed")
+
+  version = subprocess.run([node, "--version"], capture_output=True, text=True, timeout=30).stdout.strip()
+  try:
+    major = int(version.lstrip("v").split(".")[0])
+  except ValueError:
+    pytest.skip(f"could not read node version from {version!r}")
+  if major < MIN_NODE_MAJOR:
+    pytest.skip(f"node {version} cannot import a bare .js ES module; need v{MIN_NODE_MAJOR}+")
+  return node
+
+
+def evaluate(snippet):
+  """Run a snippet with the helper exports in scope and return its JSON value."""
+  node = _node_binary()
+  # Fixed TZ so "Today"/"Yesterday" grouping does not depend on the developer's clock.
+  environment = {**os.environ, "TZ": "UTC", "DASHCAM_HELPER_SNIPPET": PRELUDE + snippet}
+  result = subprocess.run([node, "--input-type=module"], input=HARNESS, env=environment,
+                          capture_output=True, text=True, timeout=60)
+  assert result.returncode == 0, result.stderr
+  return json.loads(result.stdout)
+
+
+def test_helpers_module_is_a_plain_js_asset():
+  assert HELPERS_PATH.is_file()
+  assert not list(HELPERS_PATH.parent.glob("*.mjs"))
+
+
+def test_groups_routes_into_today_yesterday_dates_and_unknown():
+  groups = evaluate('''
+    const routes = [
+      route("today", "2026-08-26T08:00:00Z"),
+      route("yesterday", "2026-08-25T08:00:00Z"),
+      route("older", "2026-08-20T08:00:00Z"),
+      route("unknown", null, { timestamp: null }),
+    ]
+    return groupRoutesByDate(routes, new Date("2026-08-26T12:00:00Z"), "en-US")
+      .map(group => [group.label, group.routes[0].name])
+  ''')
+
+  assert groups == [
+    ["Today", "today"],
+    ["Yesterday", "yesterday"],
+    ["August 20, 2026", "older"],
+    ["Unknown date", "unknown"],
+  ]
+
+
+def test_sorts_newest_and_oldest_while_leaving_unknown_dates_last():
+  order = evaluate('''
+    const routes = [
+      route("middle", "2026-08-20T08:00:00Z"),
+      route("unknown", null, { timestamp: null }),
+      route("new", "2026-08-26T08:00:00Z"),
+      route("old", "2026-08-10T08:00:00Z"),
+    ]
+    return {
+      newest: sortRoutes(routes, "newest").map(item => item.name),
+      oldest: sortRoutes(routes, "oldest").map(item => item.name),
+    }
+  ''')
+
+  assert order["newest"] == ["new", "middle", "old", "unknown"]
+  assert order["oldest"] == ["old", "middle", "new", "unknown"]
+
+
+def test_searches_custom_names_displayed_dates_and_route_ids():
+  matches = evaluate('''
+    const custom = route("0000006a--9f0a7bdf9c", "2026-08-26T08:00:00Z", {
+      timestamp: "Morning school run",
+      isCustomName: true,
+    })
+    return ["school", "August 26", "9f0a7b", "evening"]
+      .map(searchQuery => buildRouteView([custom], { searchQuery }).matching.length)
+  ''')
+
+  assert matches == [1, 1, 1, 0]
+
+
+def test_filters_preserved_routes_before_applying_the_render_limit():
+  view = evaluate('''
+    const routes = Array.from({ length: MAX_RENDERED_ROUTES + 25 }, (_, index) => route(
+      `route-${index}`,
+      new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+      { is_preserved: index % 2 === 0 },
+    ))
+    const all = buildRouteView(routes)
+    const preserved = buildRouteView(routes, { preservedOnly: true })
+    return {
+      limit: MAX_RENDERED_ROUTES,
+      all: [all.matching.length, all.visible.length, all.truncated],
+      preserved: [preserved.matching.length, preserved.visible.length, preserved.truncated],
+      allPreserved: preserved.visible.every(item => item.is_preserved),
+    }
+  ''')
+
+  assert view["limit"] == 250
+  assert view["all"] == [275, 250, True]
+  assert view["preserved"] == [138, 138, False]
+  assert view["allPreserved"] is True
+
+
+def test_segment_status_uses_stored_sparse_numbers_and_playback_position():
+  statuses = evaluate('''
+    const segments = [
+      "/video/0000006a--9f0a7bdf9c--0",
+      "/video/0000006a--9f0a7bdf9c--3",
+      "/video/0000006a--9f0a7bdf9c--11",
+    ]
+    return segments.map((_, index) => getSegmentStatus(segments, index))
+  ''')
+
+  assert statuses == [
+    "Segment 0 · 1 of 3",
+    "Segment 3 · 2 of 3",
+    "Segment 11 · 3 of 3",
+  ]
+
+
+def test_hides_segment_status_when_the_stored_number_is_unsafe():
+  results = evaluate('''
+    return [
+      parseStoredSegmentNumber("/video/route--9007199254740992"),
+      getSegmentStatus(["/video/not-a-segment"], 0),
+      getSegmentStatus(undefined, 0),
+    ]
+  ''')
+
+  assert results == [None, "", ""]
+
+
+def test_switching_camera_changes_only_the_url_and_not_segment_status():
+  result = evaluate('''
+    const segments = ["/video/0000006a--9f0a7bdf9c--7"]
+    const before = getSegmentStatus(segments, 0)
+    return {
+      url: cameraVideoUrl(segments[0], "driver"),
+      unchanged: getSegmentStatus(segments, 0) === before,
+    }
+  ''')
+
+  assert result["url"] == "/video/0000006a--9f0a7bdf9c--7?camera=driver"
+  assert result["unchanged"] is True

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -229,23 +229,28 @@ def test_hides_segment_status_when_the_stored_number_is_unsafe():
 def test_camera_video_url_carries_an_optional_quality_tier():
   result = evaluate("""
     const segment = "/video/0000006a--9f0a7bdf9c--7"
-    return {
-      full: cameraVideoUrl(segment, "forward"),
-      low: cameraVideoUrl(segment, "forward", "low"),
-      lowWide: cameraVideoUrl(segment, "wide", "low"),
-    }
+    return { full: cameraVideoUrl(segment, "forward"), low: cameraVideoUrl(segment, "forward", "low") }
   """)
 
   assert result["full"] == "/video/0000006a--9f0a7bdf9c--7?camera=forward"
   assert result["low"] == "/video/0000006a--9f0a7bdf9c--7?camera=forward&quality=low"
-  assert result["lowWide"] == "/video/0000006a--9f0a7bdf9c--7?camera=wide&quality=low"
 
 
-def test_only_the_road_camera_has_a_low_quality_tier():
+def test_only_the_road_camera_has_a_preview():
   """loggerd writes qcamera.ts alongside the road camera only."""
+  assert evaluate('return ["forward", "wide", "driver"].map(supportsLowQuality)') == [True, False, False]
+
+
+def test_upgrade_decision_only_trusts_a_positively_tall_frame():
+  """The server falls back to the full stream, so the frame size is what settles it."""
   assert evaluate("""
-    return ["forward", "wide", "driver"].map(supportsLowQuality)
-  """) == [True, False, False]
+    return {
+      qcamera: shouldUpgradeFromHeight(330),
+      full: shouldUpgradeFromHeight(1080),
+      unknown: shouldUpgradeFromHeight(0),
+      missing: shouldUpgradeFromHeight(undefined),
+    }
+  """) == {"qcamera": True, "full": False, "unknown": True, "missing": True}
 
 
 def test_switching_camera_changes_only_the_url_and_not_segment_status():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -143,7 +143,45 @@ def test_filters_preserved_routes_before_applying_the_render_limit():
   assert view["allPreserved"] is True
 
 
-def test_segment_status_uses_stored_sparse_numbers_and_playback_position():
+def test_duration_sorts_render_as_one_flat_group():
+  result = evaluate("""
+    const routes = [
+      { name: "a", _startedAtMs: Date.parse("2026-08-20T10:00:00Z"), approxDurationSeconds: 3000 },
+      { name: "b", _startedAtMs: Date.parse("2026-08-22T10:00:00Z"), approxDurationSeconds: 2700 },
+      { name: "c", _startedAtMs: Date.parse("2026-08-21T10:00:00Z"), approxDurationSeconds: 1800 },
+    ]
+    const view = buildRouteView(routes, { sortOrder: "longest" })
+    const groups = groupRoutesForView(view.visible, "longest", new Date("2026-08-27T12:00:00Z"), "en-US")
+    return { labels: groups.map(g => g.label), order: groups.flatMap(g => g.routes.map(r => r.name)) }
+  """)
+
+  assert result["labels"] == ["Longest first"]
+  assert result["order"] == ["a", "b", "c"]
+
+
+def test_date_sorts_still_group_by_day():
+  labels = evaluate("""
+    const routes = [
+      { name: "a", _startedAtMs: Date.parse("2026-08-20T10:00:00Z"), approxDurationSeconds: 3000 },
+      { name: "b", _startedAtMs: Date.parse("2026-08-22T10:00:00Z"), approxDurationSeconds: 2700 },
+    ]
+    const view = buildRouteView(routes, { sortOrder: "newest" })
+    return groupRoutesForView(view.visible, "newest", new Date("2026-08-27T12:00:00Z"), "en-US").map(g => g.label)
+  """)
+
+  assert labels == ["August 22, 2026", "August 20, 2026"]
+
+
+def test_grouping_an_empty_list_yields_no_groups():
+  assert evaluate("""
+    return [
+      groupRoutesForView([], "longest").length,
+      groupRoutesForView([], "newest").length,
+    ]
+  """) == [0, 0]
+
+
+def test_segment_status_reports_the_stored_segment_number():
   statuses = evaluate('''
     const segments = [
       "/video/0000006a--9f0a7bdf9c--0",
@@ -153,11 +191,27 @@ def test_segment_status_uses_stored_sparse_numbers_and_playback_position():
     return segments.map((_, index) => getSegmentStatus(segments, index))
   ''')
 
-  assert statuses == [
-    "Segment 0 · 1 of 3",
-    "Segment 3 · 2 of 3",
-    "Segment 11 · 3 of 3",
+  assert statuses == ["Segment 0", "Segment 3", "Segment 11"]
+
+
+def test_segment_options_label_every_clip_for_the_jump_picker():
+  options = evaluate("""
+    return getSegmentOptions([
+      "/video/0000006a--9f0a7bdf9c--12",
+      "/video/0000006a--9f0a7bdf9c--13",
+      "/video/not-a-segment",
+    ])
+  """)
+
+  assert options == [
+    {"index": 0, "label": "Segment 12"},
+    {"index": 1, "label": "Segment 13"},
+    {"index": 2, "label": "Clip 3"},
   ]
+
+
+def test_segment_options_tolerate_a_missing_segment_list():
+  assert evaluate("return [getSegmentOptions(undefined), getSegmentOptions([])]") == [[], []]
 
 
 def test_hides_segment_status_when_the_stored_number_is_unsafe():
@@ -170,6 +224,28 @@ def test_hides_segment_status_when_the_stored_number_is_unsafe():
   ''')
 
   assert results == [None, "", ""]
+
+
+def test_camera_video_url_carries_an_optional_quality_tier():
+  result = evaluate("""
+    const segment = "/video/0000006a--9f0a7bdf9c--7"
+    return {
+      full: cameraVideoUrl(segment, "forward"),
+      low: cameraVideoUrl(segment, "forward", "low"),
+      lowWide: cameraVideoUrl(segment, "wide", "low"),
+    }
+  """)
+
+  assert result["full"] == "/video/0000006a--9f0a7bdf9c--7?camera=forward"
+  assert result["low"] == "/video/0000006a--9f0a7bdf9c--7?camera=forward&quality=low"
+  assert result["lowWide"] == "/video/0000006a--9f0a7bdf9c--7?camera=wide&quality=low"
+
+
+def test_only_the_road_camera_has_a_low_quality_tier():
+  """loggerd writes qcamera.ts alongside the road camera only."""
+  assert evaluate("""
+    return ["forward", "wide", "driver"].map(supportsLowQuality)
+  """) == [True, False, False]
 
 
 def test_switching_camera_changes_only_the_url_and_not_segment_status():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -200,6 +200,17 @@ def test_route_search_input_updates_on_every_keystroke():
   assert '@input="${event => { state.searchQuery = event.target.value }}"' in source
 
 
+def test_route_summary_only_shows_loading_or_active_search_status():
+  source = COMPONENT_PATH.read_text(encoding="utf-8")
+
+  assert "const hasActiveSearch = Boolean(state.searchQuery.trim())" in source
+  assert '${state.loading || hasActiveSearch ? html`' in source
+  assert '${hasActiveSearch ? html`<span>${view.matching.length} matching drive' in source
+  assert '${state.loading ? html`<span>Loading routes</span>` : ""}' in source
+  assert "Loading ${state.progress} of ${state.total}" not in source
+  assert "total local" not in source
+
+
 def test_search_indexes_the_displayed_time_for_every_route():
   result = evaluate('''
     const routes = [
@@ -366,6 +377,22 @@ def test_camera_video_url_carries_an_optional_quality_tier():
 
   assert result["full"] == "/video/0000006a--9f0a7bdf9c--7?camera=forward"
   assert result["low"] == "/video/0000006a--9f0a7bdf9c--7?camera=forward&quality=low"
+
+
+def test_route_metadata_errors_explain_missing_local_segments():
+  result = evaluate('''
+    return {
+      missing: routeMetadataErrorMessage(404, "Route not found"),
+      backend: routeMetadataErrorMessage(400, "Invalid route name"),
+      fallback: routeMetadataErrorMessage(503),
+    }
+  ''')
+
+  assert result == {
+    "missing": "This route is no longer available on this device. Its local video segments may have been deleted or moved.",
+    "backend": "Invalid route name",
+    "fallback": "Could not load route details (503).",
+  }
 
 
 def test_only_the_road_camera_has_a_preview():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -83,7 +83,7 @@ def test_sort_order_select_and_route_items_are_keyed_and_reactive():
   source = COMPONENT_PATH.read_text(encoding="utf-8")
 
   assert '<select value="${() => state.sortOrder}" @input="${changeSortOrder}" @change="${changeSortOrder}">' in source
-  assert "state.routes = [...state.routes]" in source
+  assert 'data-view-key="${renderKey}"' in source
   assert ".key(group.key)" in source
   assert ".key(route.name)" in source
 
@@ -262,6 +262,19 @@ def test_date_sorts_still_group_by_day():
   """)
 
   assert labels == ["August 22, 2026", "August 20, 2026"]
+
+
+def test_route_view_render_key_changes_with_displayed_order_and_mode():
+  result = evaluate('''
+    const routes = [{ name: "a" }, { name: "b" }]
+    return [
+      routeViewRenderKey(routes, "newest", "list"),
+      routeViewRenderKey([...routes].reverse(), "oldest", "list"),
+      routeViewRenderKey(routes, "newest", "grid"),
+    ]
+  ''')
+
+  assert result == ["list:newest:a,b", "list:oldest:b,a", "grid:newest:a,b"]
 
 
 def test_grouping_an_empty_list_yields_no_groups():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -79,6 +79,14 @@ def test_route_titles_and_custom_name_badges_are_reactive():
   assert source.count('${() => route.isCustomName ? html`') >= 4
 
 
+def test_sort_order_select_and_route_items_are_keyed_and_reactive():
+  source = COMPONENT_PATH.read_text(encoding="utf-8")
+
+  assert '<select value="${() => state.sortOrder}" @change="${event => { state.sortOrder = event.target.value }}">' in source
+  assert ".key(group.key)" in source
+  assert ".key(route.name)" in source
+
+
 def test_player_shell_matches_low_quality_video_aspect_ratio():
   source = COMPONENT_CSS_PATH.read_text(encoding="utf-8")
 
@@ -161,6 +169,24 @@ def test_route_search_input_updates_on_every_keystroke():
   source = COMPONENT_PATH.read_text(encoding="utf-8")
 
   assert '@input="${event => { state.searchQuery = event.target.value }}"' in source
+
+
+def test_search_indexes_the_displayed_time_for_every_route():
+  result = evaluate('''
+    const routes = [
+      route("0000006a--9f0a7bdf9c", "2026-08-27T12:15:00Z"),
+      route("0000006b--9f0a7bdf9d", "2026-08-27T12:50:00Z"),
+      route("0000006c--9f0a7bdf9e", "2026-08-27T13:05:00Z"),
+    ]
+    return ["12", "12:5", "12:15"]
+      .map(searchQuery => buildRouteView(routes, { searchQuery }).matching.map(item => item.name))
+  ''')
+
+  assert result == [
+    ["0000006b--9f0a7bdf9d", "0000006a--9f0a7bdf9c"],
+    ["0000006b--9f0a7bdf9d"],
+    ["0000006a--9f0a7bdf9c"],
+  ]
 
 
 def test_filters_preserved_routes_before_applying_the_render_limit():

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -173,6 +173,24 @@ def test_search_matches_partial_title_tokens_and_friendly_dates_as_the_user_type
   ]
 
 
+def test_partial_day_does_not_match_the_four_digit_year():
+  result = evaluate('''
+    const routes = Array.from({ length: 9 }, (_, offset) => {
+      const day = 19 + offset
+      return route(`aug-${day}`, `2026-08-${day}T12:00:00Z`)
+    })
+    return {
+      partial: buildRouteView(routes, { searchQuery: "aug 2" }).matching.map(item => item.name),
+      complete: buildRouteView(routes, { searchQuery: "aug 20" }).matching.map(item => item.name),
+    }
+  ''')
+
+  assert result == {
+    "partial": ["aug-27", "aug-26", "aug-25", "aug-24", "aug-23", "aug-22", "aug-21", "aug-20"],
+    "complete": ["aug-20"],
+  }
+
+
 def test_route_search_input_updates_on_every_keystroke():
   source = COMPONENT_PATH.read_text(encoding="utf-8")
 

--- a/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
+++ b/starpilot/system/the_galaxy/tests/test_dashcam_routes_helpers.py
@@ -90,9 +90,15 @@ def test_sort_order_select_and_route_items_are_keyed_and_reactive():
 
 def test_player_shell_keeps_both_quality_levels_at_one_fixed_size():
   source = COMPONENT_CSS_PATH.read_text(encoding="utf-8")
+  component = COMPONENT_PATH.read_text(encoding="utf-8")
 
   assert "aspect-ratio: 526 / 330;" in source
+  assert "contain: layout paint;" in source
+  assert "height: 100% !important;" in source
+  assert "width: 100% !important;" in source
   assert "object-fit: cover;" in source
+  assert "deferNativeControlsUntilInteraction(stagingVideo)" in component
+  assert "stagingVideo.controls = true" not in component
 
 
 def test_groups_routes_into_today_yesterday_dates_and_unknown():

--- a/starpilot/system/the_galaxy/tests/test_route_logs.py
+++ b/starpilot/system/the_galaxy/tests/test_route_logs.py
@@ -1,0 +1,111 @@
+import io
+import tarfile
+
+from test_dashboard_stats import MODULE_DIR, _install_server_import_stubs
+
+
+def _load_server_module():
+  import importlib.util
+  import sys
+
+  _install_server_import_stubs()
+  spec = importlib.util.spec_from_file_location("route_logs_server", MODULE_DIR / "the_galaxy.py")
+  module = importlib.util.module_from_spec(spec)
+  sys.modules["route_logs_server"] = module
+  spec.loader.exec_module(module)
+  return module
+
+
+the_galaxy = _load_server_module()
+
+
+def _make_route(root, name, segments, filename="rlog.zst", size=32):
+  for segment_num in segments:
+    segment_dir = root / f"{name}--{segment_num}"
+    segment_dir.mkdir(parents=True)
+    (segment_dir / filename).write_bytes(bytes([segment_num]) * size)
+    # a sibling that must never be offered as a full log
+    (segment_dir / "qlog.zst").write_bytes(b"q")
+
+
+def _use_footage_root(monkeypatch, root):
+  monkeypatch.setattr(the_galaxy, "FOOTAGE_PATHS", [str(root) + "/"])
+
+
+def test_route_log_files_are_ordered_numerically(monkeypatch, tmp_path):
+  _make_route(tmp_path, "0000006a--9f0a7bdf9c", [0, 1, 2, 10])
+  _use_footage_root(monkeypatch, tmp_path)
+
+  logs = the_galaxy._route_log_files("0000006a--9f0a7bdf9c")
+
+  # 10 must sort after 2, not lexically between 1 and 2
+  assert [segment for segment, _, _, _ in logs] == [
+    "0000006a--9f0a7bdf9c--0",
+    "0000006a--9f0a7bdf9c--1",
+    "0000006a--9f0a7bdf9c--2",
+    "0000006a--9f0a7bdf9c--10",
+  ]
+  assert {filename for _, filename, _, _ in logs} == {"rlog.zst"}
+  assert [size for _, _, _, size in logs] == [32, 32, 32, 32]
+
+
+def test_route_log_files_prefers_newest_available_format(monkeypatch, tmp_path):
+  _make_route(tmp_path, "0000006a--9f0a7bdf9c", [0], filename="rlog.bz2")
+  (tmp_path / "0000006a--9f0a7bdf9c--0" / "rlog.zst").write_bytes(b"zstd")
+  _use_footage_root(monkeypatch, tmp_path)
+
+  logs = the_galaxy._route_log_files("0000006a--9f0a7bdf9c")
+
+  assert [filename for _, filename, _, _ in logs] == ["rlog.zst"]
+
+
+def test_route_log_files_rejects_names_that_are_not_routes(monkeypatch, tmp_path):
+  _make_route(tmp_path, "0000006a--9f0a7bdf9c", [0])
+  _use_footage_root(monkeypatch, tmp_path)
+
+  for name in ("", None, "..", "../..", "0000006a--9f0a7bdf9c--0", "0000006a--9f0a7bdf9cx", "/etc"):
+    assert the_galaxy._route_log_files(name) == [], name
+
+
+def test_route_log_files_skips_segments_without_logs(monkeypatch, tmp_path):
+  _make_route(tmp_path, "0000006a--9f0a7bdf9c", [0, 1])
+  (tmp_path / "0000006a--9f0a7bdf9c--1" / "rlog.zst").unlink()
+  _use_footage_root(monkeypatch, tmp_path)
+
+  logs = the_galaxy._route_log_files("0000006a--9f0a7bdf9c")
+
+  assert [segment for segment, _, _, _ in logs] == ["0000006a--9f0a7bdf9c--0"]
+
+
+def test_tar_buffer_hands_back_each_write_once():
+  buffer = the_galaxy._TarBuffer()
+
+  buffer.write(b"one")
+  buffer.write(b"two")
+
+  assert buffer.pop() == b"onetwo"
+  assert buffer.pop() == b""
+
+
+def test_streamed_archive_is_a_readable_tar(monkeypatch, tmp_path):
+  _make_route(tmp_path, "0000006a--9f0a7bdf9c", [0, 1], size=4096)
+  _use_footage_root(monkeypatch, tmp_path)
+  logs = the_galaxy._route_log_files("0000006a--9f0a7bdf9c")
+
+  buffer = the_galaxy._TarBuffer()
+  chunks = []
+  with tarfile.open(fileobj=buffer, mode="w|") as archive:
+    for segment, filename, path, _ in logs:
+      archive.add(path, arcname=f"{segment}/{filename}")
+      chunks.append(buffer.pop())
+  chunks.append(buffer.pop())
+
+  # more than one chunk means a long route never has to be buffered whole
+  assert sum(1 for chunk in chunks if chunk) > 1
+
+  with tarfile.open(fileobj=io.BytesIO(b"".join(chunks)), mode="r:") as archive:
+    assert archive.getnames() == [
+      "0000006a--9f0a7bdf9c--0/rlog.zst",
+      "0000006a--9f0a7bdf9c--1/rlog.zst",
+    ]
+    assert archive.extractfile("0000006a--9f0a7bdf9c--1/rlog.zst").read() == bytes([1]) * 4096

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -6482,8 +6482,10 @@ def setup(app):
         if not input_files:
           return {"error": "No video files found"}, 404
 
-        mp4_file = utilities.ffmpeg_concat_segments_to_mp4(input_files, cache_key=f"{name}-{camera}")
-        return send_file(mp4_file, mimetype="video/mp4")
+        response = Response(utilities.ffmpeg_stream_concatenated_mp4(input_files), mimetype="video/mp4")
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["X-Accel-Buffering"] = "no"
+        return response
 
     return {"error": "Route not found"}, 404
 

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -1124,7 +1124,11 @@ def _route_log_files(name):
 
   for footage_path in FOOTAGE_PATHS:
     logs = []
-    for segment in sorted(utilities.get_segments_in_route(name, footage_path), key=lambda s: int(s.rsplit("--", 1)[1])):
+    try:
+      segments = utilities.get_segments_in_route(name, footage_path)
+    except OSError:
+      continue
+    for segment in sorted(segments, key=lambda s: int(s.rsplit("--", 1)[1])):
       for filename in ROUTE_LOG_CANDIDATES:
         path = os.path.join(footage_path, segment, filename)
         if os.path.isfile(path):
@@ -1213,6 +1217,143 @@ except TypeError:
 
 # Full drive logs, newest format first. comma only accepts qlog/qcamera uploads, so these come off the device directly.
 ROUTE_LOG_CANDIDATES = ("rlog.zst", "rlog.bz2", "rlog")
+ROUTE_METADATA_WORKERS = 4
+ROUTE_METADATA_BATCH_SIZE = 8
+ROUTE_THUMBNAIL_CACHE_SECONDS = 7 * 24 * 60 * 60
+# Browsers only allow a handful of connections per origin, so a request must never
+# park on the preview queue: give up and let the card fall back, the job keeps running.
+ROUTE_THUMBNAIL_WAIT_SECONDS = 25
+_ROUTE_THUMBNAIL_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="route-thumbnail")
+_ROUTE_THUMBNAIL_FUTURES = {}
+_ROUTE_THUMBNAIL_LOCK = threading.Lock()
+
+
+def _route_scan_entries(footage_paths):
+  """Route scan entries in footage-root priority order, deduplicated by route id."""
+  entries = []
+  seen_names = set()
+  for footage_path in footage_paths:
+    try:
+      route_details = utilities.get_routes_with_segment_details(footage_path)
+    except OSError:
+      continue
+    for name, details in route_details:
+      if name in seen_names:
+        continue
+      seen_names.add(name)
+      entries.append((
+        footage_path,
+        name,
+        max(0, int(details.get("segmentCount", 0))),
+        max(0, int(details.get("firstSegmentNum", 0))),
+      ))
+  return entries
+
+
+def _route_metadata_events(entries, connect_dongle_id="", process_route=None):
+  """Yield SSE payloads while keeping queued metadata work cancellable."""
+  route_processor = process_route or utilities.process_route
+  total = len(entries)
+  yield {"routes": [], "progress": 0, "total": total, "connectDongleId": connect_dongle_id}
+  if total == 0:
+    return
+
+  executor = ThreadPoolExecutor(max_workers=ROUTE_METADATA_WORKERS, thread_name_prefix="route-metadata")
+  futures = []
+  try:
+    futures = [
+      executor.submit(route_processor, path, name, segment_count, first_segment_num)
+      for path, name, segment_count, first_segment_num in entries
+    ]
+    batch = []
+    for processed, future in enumerate(as_completed(futures), start=1):
+      try:
+        batch.append(future.result())
+      except Exception as exception:
+        print(f"Error processing route: {exception}")
+
+      if len(batch) >= ROUTE_METADATA_BATCH_SIZE or processed == total:
+        yield {"routes": batch, "progress": processed, "total": total}
+        batch = []
+  finally:
+    for future in futures:
+      future.cancel()
+    executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _route_first_segment_path(name, footage_path):
+  """Oldest surviving segment of a route. loggerd ages out --0 first, so it is not always --0."""
+  try:
+    segments = utilities.get_segments_in_route(name, footage_path)
+  except OSError:
+    return None
+  return os.path.join(footage_path, segments[0]) if segments else None
+
+
+def _resolve_route_thumbnail(file_path, footage_paths=None):
+  """Resolve only <segment>/preview.png below a configured footage root."""
+  parts = Path(str(file_path or "")).parts
+  if len(parts) != 2 or parts[1] != "preview.png" or not utilities.SEGMENT_RE.fullmatch(parts[0]):
+    return None
+
+  for footage_path in footage_paths if footage_paths is not None else FOOTAGE_PATHS:
+    footage_root = Path(footage_path).resolve()
+    segment_path = (footage_root / parts[0]).resolve()
+    if segment_path.parent != footage_root or not segment_path.is_dir():
+      continue
+    preview_path = segment_path / "preview.png"
+    if preview_path.is_symlink():
+      continue
+    if preview_path.exists():
+      resolved_preview = preview_path.resolve()
+      if resolved_preview.parent != segment_path:
+        continue
+      return resolved_preview
+    return preview_path
+  return None
+
+
+def _generate_route_thumbnail(preview_path):
+  if preview_path.is_file():
+    return preview_path
+
+  for filename in ("qcamera.ts", "fcamera.hevc"):
+    source_path = preview_path.parent / filename
+    if source_path.resolve().parent == preview_path.parent and source_path.is_file() and utilities.video_to_png(source_path, preview_path) and preview_path.is_file():
+      return preview_path
+  return None
+
+
+def _remove_route_thumbnail_future(key, future):
+  with _ROUTE_THUMBNAIL_LOCK:
+    if _ROUTE_THUMBNAIL_FUTURES.get(key) is future:
+      _ROUTE_THUMBNAIL_FUTURES.pop(key, None)
+
+
+def _get_or_create_route_thumbnail(file_path, footage_paths=None):
+  preview_path = _resolve_route_thumbnail(file_path, footage_paths)
+  if preview_path is None:
+    return None
+  if preview_path.is_file():
+    return preview_path
+
+  key = str(preview_path)
+  created = False
+  with _ROUTE_THUMBNAIL_LOCK:
+    future = _ROUTE_THUMBNAIL_FUTURES.get(key)
+    if future is None:
+      future = _ROUTE_THUMBNAIL_EXECUTOR.submit(_generate_route_thumbnail, preview_path)
+      _ROUTE_THUMBNAIL_FUTURES[key] = future
+      created = True
+
+  if created:
+    future.add_done_callback(lambda completed: _remove_route_thumbnail_future(key, completed))
+
+  try:
+    return future.result(timeout=ROUTE_THUMBNAIL_WAIT_SECONDS)
+  except TimeoutError:
+    # The completion callback keeps the running job deduplicated, then evicts it when done.
+    return None
 
 
 class _TarBuffer(io.RawIOBase):
@@ -6154,33 +6295,22 @@ def setup(app):
   @app.route("/api/routes", methods=["GET"])
   def list_routes():
     def generate():
-      routes = [
-        (path, name, segment_count)
-        for path in FOOTAGE_PATHS
-        for name, segment_count in utilities.get_routes_with_segment_counts(path)
-      ]
-      total = len(routes)
+      routes = _route_scan_entries(FOOTAGE_PATHS)
       connect_dongle_id = params.get("StockDongleId", encoding="utf-8") or params.get("DongleId", encoding="utf-8") or ""
-      yield f"data: {json.dumps({'progress': 0, 'total': total, 'connectDongleId': connect_dongle_id})}\n\n"
+      for payload in _route_metadata_events(routes, connect_dongle_id):
+        yield f"data: {json.dumps(payload)}\n\n"
 
-      with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = {
-          executor.submit(utilities.process_route, path, name, segment_count): (path, name)
-          for path, name, segment_count in routes
-        }
-        for processed, future in enumerate(as_completed(futures), start=1):
-          try:
-            result = future.result()
-            yield f"data: {json.dumps({'routes': [result]})}\n\n"
-          except Exception as exception:
-            print(f"Error processing route: {exception}")
-          yield f"data: {json.dumps({'progress': processed, 'total': total})}\n\n"
-
-    return Response(generate(), mimetype="text/event-stream")
+    response = Response(generate(), mimetype="text/event-stream")
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["X-Accel-Buffering"] = "no"
+    return response
 
   @app.route("/api/routes/<name>", methods=["DELETE"])
   def delete_route(name):
     for footage_path in FOOTAGE_PATHS:
+      if not os.path.isdir(footage_path):
+        continue
       for segment in os.listdir(footage_path):
         if segment.startswith(name):
           delete_file(os.path.join(footage_path, segment))
@@ -6226,21 +6356,21 @@ def setup(app):
 
   @app.route("/api/routes/<name>/preserve", methods=["POST"])
   def preserve_route(name):
-    preserved_routes = 0
+    preserved_routes = set()
     for footage_path in FOOTAGE_PATHS:
+      if not os.path.isdir(footage_path):
+        continue
       for segment in os.listdir(footage_path):
-        if segment.endswith("--0"):
-          segment_path = os.path.join(footage_path, segment)
-          if PRESERVE_ATTR_NAME in os.listxattr(segment_path) and os.getxattr(segment_path, PRESERVE_ATTR_NAME) == PRESERVE_ATTR_VALUE:
-            preserved_routes += 1
+        if utilities.SEGMENT_RE.fullmatch(segment) and utilities.has_preserve_attr(os.path.join(footage_path, segment)):
+          preserved_routes.add(segment.rsplit("--", 1)[0])
 
-    if preserved_routes >= PRESERVE_COUNT:
+    if name not in preserved_routes and len(preserved_routes) >= PRESERVE_COUNT:
       return {"error": f"Maximum of {PRESERVE_COUNT} preserved routes reached..."}, 400
 
     for footage_path in FOOTAGE_PATHS:
-      route_path = os.path.join(footage_path, f"{name}--0")
-      if os.path.exists(route_path):
-        os.setxattr(route_path, PRESERVE_ATTR_NAME, PRESERVE_ATTR_VALUE)
+      segment_path = _route_first_segment_path(name, footage_path)
+      if segment_path is not None:
+        os.setxattr(segment_path, PRESERVE_ATTR_NAME, PRESERVE_ATTR_VALUE)
         return {"message": "Route preserved!!"}, 200
 
     return {"error": "Route not found"}, 404
@@ -6248,9 +6378,9 @@ def setup(app):
   @app.route("/api/routes/<name>/preserve", methods=["DELETE"])
   def un_preserve_route(name):
     for footage_path in FOOTAGE_PATHS:
-      route_path = os.path.join(footage_path, f"{name}--0")
-      if PRESERVE_ATTR_NAME in os.listxattr(route_path):
-        os.removexattr(route_path, PRESERVE_ATTR_NAME)
+      segment_path = _route_first_segment_path(name, footage_path)
+      if segment_path is not None and utilities.has_preserve_attr(segment_path):
+        os.removexattr(segment_path, PRESERVE_ATTR_NAME)
         return {"message": "Route unpreserved!"}, 200
     return {"error": "Route not found"}, 404
 
@@ -6258,7 +6388,10 @@ def setup(app):
   def get_combined_route_video(name):
     camera = request.args.get("camera", "forward")
     for footage_path in FOOTAGE_PATHS:
-      segments = utilities.get_segments_in_route(name, footage_path)
+      try:
+        segments = utilities.get_segments_in_route(name, footage_path)
+      except OSError:
+        continue
       if segments:
         cam_file = {
           "forward": "fcamera.hevc",
@@ -6282,15 +6415,20 @@ def setup(app):
 
   @app.route("/api/routes/<name>", methods=["GET"])
   def get_route(name):
+    if not utilities.ROUTE_RE.fullmatch(name or ""):
+      return {"error": "Invalid route name"}, 400
     for footage_path in FOOTAGE_PATHS:
-      base_path = f"{footage_path}{name}--0"
-      if os.path.exists(base_path):
+      try:
         segments = utilities.get_segments_in_route(name, footage_path)
-        if not segments:
-          break
-
+      except OSError:
+        continue
+      if segments:
+        base_path = os.path.join(footage_path, segments[0])
         segment_urls = [f"/video/{segment}" for segment in segments]
-        total_duration = sum(utilities.get_video_duration(f"{footage_path}{name}--{i}/fcamera.hevc") for i in range(len(segment_urls)))
+        total_duration = sum(
+          utilities.get_video_duration(os.path.join(footage_path, segment, "fcamera.hevc"))
+          for segment in segments
+        )
         return {
           "name": name,
           "segment_urls": segment_urls,
@@ -6355,6 +6493,7 @@ def setup(app):
     return response
 
   @app.route("/api/routes/clear_name", methods=["POST"])
+  @app.route("/api/routes/reset_name", methods=["POST"])
   def clear_route_name():
     data = request.get_json()
     route_name = data.get("name")
@@ -6375,7 +6514,7 @@ def setup(app):
       for segment in segments_to_process:
         segment_dir = os.path.join(footage_path, segment)
         for item in os.listdir(segment_dir):
-          if not item.endswith((".hevc", ".ts", ".png", ".gif")) and item not in utilities.LOG_CANDIDATES:
+          if utilities.is_route_marker_file(item):
             try:
               os.remove(os.path.join(segment_dir, item))
               cleared = True
@@ -6414,7 +6553,7 @@ def setup(app):
       for segment in segments_to_process:
         segment_dir = os.path.join(footage_path, segment)
         for item in os.listdir(segment_dir):
-          if not item.endswith((".hevc", ".ts", ".png", ".gif", "rlog")):
+          if utilities.is_route_marker_file(item):
             try:
               os.remove(os.path.join(segment_dir, item))
             except OSError:
@@ -8768,10 +8907,18 @@ def setup(app):
 
   @app.route("/thumbnails/<path:file_path>", methods=["GET"])
   def get_thumbnail(file_path):
-    for footage_path in FOOTAGE_PATHS:
-      if os.path.exists(os.path.join(footage_path, file_path)):
-        return send_from_directory(footage_path, file_path, as_attachment=True)
-    return {"error": "Thumbnail not found"}, 404
+    preview_path = _get_or_create_route_thumbnail(file_path)
+    if preview_path is None:
+      return {"error": "Thumbnail not found"}, 404
+
+    response = send_file(
+      preview_path,
+      mimetype="image/png",
+      conditional=True,
+      max_age=ROUTE_THUMBNAIL_CACHE_SECONDS,
+    )
+    response.headers["Cache-Control"] = f"public, max-age={ROUTE_THUMBNAIL_CACHE_SECONDS}"
+    return response
 
   @app.route("/video/<path>", methods=["GET"])
   def get_video(path):

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -1223,6 +1223,15 @@ ROUTE_THUMBNAIL_CACHE_SECONDS = 7 * 24 * 60 * 60
 # Browsers only allow a handful of connections per origin, so a request must never
 # park on the preview queue: give up and let the card fall back, the job keeps running.
 ROUTE_THUMBNAIL_WAIT_SECONDS = 25
+# One minute per segment, matching loggerd's segment length.
+SEGMENT_DURATION_SECONDS = 60
+# Only ever remux one segment at a time; the driving stack needs the headroom.
+VIDEO_REMUX_WAIT_SECONDS = 25
+# Segment media never changes once loggerd has closed it, so let the browser keep it.
+VIDEO_CACHE_SECONDS = 7 * 24 * 60 * 60
+_VIDEO_REMUX_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="video-remux")
+_VIDEO_REMUX_FUTURES = {}
+_VIDEO_REMUX_LOCK = threading.Lock()
 _ROUTE_THUMBNAIL_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="route-thumbnail")
 _ROUTE_THUMBNAIL_FUTURES = {}
 _ROUTE_THUMBNAIL_LOCK = threading.Lock()
@@ -1322,6 +1331,36 @@ def _generate_route_thumbnail(preview_path):
     if source_path.resolve().parent == preview_path.parent and source_path.is_file() and utilities.video_to_png(source_path, preview_path) and preview_path.is_file():
       return preview_path
   return None
+
+
+def _remove_video_remux_future(key, future):
+  with _VIDEO_REMUX_LOCK:
+    if _VIDEO_REMUX_FUTURES.get(key) is future:
+      _VIDEO_REMUX_FUTURES.pop(key, None)
+
+
+def _get_or_create_segment_mp4(source_path):
+  """Remuxed mp4 for one segment, or None if it is not ready in time.
+
+  Concurrent requests share one ffmpeg run instead of racing to write the same file.
+  """
+  key = str(source_path)
+  created = False
+  with _VIDEO_REMUX_LOCK:
+    future = _VIDEO_REMUX_FUTURES.get(key)
+    if future is None:
+      future = _VIDEO_REMUX_EXECUTOR.submit(utilities.ffmpeg_mp4_wrap_to_path, source_path)
+      _VIDEO_REMUX_FUTURES[key] = future
+      created = True
+
+  if created:
+    future.add_done_callback(lambda completed: _remove_video_remux_future(key, completed))
+
+  try:
+    return future.result(timeout=VIDEO_REMUX_WAIT_SECONDS)
+  except TimeoutError:
+    # The callback keeps the running job deduplicated, then evicts it when done.
+    return None
 
 
 def _remove_route_thumbnail_future(key, future):
@@ -6425,14 +6464,13 @@ def setup(app):
       if segments:
         base_path = os.path.join(footage_path, segments[0])
         segment_urls = [f"/video/{segment}" for segment in segments]
-        total_duration = sum(
-          utilities.get_video_duration(os.path.join(footage_path, segment, "fcamera.hevc"))
-          for segment in segments
-        )
+        # Probing each segment cost an ffprobe before playback could even start,
+        # and segments are a fixed minute anyway.
+        total_duration = len(segments) * SEGMENT_DURATION_SECONDS
         return {
           "name": name,
           "segment_urls": segment_urls,
-          "total_duration": round(total_duration),
+          "total_duration": total_duration,
           "date": utilities.get_route_start_time(base_path),
           "available_cameras": utilities.get_available_cameras(base_path),
         }, 200
@@ -8922,65 +8960,43 @@ def setup(app):
 
   @app.route("/video/<path>", methods=["GET"])
   def get_video(path):
+    if not utilities.SEGMENT_RE.fullmatch(path or ""):
+      return {"error": "Invalid segment name"}, 400
+
     camera = request.args.get("camera")
     filename = {"driver": "dcamera.hevc", "wide": "ecamera.hevc"}.get(camera, "fcamera.hevc")
+
+    # loggerd writes qcamera.ts as H.264 in MPEG-TS, so it plays with no ffmpeg at
+    # all. It exists for the road camera only, so other views skip this tier.
+    if request.args.get("quality") == "low" and filename == "fcamera.hevc":
+      for footage_path in FOOTAGE_PATHS:
+        preview_path = os.path.join(footage_path, path, "qcamera.ts")
+        if os.path.isfile(preview_path):
+          return send_file(
+            preview_path,
+            mimetype="video/mp2t",
+            conditional=True,
+            max_age=VIDEO_CACHE_SECONDS,
+          )
+      return {"error": "Low quality video not available"}, 404
+
     for footage_path in FOOTAGE_PATHS:
-      filepath = f"{footage_path}{path}/{filename}"
+      filepath = os.path.join(footage_path, path, filename)
       if os.path.exists(filepath):
-        file_handle = utilities.ffmpeg_mp4_wrap_process_builder(filepath)
+        try:
+          cache_path = _get_or_create_segment_mp4(filepath)
+        except (FileNotFoundError, ValueError) as error:
+          return {"error": str(error)}, 409
+        if cache_path is None:
+          return {"error": "Video is still being prepared"}, 503
 
-        file_handle.seek(0, 2)
-        file_size = file_handle.tell()
-        file_handle.seek(0)
-
-        range_header = request.headers.get('Range', None)
-        if range_header:
-          byte_start = 0
-          byte_end = file_size - 1
-
-          if range_header.startswith('bytes='):
-            range_spec = range_header[6:]
-            if '-' in range_spec:
-              start, end = range_spec.split('-', 1)
-              if start:
-                byte_start = max(0, int(start))
-              if end:
-                byte_end = min(file_size - 1, int(end))
-
-          if byte_start >= file_size:
-            file_handle.close()
-            return Response("Requested Range Not Satisfiable", 416)
-
-          byte_end = max(byte_start, byte_end)
-
-          file_handle.seek(byte_start)
-          read_length = byte_end - byte_start + 1
-          data = file_handle.read(read_length)
-
-          response = Response(
-            data,
-            206,
-            headers={
-              'Content-Range': f'bytes {byte_start}-{byte_end}/{file_size}',
-              'Accept-Ranges': 'bytes',
-              'Content-Length': str(len(data)),
-              'Content-Type': 'video/mp4'
-            }
-          )
-        else:
-          data = file_handle.read()
-          response = Response(
-            data,
-            200,
-            headers={
-              'Accept-Ranges': 'bytes',
-              'Content-Length': str(file_size),
-              'Content-Type': 'video/mp4'
-            }
-          )
-
-        file_handle.close()
-        return response
+        # send_file streams from disk and handles Range and ETag itself.
+        return send_file(
+          cache_path,
+          mimetype="video/mp4",
+          conditional=True,
+          max_age=VIDEO_CACHE_SECONDS,
+        )
     return {"error": "Video not found"}, 404
 
 def main():

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -10,6 +10,7 @@ import sys
 import sysconfig
 import tarfile
 
+import io
 from io import BytesIO
 from pathlib import Path
 
@@ -1116,6 +1117,24 @@ def _get_toggle_backup_keys():
   return keys
 
 
+def _route_log_files(name):
+  """Full logs for a route as [(segment, filename, path, size)], oldest segment first."""
+  if not utilities.ROUTE_RE.match(name or ""):
+    return []
+
+  for footage_path in FOOTAGE_PATHS:
+    logs = []
+    for segment in sorted(utilities.get_segments_in_route(name, footage_path), key=lambda s: int(s.rsplit("--", 1)[1])):
+      for filename in ROUTE_LOG_CANDIDATES:
+        path = os.path.join(footage_path, segment, filename)
+        if os.path.isfile(path):
+          logs.append((segment, filename, path, os.path.getsize(path)))
+          break
+    if logs:
+      return logs
+  return []
+
+
 def _coerce_toggle_restore_value(key, value):
   value_type = _get_param_key_type(_params_raw, key)
 
@@ -1191,6 +1210,29 @@ except TypeError:
     "/data/media/0/realdata_konik/",
     str(Paths.log_root()),
   ]
+
+# Full drive logs, newest format first. comma only accepts qlog/qcamera uploads, so these come off the device directly.
+ROUTE_LOG_CANDIDATES = ("rlog.zst", "rlog.bz2", "rlog")
+
+
+class _TarBuffer(io.RawIOBase):
+  """Collects tarfile output so a route archive can be streamed out instead of built on disk."""
+
+  def __init__(self):
+    self._chunks = []
+
+  def writable(self):
+    return True
+
+  def write(self, data):
+    self._chunks.append(bytes(data))
+    return len(data)
+
+  def pop(self):
+    data = b"".join(self._chunks)
+    self._chunks.clear()
+    return data
+
 
 KEYS = {
   "amap1": ("amap1", "", "AMapKey1", "AMap / Gaode key #1", 39),
@@ -6257,6 +6299,60 @@ def setup(app):
           "available_cameras": utilities.get_available_cameras(base_path),
         }, 200
     return {"error": "Route not found"}, 404
+
+  @app.route("/api/routes/<name>/logs", methods=["GET"])
+  def list_route_logs(name):
+    logs = _route_log_files(name)
+    if not logs:
+      return jsonify({"error": "No full logs are stored on the device for this route."}), 404
+
+    return jsonify({
+      "name": name,
+      "totalBytes": sum(size for *_, size in logs),
+      "segments": [
+        {
+          "segment": segment,
+          "segmentNum": int(segment.rsplit("--", 1)[1]),
+          "filename": filename,
+          "bytes": size,
+          "url": f"/api/routes/{name}/logs/{int(segment.rsplit('--', 1)[1])}",
+        }
+        for segment, filename, _, size in logs
+      ],
+    }), 200
+
+  @app.route("/api/routes/<name>/logs/<int:segment_num>", methods=["GET"])
+  def download_route_log(name, segment_num):
+    for segment, filename, path, _ in _route_log_files(name):
+      if int(segment.rsplit("--", 1)[1]) == segment_num:
+        return send_file(path, as_attachment=True, download_name=f"{segment}-{filename}")
+    return jsonify({"error": "No full log is stored on the device for this segment."}), 404
+
+  @app.route("/api/routes/<name>/logs/download", methods=["GET"])
+  def download_route_logs_archive(name):
+    logs = _route_log_files(name)
+    if not logs:
+      return jsonify({"error": "No full logs are stored on the device for this route."}), 404
+
+    def generate():
+      buffer = _TarBuffer()
+      # streamed a file at a time so a long route never needs its whole archive in memory
+      with tarfile.open(fileobj=buffer, mode="w|") as archive:
+        for segment, filename, path, _ in logs:
+          try:
+            archive.add(path, arcname=f"{segment}/{filename}")
+          except OSError:
+            continue
+          chunk = buffer.pop()
+          if chunk:
+            yield chunk
+      chunk = buffer.pop()
+      if chunk:
+        yield chunk
+
+    response = Response(generate(), mimetype="application/x-tar")
+    response.headers["Content-Disposition"] = f'attachment; filename="{name}-logs.tar"'
+    return response
 
   @app.route("/api/routes/clear_name", methods=["POST"])
   def clear_route_name():

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -1225,8 +1225,9 @@ ROUTE_THUMBNAIL_CACHE_SECONDS = 7 * 24 * 60 * 60
 ROUTE_THUMBNAIL_WAIT_SECONDS = 25
 # One minute per segment, matching loggerd's segment length.
 SEGMENT_DURATION_SECONDS = 60
-# Only ever remux one segment at a time; the driving stack needs the headroom.
-VIDEO_REMUX_WAIT_SECONDS = 25
+# Only ever remux one segment at a time; the driving stack needs the headroom. The
+# subprocess timeout is the hard bound, with a small allowance for executor handoff.
+VIDEO_REMUX_WAIT_SECONDS = utilities.VIDEO_REMUX_TIMEOUT_SECONDS + 5
 # Segment media never changes once loggerd has closed it, so let the browser keep it.
 VIDEO_CACHE_SECONDS = 7 * 24 * 60 * 60
 _VIDEO_REMUX_EXECUTOR = ThreadPoolExecutor(max_workers=1, thread_name_prefix="video-remux")
@@ -8966,19 +8967,26 @@ def setup(app):
     camera = request.args.get("camera")
     filename = {"driver": "dcamera.hevc", "wide": "ecamera.hevc"}.get(camera, "fcamera.hevc")
 
-    # loggerd writes qcamera.ts as H.264 in MPEG-TS, so it plays with no ffmpeg at
-    # all. It exists for the road camera only, so other views skip this tier.
+    # qcamera.ts is a 526x330 companion to the road camera, so wrapping it costs a
+    # fraction of the full stream. It still needs the mp4 wrap - a bare MPEG-TS will
+    # not play in a <video>. Anything missing falls through to the full stream.
     if request.args.get("quality") == "low" and filename == "fcamera.hevc":
       for footage_path in FOOTAGE_PATHS:
         preview_path = os.path.join(footage_path, path, "qcamera.ts")
-        if os.path.isfile(preview_path):
-          return send_file(
-            preview_path,
-            mimetype="video/mp2t",
-            conditional=True,
-            max_age=VIDEO_CACHE_SECONDS,
-          )
-      return {"error": "Low quality video not available"}, 404
+        if not os.path.isfile(preview_path):
+          continue
+        try:
+          preview_mp4 = _get_or_create_segment_mp4(preview_path)
+        except (FileNotFoundError, ValueError):
+          break
+        if preview_mp4 is None:
+          return {"error": "Preview video is still being prepared"}, 503
+        return send_file(
+          preview_mp4,
+          mimetype="video/mp4",
+          conditional=True,
+          max_age=VIDEO_CACHE_SECONDS,
+        )
 
     for footage_path in FOOTAGE_PATHS:
       filepath = os.path.join(footage_path, path, filename)

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -6366,6 +6366,7 @@ def setup(app):
 
     try:
       utilities.stop_dashboard_background_analysis()
+      include_preserved = request.args.get("include_preserved", "true").strip().lower() not in ("0", "false", "no", "off")
 
       route_paths = []
       seen_paths = set()
@@ -6375,18 +6376,51 @@ def setup(app):
           seen_paths.add(path)
           route_paths.append(path)
 
-      for route_path in route_paths:
-        _run_factory_reset_delete(route_path)
+      preserved_route_names = set()
+      deleted_route_names = set()
+      if include_preserved:
+        for route_path in route_paths:
+          _run_factory_reset_delete(route_path)
+      else:
+        # The preserve xattr lives on one segment, but preservation applies to the
+        # whole route in every footage root.
+        for route_path in route_paths:
+          if not os.path.isdir(route_path):
+            continue
+          for segment in os.listdir(route_path):
+            if utilities.SEGMENT_RE.fullmatch(segment) and utilities.has_preserve_attr(os.path.join(route_path, segment)):
+              preserved_route_names.add(segment.rsplit("--", 1)[0])
 
-      persisted_route_count = utilities.clear_dashboard_route_history(params)
+        for route_path in route_paths:
+          if not os.path.isdir(route_path):
+            continue
+          for segment in os.listdir(route_path):
+            if not utilities.SEGMENT_RE.fullmatch(segment):
+              continue
+            route_name = segment.rsplit("--", 1)[0]
+            if route_name in preserved_route_names:
+              continue
+            delete_file(os.path.join(route_path, segment))
+            deleted_route_names.add(route_name)
+
+      persisted_route_count = utilities.clear_dashboard_route_history(
+        params,
+        retained_route_names=preserved_route_names if not include_preserved else None,
+      )
       _STATS_RESPONSE_CACHE.update({
         "updated_at": 0.0,
         "payload": None,
       })
       return jsonify({
         "success": True,
-        "message": "All local driving routes deleted. Saved personal records were kept.",
-        "deletedPaths": len(route_paths),
+        "message": (
+          "All local driving routes deleted, including preserved routes. Saved personal records were kept."
+          if include_preserved else
+          "All non-preserved local driving routes deleted. Preserved routes were kept."
+        ),
+        "deletedPaths": len(route_paths) if include_preserved else 0,
+        "deletedRoutes": len(deleted_route_names) if not include_preserved else None,
+        "preservedRoutes": len(preserved_route_names) if not include_preserved else 0,
         "clearedDashboardRoutes": persisted_route_count,
       }), 200
     except Exception as exception:

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -6644,7 +6644,7 @@ def setup(app):
           return jsonify({"error": f"Error creating new name file: {e}"}), 500
 
     if renamed:
-      return jsonify({"message": "Route renamed successfully!"}), 200
+      return jsonify({"message": "Route renamed successfully!", "name": new_name}), 200
     else:
       return jsonify({"error": "Route not found"}), 404
 

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -12,6 +12,7 @@ import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 
@@ -748,6 +749,50 @@ def ffmpeg_concat_segments_to_mp4(input_files, cache_key=None):
       list_file.unlink()
 
   return open(cache_path, "rb")
+
+
+def ffmpeg_stream_concatenated_mp4(input_files, chunk_size=256 * 1024):
+  """Stream-copy camera segments as fragmented MP4 without building a full cache file."""
+  if not input_files:
+    raise ValueError("No input files provided for concatenation")
+
+  VIDEO_CACHE_PATH.mkdir(exist_ok=True)
+  with tempfile.NamedTemporaryFile("w", suffix=".txt", prefix="route-download-", dir=VIDEO_CACHE_PATH, delete=False) as list_file:
+    list_path = Path(list_file.name)
+    for segment in input_files:
+      list_file.write(f"file '{Path(segment)}'\n")
+
+  process = None
+  try:
+    process = subprocess.Popen(
+      [FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-f", "concat", "-safe", "0",
+       "-i", str(list_path), "-c", "copy", "-movflags", "frag_keyframe+empty_moov+default_base_moof",
+       "-f", "mp4", "pipe:1"],
+      stdout=subprocess.PIPE,
+      stderr=subprocess.DEVNULL,
+    )
+    while True:
+      chunk = process.stdout.read(chunk_size)
+      if not chunk:
+        break
+      yield chunk
+    if process.wait() != 0:
+      raise ValueError("Could not stream the combined route video")
+  finally:
+    if process is not None:
+      if process.stdout is not None:
+        process.stdout.close()
+      if process.poll() is None:
+        process.terminate()
+        try:
+          process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+          process.kill()
+          process.wait()
+    try:
+      list_path.unlink()
+    except OSError:
+      pass
 
 def ffmpeg_mp4_wrap_to_path(filename):
   """Remux one raw .hevc segment to mp4 and return the cache path.

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -669,6 +669,9 @@ FFPROBE_BIN = _resolve_ffmpeg_binary("ffprobe")
 # Bound the cache by its own size rather than reacting to free space: loggerd already
 # keeps the disk near full, so the old policy wiped every mp4 on almost every request.
 VIDEO_CACHE_MAX_BYTES = 512 * 1024 * 1024
+# A malformed or truncated segment must not occupy the Galaxy's only remux worker
+# forever. Stream-copy normally finishes in seconds; this also bounds the fallback.
+VIDEO_REMUX_TIMEOUT_SECONDS = 60
 
 
 def _prune_video_cache(keep_path=None):
@@ -772,15 +775,31 @@ def ffmpeg_mp4_wrap_to_path(filename):
     return cache_path
 
   _prune_video_cache(keep_path=cache_path)
+  deadline = time.monotonic() + VIDEO_REMUX_TIMEOUT_SECONDS
+
+  def remaining_time():
+    return max(0.1, deadline - time.monotonic())
 
   try:
-    subprocess.run([FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-i", str(input_path), "-c", "copy", "-movflags", "faststart", "-y", str(cache_path)], check=True)
+    subprocess.run(
+      [FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-i", str(input_path),
+       "-c", "copy", "-movflags", "faststart", "-y", str(cache_path)],
+      check=True,
+      timeout=remaining_time(),
+    )
+  except subprocess.TimeoutExpired:
+    cache_path.unlink(missing_ok=True)
+    raise ValueError(f"Timed out processing video file: {input_path}")
   except subprocess.CalledProcessError:
     try:
-      subprocess.run([FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-i", str(input_path), "-c:v", "libx264", "-movflags", "faststart", "-y", str(cache_path)], check=True)
-    except subprocess.CalledProcessError:
-      if cache_path.exists():
-        cache_path.unlink()
+      subprocess.run(
+        [FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-i", str(input_path),
+         "-c:v", "libx264", "-movflags", "faststart", "-y", str(cache_path)],
+        check=True,
+        timeout=remaining_time(),
+      )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+      cache_path.unlink(missing_ok=True)
       raise ValueError(f"Cannot process video file: {input_path}")
 
   return cache_path

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -650,6 +650,57 @@ def encode_parameters(params_dict):
   encoded_data = base64.b64encode(obfuscated_data.encode("utf-8")).decode("utf-8")
   return encoded_data
 
+# The venv ships ffmpeg/ffprobe as console scripts that exec the real binary only
+# after a full CPython startup. Resolve past the shim once and skip that per call.
+def _resolve_ffmpeg_binary(name):
+  try:
+    import ffmpeg as ffmpeg_package
+    candidate = Path(ffmpeg_package.__file__).parent / "install" / "bin" / name
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+      return str(candidate)
+  except Exception:
+    pass
+  return shutil.which(name) or name
+
+
+FFMPEG_BIN = _resolve_ffmpeg_binary("ffmpeg")
+FFPROBE_BIN = _resolve_ffmpeg_binary("ffprobe")
+
+# Bound the cache by its own size rather than reacting to free space: loggerd already
+# keeps the disk near full, so the old policy wiped every mp4 on almost every request.
+VIDEO_CACHE_MAX_BYTES = 512 * 1024 * 1024
+
+
+def _prune_video_cache(keep_path=None):
+  """Evict oldest-first until the cache fits its budget."""
+  try:
+    entries = []
+    for cache_file in VIDEO_CACHE_PATH.glob("*.mp4"):
+      try:
+        stat = cache_file.stat()
+      except OSError:
+        continue
+      entries.append((stat.st_mtime, stat.st_size, cache_file))
+  except OSError:
+    return
+
+  total = sum(size for _, size, _ in entries)
+  if total <= VIDEO_CACHE_MAX_BYTES:
+    return
+
+  keep = str(keep_path) if keep_path else None
+  for _, size, cache_file in sorted(entries):
+    if total <= VIDEO_CACHE_MAX_BYTES:
+      break
+    if keep and str(cache_file) == keep:
+      continue
+    try:
+      cache_file.unlink()
+      total -= size
+    except OSError:
+      pass
+
+
 def ffmpeg_concat_segments_to_mp4(input_files, cache_key=None):
   if not input_files:
     raise ValueError("No input files provided for concatenation")
@@ -665,6 +716,8 @@ def ffmpeg_concat_segments_to_mp4(input_files, cache_key=None):
   if cache_path.exists() and all(cache_path.stat().st_mtime > Path(f).stat().st_mtime for f in input_files):
     return open(cache_path, "rb")
 
+  _prune_video_cache(keep_path=cache_path)
+
   list_file = VIDEO_CACHE_PATH / f"{file_hash}.txt"
   with open(list_file, "w") as f:
     for seg in input_files:
@@ -672,14 +725,14 @@ def ffmpeg_concat_segments_to_mp4(input_files, cache_key=None):
 
   try:
     subprocess.run(
-      ["ffmpeg", "-hide_banner", "-loglevel", "error", "-f", "concat", "-safe", "0",
+      [FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-f", "concat", "-safe", "0",
        "-i", str(list_file), "-c", "copy", "-movflags", "faststart", "-y", str(cache_path)],
       check=True
     )
   except subprocess.CalledProcessError:
     try:
       subprocess.run(
-        ["ffmpeg", "-hide_banner", "-loglevel", "error", "-f", "concat", "-safe", "0",
+        [FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-f", "concat", "-safe", "0",
          "-i", str(list_file), "-c:v", "libx264", "-movflags", "faststart", "-y", str(cache_path)],
         check=True
       )
@@ -693,7 +746,11 @@ def ffmpeg_concat_segments_to_mp4(input_files, cache_key=None):
 
   return open(cache_path, "rb")
 
-def ffmpeg_mp4_wrap_process_builder(filename):
+def ffmpeg_mp4_wrap_to_path(filename):
+  """Remux one raw .hevc segment to mp4 and return the cache path.
+
+  Callers get a path, not a handle, so send_file can stream it without reading it all.
+  """
   input_path = Path(filename)
 
   if not input_path.exists():
@@ -708,31 +765,29 @@ def ffmpeg_mp4_wrap_process_builder(filename):
 
   VIDEO_CACHE_PATH.mkdir(exist_ok=True)
 
-  total, used, free = shutil.disk_usage(VIDEO_CACHE_PATH)
-  if free < 500 * 1024 * 1024:
-    for cache_file in VIDEO_CACHE_PATH.glob("*.mp4"):
-      try:
-        cache_file.unlink()
-      except:
-        pass
-
   file_hash = hashlib.md5(str(input_path).encode()).hexdigest()
   cache_path = VIDEO_CACHE_PATH / f"{file_hash}.mp4"
 
   if cache_path.exists() and cache_path.stat().st_mtime > input_path.stat().st_mtime:
-    return open(cache_path, "rb")
+    return cache_path
+
+  _prune_video_cache(keep_path=cache_path)
 
   try:
-    subprocess.run(["ffmpeg", "-hide_banner", "-loglevel", "error", "-i", str(input_path), "-c", "copy", "-movflags", "faststart", "-y", str(cache_path)], check=True)
+    subprocess.run([FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-i", str(input_path), "-c", "copy", "-movflags", "faststart", "-y", str(cache_path)], check=True)
   except subprocess.CalledProcessError:
     try:
-      subprocess.run(["ffmpeg", "-hide_banner", "-loglevel", "error", "-i", str(input_path), "-c:v", "libx264", "-movflags", "faststart", "-y", str(cache_path)], check=True)
+      subprocess.run([FFMPEG_BIN, "-hide_banner", "-loglevel", "error", "-i", str(input_path), "-c:v", "libx264", "-movflags", "faststart", "-y", str(cache_path)], check=True)
     except subprocess.CalledProcessError:
       if cache_path.exists():
         cache_path.unlink()
       raise ValueError(f"Cannot process video file: {input_path}")
 
-  return open(cache_path, "rb")
+  return cache_path
+
+
+def ffmpeg_mp4_wrap_process_builder(filename):
+  return open(ffmpeg_mp4_wrap_to_path(filename), "rb")
 
 def format_git_date(raw_date: str):
   date_object = datetime.strptime(raw_date.split()[1], "%Y-%m-%d")
@@ -3014,7 +3069,7 @@ def get_segments_in_route(route_time_str, footage_path):
 def get_video_duration(input_path):
   try:
     result = subprocess.run([
-      "ffprobe", "-v", "error", "-show_entries", "format=duration",
+      FFPROBE_BIN, "-v", "error", "-show_entries", "format=duration",
       "-of", "default=noprint_wrappers=1:nokey=1", str(input_path)
     ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
     return float(result.stdout)
@@ -3105,7 +3160,7 @@ VIDEO_TO_PNG_TIMEOUT_SECONDS = 20
 def video_to_png(input_path, output_path):
   try:
     subprocess.run([
-      "ffmpeg", "-hide_banner", "-loglevel", "error",
+      FFMPEG_BIN, "-hide_banner", "-loglevel", "error",
       "-ss", "1",
       "-i", str(input_path),
       "-frames:v", "1",

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -1773,12 +1773,30 @@ def _invalidate_dashboard_cache():
   })
 
 
-def clear_dashboard_route_history(params_obj):
-  """Remove route-backed dashboard history while keeping durable records."""
+def clear_dashboard_route_history(params_obj, retained_route_names=None):
+  """Remove route-backed dashboard history while keeping durable records and optional retained routes."""
   stats = _load_dashboard_persistent_stats(params_obj)
-  route_count = len(stats.get("routes", {}))
-  stats["routes"] = {}
-  stats["ignoredRoutes"] = []
+  routes = stats.get("routes", {})
+  retained_routes = None if retained_route_names is None else {
+    str(route_name or "").strip()
+    for route_name in retained_route_names
+    if ROUTE_RE.fullmatch(str(route_name or "").strip())
+  }
+  if retained_routes is None:
+    stats["routes"] = {}
+    stats["ignoredRoutes"] = []
+  else:
+    stats["routes"] = {
+      route_name: entry
+      for route_name, entry in routes.items()
+      if route_name in retained_routes
+    }
+    stats["ignoredRoutes"] = [
+      route_name
+      for route_name in stats.get("ignoredRoutes", [])
+      if route_name in retained_routes
+    ]
+  route_count = len(routes) - len(stats["routes"])
   serialized = json.dumps(stats, separators=(",", ":"))
 
   persisted_to_params = False

--- a/starpilot/system/the_galaxy/utilities.py
+++ b/starpilot/system/the_galaxy/utilities.py
@@ -15,7 +15,7 @@ import sys
 import threading
 import time
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List
 from urllib.parse import quote
@@ -2993,19 +2993,23 @@ def get_routes_names(footage_path):
   route_times = {segment.route_name.time_str for segment in segments}
   return sorted(route_times, reverse=True)
 
-def get_routes_with_segment_counts(footage_path):
-  route_counts = {}
+def get_routes_with_segment_details(footage_path):
+  route_details = {}
   for segment in get_all_segment_names(footage_path):
     route_name = segment.route_name.time_str
-    route_counts[route_name] = route_counts.get(route_name, 0) + 1
-  return sorted(route_counts.items(), reverse=True)
+    segment_num = int(getattr(segment, "segment_num", 0))
+    details = route_details.setdefault(route_name, {"segmentCount": 0, "firstSegmentNum": segment_num})
+    details["segmentCount"] += 1
+    details["firstSegmentNum"] = min(details["firstSegmentNum"], segment_num)
+  return sorted(route_details.items(), reverse=True)
 
 def get_segments_in_route(route_time_str, footage_path):
-  return [
+  segments = [
     f"{segment.time_str}--{segment.segment_num}"
     for segment in get_all_segment_names(footage_path)
     if segment.time_str == route_time_str
   ]
+  return sorted(segments, key=lambda segment: int(segment.rsplit("--", 1)[1]))
 
 def get_video_duration(input_path):
   try:
@@ -3018,7 +3022,10 @@ def get_video_duration(input_path):
     return 60
 
 def has_preserve_attr(path: str):
-  return PRESERVE_ATTR_NAME in os.listxattr(path) and os.getxattr(path, PRESERVE_ATTR_NAME) == PRESERVE_ATTR_VALUE
+  try:
+    return PRESERVE_ATTR_NAME in os.listxattr(path) and os.getxattr(path, PRESERVE_ATTR_NAME) == PRESERVE_ATTR_VALUE
+  except (AttributeError, OSError):
+    return False
 
 def list_file(path):
   return sorted(os.listdir(path), reverse=True)
@@ -3035,30 +3042,35 @@ def normalize_theme_name(name, for_path=False):
     return f"{normalized_parts[0]} ({' '.join(normalized_parts[1:])})".replace(" Week", "")
   return ' '.join(normalized_parts).replace(" Week", "")
 
-def process_route(footage_path, route_name, segment_count=0):
-  segment_path = f"{footage_path}{route_name}--0"
-  qcamera_path = f"{segment_path}/qcamera.ts"
+def is_route_marker_file(filename):
+  """A renamed route stores its display name as an empty marker file in the segment."""
+  return not filename.endswith((".hevc", ".ts", ".png", ".gif")) and filename not in LOG_CANDIDATES
 
-  png_output_path = os.path.join(segment_path, "preview.png")
-  if not os.path.exists(png_output_path):
-    video_to_png(qcamera_path, png_output_path)
+def _utc_rfc3339(value):
+  if value is None:
+    return None
+  # Naive values come off the filesystem in local time; astimezone reads them that way.
+  return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
+def process_route(footage_path, route_name, segment_count=0, first_segment_num=0):
+  segment_name = f"{route_name}--{max(0, int(first_segment_num))}"
+  segment_path = os.path.join(footage_path, segment_name)
   custom_name = None
   if os.path.isdir(segment_path):
     for item in os.listdir(segment_path):
-      if not item.endswith((".hevc", ".ts", ".png", ".gif")) and item not in LOG_CANDIDATES:
+      if is_route_marker_file(item):
         custom_name = item
         break
 
-  route_timestamp_str = custom_name
-  if not custom_name:
-    route_timestamp_dt = get_route_start_time(segment_path)
-    route_timestamp_str = route_timestamp_dt.isoformat() if route_timestamp_dt else None
+  route_timestamp_dt = get_route_start_time(segment_path)
+  route_timestamp_str = custom_name or (route_timestamp_dt.isoformat() if route_timestamp_dt else None)
 
   return {
     "name": route_name,
-    "png": f"/thumbnails/{route_name}--0/preview.png",
+    "png": f"/thumbnails/{segment_name}/preview.png",
     "timestamp": route_timestamp_str,
+    "startedAt": _utc_rfc3339(route_timestamp_dt),
+    "isCustomName": custom_name is not None,
     "is_preserved": has_preserve_attr(segment_path),
     "segmentCount": max(0, int(segment_count)),
     "approxDurationSeconds": max(0, int(segment_count)) * 60,
@@ -3088,6 +3100,8 @@ def segment_to_segment_name(data_dir, segment):
   full_path = os.path.join(data_dir, f"FakeDongleID1337|{segment}")
   return SegmentName(full_path)
 
+VIDEO_TO_PNG_TIMEOUT_SECONDS = 20
+
 def video_to_png(input_path, output_path):
   try:
     subprocess.run([
@@ -3097,11 +3111,17 @@ def video_to_png(input_path, output_path):
       "-frames:v", "1",
       "-y",
       str(output_path)
-    ], capture_output=True, check=True, text=True)
-  except subprocess.CalledProcessError as e:
+    ], capture_output=True, check=True, text=True, timeout=VIDEO_TO_PNG_TIMEOUT_SECONDS)
+    return os.path.isfile(output_path)
+  except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
     print(f"Failed to generate PNG for {input_path}")
-    if e.stderr:
+    if getattr(e, "stderr", None):
       print(e.stderr)
+    try:
+      Path(output_path).unlink(missing_ok=True)
+    except OSError:
+      pass
+    return False
 
 def xor_encrypt_decrypt(data, key):
   return "".join(chr(ord(c) ^ ord(key[i % len(key)])) for i, c in enumerate(data))


### PR DESCRIPTION
What started as just wanting to be able to download logs from the galaxy, one thing led to another, leaving us with an updated and more functional Dashcam Routes Page.

This PR Refactors the Galaxy dashcam routes page into a more complete local route manager and viewer, including:

  - Redesigned responsive list/grid layouts and route grouping.
  - Route log downloads.
  - Full-route MP4 downloads that stream immediately without building a complete temporary file.
  - Separate deletion actions for non-preserved routes and all routes.
  - Reactive route renaming, sorting, and type-ahead search across names, dates, times, and route IDs.
  - Smoother low-to-high-resolution video switching with consistent framing and controls.
  - Clearer loading states, empty states, and route-specific errors.

  Verification:

Lots of personal QA and Ran the focused dashcam route, helper, and route-log test suites:

  - 69 tests passed.
  - Covered route discovery, sparse segments, preservation and deletion, renaming, search, sorting, logs, video-quality switching, and streamed downloads.
  - JavaScript and Python syntax checks passed.
  - git diff --check passed.