### PR TITLE
Honda Accord 11G: integrate native longitudinal planner and MPC policy

### DIFF
--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -14,6 +14,7 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.realtime import DT_MDL
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.lead_behavior import get_tracked_lead_catchup_bias, is_radarless_matched_follow_window
+from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import get_honda_accord_11g_mpc_policy
 # WARNING: imports outside of constants will not trigger a rebuild
 from openpilot.selfdrive.modeld.constants import index_function, ModelConstants
 
@@ -428,10 +429,11 @@ def gen_long_ocp():
 
 
 class LongitudinalMpc:
-  def __init__(self, mode='acc', dt=DT_MDL):
+  def __init__(self, mode='acc', dt=DT_MDL, CP=None, solver=None):
     self.mode = mode
     self.dt = dt
-    self.solver = AcadosOcpSolverCython(MODEL_NAME, ACADOS_SOLVER_TYPE, N)
+    self.honda_accord_11g_policy = get_honda_accord_11g_mpc_policy(CP)
+    self.solver = solver if solver is not None else AcadosOcpSolverCython(MODEL_NAME, ACADOS_SOLVER_TYPE, N)
     self.source = SOURCES[2]
     # Initialize smoothing filters with default time constants
     self.current_filter_time = LEAD_FILTER_TIME_LOW
@@ -508,6 +510,19 @@ class LongitudinalMpc:
                   personality=log.LongitudinalPersonality.standard, v_ego=0.0, lead_dist=50.0,
                   uncertainty=0.0, accel_reengage=False, panic_bypass=False,
                   filter_time_factor_floor=0.0):
+    if self.honda_accord_11g_policy is not None:
+      policy = self.honda_accord_11g_policy
+      jerk_factor = get_jerk_factor(personality=personality)[0]
+      self.current_x_ego_cost = policy["obstacle_cost"]
+      self.current_j_ego_cost = policy["jerk_cost"]
+      self.current_a_change_cost = policy["accel_change_cost"]
+      self.current_dist_adapt = 0.0
+      a_change_cost = jerk_factor * policy["accel_change_cost"] if prev_accel_constraint else 0.0
+      cost_weights = [policy["obstacle_cost"], X_EGO_COST, V_EGO_COST, A_EGO_COST,
+                      a_change_cost, jerk_factor * policy["jerk_cost"]]
+      self.set_cost_weights(cost_weights, [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST])
+      return
+
     # Update parameters based on current speed with interpolation for smooth scaling
     speed_mph = v_ego * CV.MS_TO_MPH  # Convert m/s to mph
 
@@ -601,7 +616,13 @@ class LongitudinalMpc:
         self.solver.set(i, 'x', self.x0)
 
   @staticmethod
-  def extrapolate_lead(x_lead, v_lead, a_lead, a_lead_tau, v_ego=0.0):
+  def extrapolate_lead(x_lead, v_lead, a_lead, a_lead_tau, v_ego=0.0, *, raw_decay=False):
+    if raw_decay:
+      a_lead_traj = a_lead * np.exp(-a_lead_tau * (T_IDXS ** 2) / 2.0)
+      v_lead_traj = np.clip(v_lead + np.cumsum(T_DIFFS * a_lead_traj), 0.0, 1e8)
+      x_lead_traj = x_lead + np.cumsum(T_DIFFS * v_lead_traj)
+      return np.column_stack((x_lead_traj, v_lead_traj))
+
     speed_mph = v_ego * CV.MS_TO_MPH
     bp = [0, 20, 35]
     exp_weight = np.interp(speed_mph, bp, [1.0, 1.0, 0.0])  # Full exp at <20, blend to constant at 35
@@ -630,6 +651,24 @@ class LongitudinalMpc:
                    smooth_duplicate_vision=False, model_lead=None):
     v_ego = self.x0[1]
     lead_active = lead is not None and lead.status and tracking_lead
+    if self.honda_accord_11g_policy is not None:
+      if lead_active:
+        x_lead = lead.dRel
+        v_lead = lead.vLead
+        a_lead = lead.aLeadK
+        a_lead_tau = lead.aLeadTau
+      else:
+        x_lead = 50.0
+        v_lead = v_ego + 10.0
+        a_lead = 0.0
+        a_lead_tau = self.honda_accord_11g_policy["lead_accel_tau"]
+
+      min_x_lead = ((v_ego + v_lead) / 2) * (v_ego - v_lead) / (-ACCEL_MIN * 2)
+      x_lead = np.clip(x_lead, min_x_lead, 1e8)
+      v_lead = np.clip(v_lead, 0.0, 1e8)
+      a_lead = np.clip(a_lead, -10.0, 5.0)
+      return self.extrapolate_lead(x_lead, v_lead, a_lead, a_lead_tau, raw_decay=True)
+
     if lead_active:
       model_lead_xv = build_model_lead_trajectory(model_lead, lead, v_ego)
       if model_lead_xv is not None:
@@ -928,6 +967,19 @@ class LongitudinalMpc:
              tracked_lead_catchup_bias_gain=None, tracked_lead_catchup_bias_cap=None,
              tracked_lead_catchup_speed_range=None, tracked_lead_catchup_fade_margins=None,
              tracked_lead_catchup_cruise_error_full=None):
+    if self.honda_accord_11g_policy is not None:
+      t_follow = get_T_FOLLOW(personality=personality)
+      optional_far_lead_comfort = False
+      smooth_duplicate_vision = False
+      modelV2 = None
+      lead_obstacle_bias = (0.0, 0.0)
+      tracked_lead_catchup_headway_margins = None
+      tracked_lead_catchup_bias_gain = None
+      tracked_lead_catchup_bias_cap = None
+      tracked_lead_catchup_speed_range = None
+      tracked_lead_catchup_fade_margins = None
+      tracked_lead_catchup_cruise_error_full = None
+
     v_ego = self.x0[1]
     lead_one = radarstate.leadOne
     lead_two = radarstate.leadTwo
@@ -951,7 +1003,7 @@ class LongitudinalMpc:
     lead_1_obstacle -= float(lead_obstacle_bias[1])
 
     self.params[:,0] = ACCEL_MIN
-    self.params[:,1] = max(0.0, self.max_a)
+    self.params[:,1] = ACCEL_MAX if self.honda_accord_11g_policy is not None else max(0.0, self.max_a)
 
     # Update in ACC mode or ACC/e2e blend
     if self.mode == 'acc':
@@ -959,9 +1011,17 @@ class LongitudinalMpc:
 
       # Fake an obstacle for cruise, this ensures smooth acceleration to set speed
       # when the leads are no factor.
-      v_lower = v_ego + (T_IDXS * self.cruise_min_a * 1.05)
+      cruise_min_a = (
+        self.honda_accord_11g_policy["cruise_min_accel"]
+        if self.honda_accord_11g_policy is not None else self.cruise_min_a
+      )
+      cruise_max_a = (
+        self.honda_accord_11g_policy["cruise_max_accel"]
+        if self.honda_accord_11g_policy is not None else self.max_a
+      )
+      v_lower = v_ego + (T_IDXS * cruise_min_a * 1.05)
       # TODO does this make sense when max_a is negative?
-      v_upper = v_ego + (T_IDXS * self.max_a * 1.05)
+      v_upper = v_ego + (T_IDXS * cruise_max_a * 1.05)
       v_cruise_clipped = np.clip(v_cruise * np.ones(N+1),
                                  v_lower,
                                  v_upper)

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -22,6 +22,9 @@ from openpilot.selfdrive.controls.lib.lead_follow_policy import is_nonurgent_dup
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_far_follow_output_slew_rates,
   get_follow_prebrake_min_headway,
+  get_honda_accord_11g_cruise_accel_max,
+  get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_total_accel_max,
   get_honda_accord_lead_departure_tune,
   get_honda_accord_stop_go_accel_cap,
   get_honda_accord_stop_go_accel_rise_rate,
@@ -339,7 +342,10 @@ def get_longitudinal_personality(sm):
   return sm['selfdriveState'].personality
 
 
-def get_max_accel(v_ego):
+def get_max_accel(v_ego, CP=None):
+  accord_11g_max = get_honda_accord_11g_cruise_accel_max(CP, v_ego) if CP is not None else None
+  if accord_11g_max is not None:
+    return accord_11g_max
   return np.interp(v_ego, A_CRUISE_MAX_BP, A_CRUISE_MAX_VALS)
 
 def get_coast_accel(pitch):
@@ -353,7 +359,8 @@ def limit_accel_in_turns(v_ego, angle_steers, a_target, CP):
   """
   # FIXME: This function to calculate lateral accel is incorrect and should use the VehicleModel
   # The lookup table for turns should also be updated if we do this
-  a_total_max = np.interp(v_ego, _A_TOTAL_MAX_BP, _A_TOTAL_MAX_V)
+  accord_11g_total_max = get_honda_accord_11g_total_accel_max(CP, v_ego)
+  a_total_max = accord_11g_total_max if accord_11g_total_max is not None else np.interp(v_ego, _A_TOTAL_MAX_BP, _A_TOTAL_MAX_V)
   a_y = v_ego ** 2 * angle_steers * CV.DEG_TO_RAD / (CP.steerRatio * CP.wheelbase)
   a_x_allowed = math.sqrt(max(a_total_max ** 2 - a_y ** 2, 0.))
 
@@ -528,12 +535,16 @@ def get_accel_from_plan_classic(CP, speeds, accels, vEgoStopping):
   return a_target, should_stop
 
 
-def get_accel_from_plan(speeds, accels, action_t=DT_MDL, vEgoStopping=0.05):
+def get_accel_from_plan(speeds, accels, action_t=DT_MDL, vEgoStopping=0.05, min_stable_delay=0.0):
   if len(speeds) == CONTROL_N:
     v_now = speeds[0]
     a_now = accels[0]
 
-    v_target = np.interp(action_t, CONTROL_N_T_IDX, speeds)
+    if 0.0 < action_t < min_stable_delay:
+      stable_v_target = np.interp(min_stable_delay, CONTROL_N_T_IDX, speeds)
+      v_target = v_now + (action_t / min_stable_delay) * (stable_v_target - v_now)
+    else:
+      v_target = np.interp(action_t, CONTROL_N_T_IDX, speeds)
     a_target = 2 * (v_target - v_now) / (action_t) - a_now
     v_target_1sec = np.interp(action_t + 1.0, CONTROL_N_T_IDX, speeds)
   else:
@@ -1987,7 +1998,11 @@ class LongitudinalPlanner:
     prev_accel_constraint = not (reset_state or sm['carState'].standstill)
 
     if self.mpc.mode == 'acc':
-      accel_limits = [sm['starpilotPlan'].minAcceleration, sm['starpilotPlan'].maxAcceleration]
+      accord_11g_accel_max = get_honda_accord_11g_cruise_accel_max(self.CP, v_ego)
+      if accord_11g_accel_max is not None:
+        accel_limits = [ACCEL_MIN, accord_11g_accel_max]
+      else:
+        accel_limits = [sm['starpilotPlan'].minAcceleration, sm['starpilotPlan'].maxAcceleration]
       steer_angle_without_offset = sm['carState'].steeringAngleDeg - sm['liveParameters'].angleOffsetDeg
       accel_limits_turns = limit_accel_in_turns(v_ego, steer_angle_without_offset, accel_limits, self.CP)
       accel_limits_turns[0] = max(get_vehicle_min_accel(self.CP, v_ego), accel_limits_turns[0])
@@ -2361,6 +2376,7 @@ class LongitudinalPlanner:
     tinygrad_model = bool(getattr(starpilot_toggles, "tinygrad_model", False))
     experimental_mlsim = bool(tinygrad_model and self.mlsim and self.mode != 'acc')
     action_t = self.CP.longitudinalActuatorDelay + DT_MDL
+    accord_11g_min_action_delay = get_honda_accord_11g_min_action_delay(self.CP) or 0.0
     prev_output_a_target = float(self.output_a_target)
     model_launch_accel = None
     if self.model_launch_armed and not bool(sm['modelV2'].action.shouldStop):
@@ -2372,7 +2388,8 @@ class LongitudinalPlanner:
     elif tinygrad_model:
       output_a_target_mpc, output_should_stop_mpc = get_accel_from_plan(
         self.v_desired_trajectory, self.a_desired_trajectory,
-        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping)
+        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping,
+        min_stable_delay=accord_11g_min_action_delay)
       output_a_target_e2e = sm['modelV2'].action.desiredAcceleration
       output_should_stop_e2e = sm['modelV2'].action.shouldStop
 
@@ -2385,7 +2402,8 @@ class LongitudinalPlanner:
     else:
       output_a_target, output_should_stop = get_accel_from_plan(
         self.v_desired_trajectory, self.a_desired_trajectory,
-        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping)
+        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping,
+        min_stable_delay=accord_11g_min_action_delay)
 
     comfort_output_accel_min = get_vehicle_min_accel(self.CP, v_ego) if experimental_mlsim else accel_limits_turns[0]
     vision_cap_accel_min = min(comfort_output_accel_min, get_vehicle_min_accel(self.CP, v_ego))

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -562,7 +562,7 @@ def get_accel_from_plan(speeds, accels, action_t=DT_MDL, vEgoStopping=0.05, min_
 class LongitudinalPlanner:
   def __init__(self, CP, init_v=0.0, init_a=0.0, dt=DT_MDL):
     self.CP = CP
-    self.mpc = LongitudinalMpc(dt=dt)
+    self.mpc = LongitudinalMpc(dt=dt, CP=CP)
     self.fcw = False
     self.dt = dt
     self.model_allow_throttle = True
@@ -654,6 +654,8 @@ class LongitudinalPlanner:
     return is_tinygrad_model_version(self.generation)
 
   def get_mpc_mode(self) -> str:
+    if getattr(self.mpc, 'honda_accord_11g_policy', None) is not None:
+      return 'acc'
     if not self.mlsim:
       return self.mode
     return getattr(self.mpc, 'mode', 'acc')
@@ -1972,9 +1974,7 @@ class LongitudinalPlanner:
     self.generation = getattr(starpilot_toggles, "model_version", None)
     experimental_mode = bool(sm['selfdriveState'].experimentalMode)
     self.mode = 'blended' if experimental_mode else 'acc'
-    self.mpc.mode = 'acc'
-    if not self.mlsim:
-      self.mpc.mode = self.mode
+    self.mpc.mode = self.get_mpc_mode()
 
     if len(sm['carControl'].orientationNED) == 3:
       accel_coast = get_coast_accel(sm['carControl'].orientationNED[1])

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -22,8 +22,11 @@ from openpilot.selfdrive.controls.lib.lead_follow_policy import is_nonurgent_dup
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_far_follow_output_slew_rates,
   get_follow_prebrake_min_headway,
+  get_honda_accord_11g_allow_throttle,
   get_honda_accord_11g_cruise_accel_max,
   get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_no_throttle_accel_max,
+  get_honda_accord_11g_reduction_only_v_cruise,
   get_honda_accord_11g_total_accel_max,
   get_honda_accord_lead_departure_tune,
   get_honda_accord_stop_go_accel_cap,
@@ -56,7 +59,7 @@ from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_tracked_lead_catchup_headway_margins,
 )
 from openpilot.selfdrive.controls.lib.drive_helpers import CONTROL_N
-from openpilot.selfdrive.car.cruise import V_CRUISE_UNSET
+from openpilot.selfdrive.car.cruise import V_CRUISE_MAX, V_CRUISE_UNSET
 from openpilot.common.swaglog import cloudlog
 from cereal import log
 
@@ -1980,10 +1983,18 @@ class LongitudinalPlanner:
 
     v_ego = get_planner_v_ego(self.CP, sm['carState'])
     scene_v_ego = float(sm['carState'].vEgo)
-    v_cruise = sm['starpilotPlan'].vCruise
-    if not np.isfinite(v_cruise):
-      cloudlog.error(f"Longitudinal planner received non-finite vCruise={v_cruise}, falling back to v_ego={v_ego:.2f}")
-      v_cruise = max(v_ego, 0.0)
+    starpilot_v_cruise = float(sm['starpilotPlan'].vCruise)
+    stock_v_cruise = min(float(sm['carState'].vCruise), V_CRUISE_MAX) * CV.KPH_TO_MS
+    accord_11g_v_cruise = get_honda_accord_11g_reduction_only_v_cruise(
+      self.CP, stock_v_cruise, starpilot_v_cruise,
+    )
+    if accord_11g_v_cruise is not None:
+      v_cruise = accord_11g_v_cruise
+    else:
+      v_cruise = starpilot_v_cruise
+      if not np.isfinite(v_cruise):
+        cloudlog.error(f"Longitudinal planner received non-finite vCruise={v_cruise}, falling back to v_ego={v_ego:.2f}")
+        v_cruise = max(v_ego, 0.0)
     v_cruise_initialized = sm['carState'].vCruise != V_CRUISE_UNSET
 
     long_control_off = sm['controlsState'].longControlState == LongCtrlState.off
@@ -2037,29 +2048,42 @@ class LongitudinalPlanner:
     # Don't clip at low speeds since throttle_prob doesn't account for creep. Raw
     # gasPressProb can cross both hysteresis thresholds for only a few model frames,
     # so confirm transitions before changing the physical coast cap.
-    if v_ego <= MIN_ALLOW_THROTTLE_SPEED:
-      self.model_allow_throttle = True
+    accord_11g_allow_throttle = get_honda_accord_11g_allow_throttle(self.CP, throttle_prob, v_ego)
+    if accord_11g_allow_throttle is not None:
+      self.model_allow_throttle = accord_11g_allow_throttle
       self.model_allow_throttle_transition_t = 0.0
     else:
-      transition_requested = (
-        throttle_prob <= ALLOW_THROTTLE_DISABLE_THRESHOLD if self.model_allow_throttle
-        else throttle_prob > ALLOW_THROTTLE_ENABLE_THRESHOLD
-      )
-      if transition_requested:
-        self.model_allow_throttle_transition_t += self.dt
-        if self.model_allow_throttle_transition_t + 1e-6 >= ALLOW_THROTTLE_TRANSITION_CONFIRM_TIME:
-          self.model_allow_throttle = not self.model_allow_throttle
-          self.model_allow_throttle_transition_t = 0.0
-      else:
+      if v_ego <= MIN_ALLOW_THROTTLE_SPEED:
+        self.model_allow_throttle = True
         self.model_allow_throttle_transition_t = 0.0
-    self.allow_throttle = self.model_allow_throttle and not sm['starpilotPlan'].disableThrottle
+      else:
+        transition_requested = (
+          throttle_prob <= ALLOW_THROTTLE_DISABLE_THRESHOLD if self.model_allow_throttle
+          else throttle_prob > ALLOW_THROTTLE_ENABLE_THRESHOLD
+        )
+        if transition_requested:
+          self.model_allow_throttle_transition_t += self.dt
+          if self.model_allow_throttle_transition_t + 1e-6 >= ALLOW_THROTTLE_TRANSITION_CONFIRM_TIME:
+            self.model_allow_throttle = not self.model_allow_throttle
+            self.model_allow_throttle_transition_t = 0.0
+        else:
+          self.model_allow_throttle_transition_t = 0.0
+    self.allow_throttle = self.model_allow_throttle and (
+      accord_11g_allow_throttle is not None or not sm['starpilotPlan'].disableThrottle
+    )
 
     if not self.allow_throttle:
-      clipped_accel_coast = max(accel_coast, accel_limits_turns[0])
-      # Hold the output cap to the physical coasting limit until throttle is
-      # allowed again. Relaxing back toward positive accel while the gate is
-      # still closed can stall downhill coastdown well above the target speed.
-      accel_limits_turns[1] = min(accel_limits_turns[1], clipped_accel_coast)
+      accord_11g_coast_cap = get_honda_accord_11g_no_throttle_accel_max(
+        self.CP, v_ego, accel_limits_turns[0], accel_limits_turns[1], accel_coast,
+      )
+      if accord_11g_coast_cap is not None:
+        accel_limits_turns[1] = accord_11g_coast_cap
+      else:
+        clipped_accel_coast = max(accel_coast, accel_limits_turns[0])
+        # Hold the output cap to the physical coasting limit until throttle is
+        # allowed again. Relaxing back toward positive accel while the gate is
+        # still closed can stall downhill coastdown well above the target speed.
+        accel_limits_turns[1] = min(accel_limits_turns[1], clipped_accel_coast)
     no_throttle_output_max = accel_limits_turns[1]
 
     if force_slow_decel:

--- a/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
+++ b/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
@@ -27,6 +27,14 @@ HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD = 0.4
 HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED = 2.5
 HONDA_ACCORD_11G_MIN_ACTION_DELAY = 0.3
 HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP = 0.05
+HONDA_ACCORD_11G_MPC_POLICY = {
+  "obstacle_cost": 3.0,
+  "jerk_cost": 5.0,
+  "accel_change_cost": 200.0,
+  "cruise_min_accel": -1.2,
+  "cruise_max_accel": 1.6,
+  "lead_accel_tau": 1.5,
+}
 HYUNDAI_ELANTRA_LEAD_FOLLOW_JERK_SCALE = 1.25
 GENESIS_GV70_ELECTRIFIED_LEAD_FOLLOW_JERK_SCALE = 1.35
 FORD_LIGHTNING_LEAD_FOLLOW_JERK_SCALE = 1.35
@@ -182,6 +190,10 @@ def get_honda_accord_11g_min_action_delay(CP):
 
 def get_honda_accord_11g_accel_clip_slew_step(CP):
   return HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP if is_honda_accord_11g(CP) else None
+
+
+def get_honda_accord_11g_mpc_policy(CP):
+  return HONDA_ACCORD_11G_MPC_POLICY if is_honda_accord_11g(CP) else None
 
 
 def get_honda_accord_11g_reduction_only_v_cruise(CP, stock_v_cruise, starpilot_v_cruise):

--- a/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
+++ b/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
@@ -19,6 +19,14 @@ HONDA_ACCORD_STOP_GO_MAX_LEAD_BRAKE = 0.25
 HONDA_ACCORD_STOP_GO_MAX_LATERAL_OFFSET = 1.25
 HONDA_ACCORD_STOP_GO_MIN_MODEL_PROB = 0.95
 HONDA_ACCORD_STOP_GO_ACCEL_RISE_RATE = 4.0
+HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_BP = (0.0, 10.0, 25.0, 40.0)
+HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_V = (1.6, 1.2, 0.8, 0.6)
+HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_BP = (20.0, 40.0)
+HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_V = (1.7, 3.2)
+HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD = 0.4
+HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED = 2.5
+HONDA_ACCORD_11G_MIN_ACTION_DELAY = 0.3
+HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP = 0.05
 HYUNDAI_ELANTRA_LEAD_FOLLOW_JERK_SCALE = 1.25
 GENESIS_GV70_ELECTRIFIED_LEAD_FOLLOW_JERK_SCALE = 1.35
 FORD_LIGHTNING_LEAD_FOLLOW_JERK_SCALE = 1.35
@@ -117,6 +125,50 @@ DEFAULT_FORCE_STOP_HANDOFF_M = 6.0
 HYUNDAI_SANTA_FE_2022_FORCE_STOP_REANCHOR_SPEED_TOLERANCE = 0.25
 HYUNDAI_SANTA_FE_2022_FORCE_STOP_LOW_SPEED_HOLD = 2.5
 KIA_CARNIVAL_2025_STOP_SIGN_LOW_SPEED_HOLD = 0.75
+
+
+def is_honda_accord_11g(CP):
+  return (
+    getattr(CP, "brand", "") == "honda" and
+    str(getattr(CP, "carFingerprint", "")) == "HONDA_ACCORD_11G"
+  )
+
+
+def get_honda_accord_11g_cruise_accel_max(CP, v_ego):
+  """Return the validated Accord 11G cruise acceleration ceiling."""
+  if not is_honda_accord_11g(CP):
+    return None
+  return float(np.interp(v_ego, HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_BP, HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_V))
+
+
+def get_honda_accord_11g_total_accel_max(CP, v_ego):
+  """Return the validated Accord 11G combined longitudinal/lateral envelope."""
+  if not is_honda_accord_11g(CP):
+    return None
+  return float(np.interp(v_ego, HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_BP, HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_V))
+
+
+def get_honda_accord_11g_throttle_policy(CP):
+  if not is_honda_accord_11g(CP):
+    return None
+  return HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD, HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED
+
+
+def get_honda_accord_11g_min_action_delay(CP):
+  return HONDA_ACCORD_11G_MIN_ACTION_DELAY if is_honda_accord_11g(CP) else None
+
+
+def get_honda_accord_11g_accel_clip_slew_step(CP):
+  return HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP if is_honda_accord_11g(CP) else None
+
+
+def get_honda_accord_11g_reduction_only_v_cruise(CP, stock_v_cruise, starpilot_v_cruise):
+  """Keep StarPilot as a reduction-only speed constraint for the Accord 11G."""
+  if not is_honda_accord_11g(CP):
+    return None
+  if np.isfinite(starpilot_v_cruise) and starpilot_v_cruise >= 0.0:
+    return float(min(stock_v_cruise, starpilot_v_cruise))
+  return float(stock_v_cruise)
 
 
 def get_toyota_prius_stopped_lead_obstacle_bias(CP, lead, v_ego):

--- a/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
+++ b/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
@@ -154,6 +154,28 @@ def get_honda_accord_11g_throttle_policy(CP):
   return HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD, HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED
 
 
+def get_honda_accord_11g_allow_throttle(CP, throttle_prob, v_ego):
+  policy = get_honda_accord_11g_throttle_policy(CP)
+  if policy is None:
+    return None
+  threshold, min_allow_speed = policy
+  return bool(throttle_prob > threshold or v_ego <= min_allow_speed)
+
+
+def get_honda_accord_11g_no_throttle_accel_max(CP, v_ego, accel_min, accel_max, accel_coast):
+  policy = get_honda_accord_11g_throttle_policy(CP)
+  if policy is None:
+    return None
+  _, min_allow_speed = policy
+  clipped_accel_coast = max(float(accel_coast), float(accel_min))
+  coast_cap = np.interp(
+    v_ego,
+    [min_allow_speed, min_allow_speed * 2.0],
+    [accel_max, clipped_accel_coast],
+  )
+  return float(min(accel_max, coast_cap))
+
+
 def get_honda_accord_11g_min_action_delay(CP):
   return HONDA_ACCORD_11G_MIN_ACTION_DELAY if is_honda_accord_11g(CP) else None
 

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -2,9 +2,12 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from cereal import log
+from opendbc.car.interfaces import ACCEL_MAX, ACCEL_MIN
 
 from openpilot.selfdrive.controls.lib.longitudinal_planner import (
   CONTROL_N_T_IDX,
+  LongitudinalPlanner,
   get_accel_from_plan,
   get_max_accel,
   limit_accel_in_turns,
@@ -14,16 +17,56 @@ from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_honda_accord_11g_allow_throttle,
   get_honda_accord_11g_cruise_accel_max,
   get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_mpc_policy,
   get_honda_accord_11g_no_throttle_accel_max,
   get_honda_accord_11g_reduction_only_v_cruise,
   get_honda_accord_11g_throttle_policy,
   get_honda_accord_11g_total_accel_max,
   is_honda_accord_11g,
 )
+from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import (
+  COST_E_DIM,
+  DANGER_ZONE_COST,
+  FCW_IDXS,
+  LIMIT_COST,
+  N,
+  T_DIFFS,
+  T_IDXS,
+  LongitudinalMpc,
+  get_T_FOLLOW,
+)
 
 
 def make_cp(brand="honda", fingerprint="HONDA_ACCORD_11G"):
   return SimpleNamespace(brand=brand, carFingerprint=fingerprint)
+
+
+class FakeSolver:
+  def __init__(self):
+    self.costs = {}
+    self.values = {}
+
+  def reset(self):
+    pass
+
+  def cost_set(self, stage, field, value):
+    self.costs[(stage, field)] = np.array(value, copy=True)
+
+  def set(self, stage, field, value):
+    self.values[(stage, field)] = np.array(value, copy=True)
+
+
+def make_lead(status=False, d_rel=50.0, v_lead=30.0, a_lead=0.0, tau=1.5):
+  return SimpleNamespace(
+    status=status,
+    dRel=d_rel,
+    vLead=v_lead,
+    vRel=0.0,
+    aLeadK=a_lead,
+    aLeadTau=tau,
+    radar=True,
+    modelProb=1.0,
+  )
 
 
 @pytest.mark.parametrize("brand, fingerprint", [
@@ -41,6 +84,7 @@ def test_accord11g_native_contract_is_exactly_platform_scoped(brand, fingerprint
   assert get_honda_accord_11g_throttle_policy(other) is None
   assert get_honda_accord_11g_min_action_delay(other) is None
   assert get_honda_accord_11g_accel_clip_slew_step(other) is None
+  assert get_honda_accord_11g_mpc_policy(other) is None
   assert get_honda_accord_11g_reduction_only_v_cruise(other, 20.0, 15.0) is None
 
 
@@ -148,3 +192,80 @@ def test_native_plan_projection_uses_accord11g_stable_delay_without_changing_def
   assert stable_accel != pytest.approx(default_accel)
   assert not stable_should_stop
   assert not default_should_stop
+
+
+def test_accord11g_native_mpc_costs_match_validated_policy():
+  solver = FakeSolver()
+  mpc = LongitudinalMpc(CP=make_cp(), solver=solver)
+  policy = get_honda_accord_11g_mpc_policy(make_cp())
+
+  expected = np.diag([
+    policy["obstacle_cost"], 0.0, 0.0, 0.0,
+    policy["accel_change_cost"], policy["jerk_cost"],
+  ])
+  assert solver.costs[(0, "W")] == pytest.approx(expected)
+  assert solver.costs[(N, "W")].shape == (COST_E_DIM, COST_E_DIM)
+  assert solver.costs[(0, "Zl")] == pytest.approx([LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST])
+
+  mpc.set_weights(personality=log.LongitudinalPersonality.aggressive)
+  expected_aggressive = expected.copy()
+  expected_aggressive[4, 4] *= 0.5
+  expected_aggressive[5, 5] *= 0.5
+  assert solver.costs[(0, "W")] == pytest.approx(expected_aggressive)
+
+  mpc.set_weights(prev_accel_constraint=False)
+  assert solver.costs[(0, "W")][4, 4] == pytest.approx(0.0)
+
+
+def test_accord11g_native_mpc_uses_raw_lead_decay_without_changing_other_cars():
+  accord = LongitudinalMpc(CP=make_cp(), solver=FakeSolver())
+  civic = LongitudinalMpc(CP=make_cp(fingerprint="HONDA_CIVIC_BOSCH"), solver=FakeSolver())
+  for mpc in (accord, civic):
+    mpc.set_cur_state(35.0, 0.0)
+
+  lead = make_lead(True, 45.0, 25.0, -1.0, 0.8)
+  accord_lead_xv = accord.process_lead(lead)
+  civic_lead_xv = civic.process_lead(lead)
+  expected_a = lead.aLeadK * np.exp(-lead.aLeadTau * (T_IDXS ** 2) / 2.0)
+  expected_v = np.clip(lead.vLead + np.cumsum(T_DIFFS * expected_a), 0.0, 1e8)
+  expected_x = lead.dRel + np.cumsum(T_DIFFS * expected_v)
+
+  assert accord_lead_xv == pytest.approx(np.column_stack((expected_x, expected_v)))
+  assert not np.allclose(accord_lead_xv, civic_lead_xv)
+
+
+def test_accord11g_native_mpc_parameters_and_follow_time_match_validated_policy():
+  solver = FakeSolver()
+  mpc = LongitudinalMpc(CP=make_cp(), solver=solver)
+  mpc.set_cur_state(20.0, 0.0)
+  mpc.set_accel_limits(-0.4, 0.6)
+  mpc.run = lambda: None
+  radar_state = SimpleNamespace(leadOne=make_lead(), leadTwo=make_lead())
+  zeros = np.zeros(N + 1)
+
+  mpc.update(
+    radar_state, 25.0, zeros.copy(), zeros.copy(), zeros.copy(), zeros.copy(),
+    danger_factor=0.1, t_follow=9.0, personality=log.LongitudinalPersonality.aggressive,
+  )
+
+  assert mpc.source == "cruise"
+  assert mpc.params[:, 0] == pytest.approx(ACCEL_MIN)
+  assert mpc.params[:, 1] == pytest.approx(ACCEL_MAX)
+  assert mpc.params[:, 4] == pytest.approx(get_T_FOLLOW(personality=log.LongitudinalPersonality.aggressive))
+  assert mpc.params[:, 5] == pytest.approx(0.75)
+  assert not np.any(mpc.lead_xv_0[FCW_IDXS, 0] - mpc.x_sol[FCW_IDXS, 0] < 0.25)
+
+
+def test_accord11g_native_mpc_stays_in_acc_mode_without_changing_other_cars():
+  accord_planner = LongitudinalPlanner.__new__(LongitudinalPlanner)
+  accord_planner.generation = None
+  accord_planner.mode = "blended"
+  accord_planner.mpc = SimpleNamespace(honda_accord_11g_policy=get_honda_accord_11g_mpc_policy(make_cp()), mode="blended")
+
+  civic_planner = LongitudinalPlanner.__new__(LongitudinalPlanner)
+  civic_planner.generation = None
+  civic_planner.mode = "blended"
+  civic_planner.mpc = SimpleNamespace(honda_accord_11g_policy=None, mode="blended")
+
+  assert accord_planner.get_mpc_mode() == "acc"
+  assert civic_planner.get_mpc_mode() == "blended"

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -1,7 +1,14 @@
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
+from openpilot.selfdrive.controls.lib.longitudinal_planner import (
+  CONTROL_N_T_IDX,
+  get_accel_from_plan,
+  get_max_accel,
+  limit_accel_in_turns,
+)
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_honda_accord_11g_accel_clip_slew_step,
   get_honda_accord_11g_cruise_accel_max,
@@ -79,3 +86,37 @@ def test_accord11g_scalar_planner_contract_matches_road_validated_values():
 ])
 def test_accord11g_starpilot_v_cruise_is_reduction_only(starpilot_v_cruise, expected):
   assert get_honda_accord_11g_reduction_only_v_cruise(make_cp(), 20.0, starpilot_v_cruise) == pytest.approx(expected)
+
+
+def test_native_planner_uses_accord11g_acceleration_envelopes_only_for_accord():
+  accord = SimpleNamespace(brand="honda", carFingerprint="HONDA_ACCORD_11G", steerRatio=15.0, wheelbase=2.8)
+  civic = SimpleNamespace(brand="honda", carFingerprint="HONDA_CIVIC_BOSCH", steerRatio=15.0, wheelbase=2.8)
+
+  assert get_max_accel(17.5, accord) == pytest.approx(1.0)
+  assert get_max_accel(17.5, civic) == pytest.approx(1.1875)
+  assert limit_accel_in_turns(30.0, 0.0, [-3.5, 10.0], accord) == pytest.approx([-3.5, 2.45])
+  assert limit_accel_in_turns(30.0, 0.0, [-3.5, 10.0], civic) == pytest.approx([-3.5, 3.35])
+
+
+def test_native_plan_projection_uses_accord11g_stable_delay_without_changing_default():
+  control_t = np.asarray(CONTROL_N_T_IDX)
+  speeds = 10.0 + control_t ** 2
+  accels = np.zeros_like(control_t)
+  action_t = 0.2
+  stable_delay = 0.3
+  stable_speed = float(np.interp(stable_delay, CONTROL_N_T_IDX, speeds))
+  expected_stable_target = float(speeds[0] + (action_t / stable_delay) * (stable_speed - speeds[0]))
+  expected_stable_accel = 2.0 * (expected_stable_target - speeds[0]) / action_t
+  expected_default_target = float(np.interp(action_t, CONTROL_N_T_IDX, speeds))
+  expected_default_accel = 2.0 * (expected_default_target - speeds[0]) / action_t
+
+  stable_accel, stable_should_stop = get_accel_from_plan(
+    speeds, accels, action_t=action_t, min_stable_delay=stable_delay,
+  )
+  default_accel, default_should_stop = get_accel_from_plan(speeds, accels, action_t=action_t)
+
+  assert stable_accel == pytest.approx(expected_stable_accel)
+  assert default_accel == pytest.approx(expected_default_accel)
+  assert stable_accel != pytest.approx(default_accel)
+  assert not stable_should_stop
+  assert not default_should_stop

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -11,8 +11,10 @@ from openpilot.selfdrive.controls.lib.longitudinal_planner import (
 )
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_honda_accord_11g_accel_clip_slew_step,
+  get_honda_accord_11g_allow_throttle,
   get_honda_accord_11g_cruise_accel_max,
   get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_no_throttle_accel_max,
   get_honda_accord_11g_reduction_only_v_cruise,
   get_honda_accord_11g_throttle_policy,
   get_honda_accord_11g_total_accel_max,
@@ -86,6 +88,32 @@ def test_accord11g_scalar_planner_contract_matches_road_validated_values():
 ])
 def test_accord11g_starpilot_v_cruise_is_reduction_only(starpilot_v_cruise, expected):
   assert get_honda_accord_11g_reduction_only_v_cruise(make_cp(), 20.0, starpilot_v_cruise) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("throttle_prob, v_ego, expected", [
+  (0.41, 10.0, True),
+  (0.40, 10.0, False),
+  (0.0, 2.5, True),
+  (0.0, 2.51, False),
+])
+def test_accord11g_throttle_gate_matches_validated_policy(throttle_prob, v_ego, expected):
+  assert get_honda_accord_11g_allow_throttle(make_cp(), throttle_prob, v_ego) is expected
+  assert get_honda_accord_11g_allow_throttle(make_cp(fingerprint="HONDA_CIVIC_BOSCH"), throttle_prob, v_ego) is None
+
+
+@pytest.mark.parametrize("v_ego, accel_coast, expected", [
+  (2.5, -0.3, 1.6),
+  (3.75, -0.3, 0.65),
+  (5.0, -0.3, -0.3),
+  (5.0, -5.0, -3.5),
+])
+def test_accord11g_no_throttle_coast_cap_matches_validated_interpolation(v_ego, accel_coast, expected):
+  assert get_honda_accord_11g_no_throttle_accel_max(
+    make_cp(), v_ego, accel_min=-3.5, accel_max=1.6, accel_coast=accel_coast,
+  ) == pytest.approx(expected)
+  assert get_honda_accord_11g_no_throttle_accel_max(
+    make_cp(fingerprint="HONDA_CIVIC_BOSCH"), v_ego, accel_min=-3.5, accel_max=1.6, accel_coast=accel_coast,
+  ) is None
 
 
 def test_native_planner_uses_accord11g_acceleration_envelopes_only_for_accord():

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+import pytest
+
+from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
+  get_honda_accord_11g_accel_clip_slew_step,
+  get_honda_accord_11g_cruise_accel_max,
+  get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_reduction_only_v_cruise,
+  get_honda_accord_11g_throttle_policy,
+  get_honda_accord_11g_total_accel_max,
+  is_honda_accord_11g,
+)
+
+
+def make_cp(brand="honda", fingerprint="HONDA_ACCORD_11G"):
+  return SimpleNamespace(brand=brand, carFingerprint=fingerprint)
+
+
+@pytest.mark.parametrize("brand, fingerprint", [
+  ("honda", "HONDA_ACCORD"),
+  ("honda", "HONDA_CIVIC_BOSCH"),
+  ("toyota", "HONDA_ACCORD_11G"),
+  ("toyota", "TOYOTA_RAV4"),
+])
+def test_accord11g_native_contract_is_exactly_platform_scoped(brand, fingerprint):
+  other = make_cp(brand, fingerprint)
+
+  assert not is_honda_accord_11g(other)
+  assert get_honda_accord_11g_cruise_accel_max(other, 10.0) is None
+  assert get_honda_accord_11g_total_accel_max(other, 20.0) is None
+  assert get_honda_accord_11g_throttle_policy(other) is None
+  assert get_honda_accord_11g_min_action_delay(other) is None
+  assert get_honda_accord_11g_accel_clip_slew_step(other) is None
+  assert get_honda_accord_11g_reduction_only_v_cruise(other, 20.0, 15.0) is None
+
+
+@pytest.mark.parametrize("v_ego, expected", [
+  (-1.0, 1.6),
+  (0.0, 1.6),
+  (5.0, 1.4),
+  (10.0, 1.2),
+  (17.5, 1.0),
+  (25.0, 0.8),
+  (32.5, 0.7),
+  (40.0, 0.6),
+  (50.0, 0.6),
+])
+def test_accord11g_cruise_accel_ceiling_matches_validated_curve(v_ego, expected):
+  assert get_honda_accord_11g_cruise_accel_max(make_cp(), v_ego) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("v_ego, expected", [
+  (0.0, 1.7),
+  (20.0, 1.7),
+  (30.0, 2.45),
+  (40.0, 3.2),
+  (50.0, 3.2),
+])
+def test_accord11g_total_accel_envelope_matches_validated_curve(v_ego, expected):
+  assert get_honda_accord_11g_total_accel_max(make_cp(), v_ego) == pytest.approx(expected)
+
+
+def test_accord11g_scalar_planner_contract_matches_road_validated_values():
+  accord = make_cp()
+
+  assert is_honda_accord_11g(accord)
+  assert get_honda_accord_11g_throttle_policy(accord) == pytest.approx((0.4, 2.5))
+  assert get_honda_accord_11g_min_action_delay(accord) == pytest.approx(0.3)
+  assert get_honda_accord_11g_accel_clip_slew_step(accord) == pytest.approx(0.05)
+
+
+@pytest.mark.parametrize("starpilot_v_cruise, expected", [
+  (15.0, 15.0),
+  (20.0, 20.0),
+  (25.0, 20.0),
+  (float("nan"), 20.0),
+  (-1.0, 20.0),
+])
+def test_accord11g_starpilot_v_cruise_is_reduction_only(starpilot_v_cruise, expected):
+  assert get_honda_accord_11g_reduction_only_v_cruise(make_cp(), 20.0, starpilot_v_cruise) == pytest.approx(expected)


### PR DESCRIPTION
**Description**

Integrates the Accord 11G longitudinal behavior into StarPilot's native planner and MPC architecture. The implementation remains explicitly gated to `HONDA_ACCORD_11G`; behavior for other platforms remains unchanged.

This PR contains:

- `NATIVE-01`: defines the Accord 11G longitudinal behavior contract and focused tests.
- `NATIVE-02`: integrates the native acceleration envelope and plan projection.
- `NATIVE-03`: integrates Accord-specific cruise and throttle policy.
- `NATIVE-04`: integrates lead processing, following-distance, jerk, and MPC policy into the native longitudinal MPC.

The implementation uses the shared StarPilot planner/MPC rather than maintaining a parallel Accord-specific planner stack.

Base: `642072491379205b5c28d1f5a77db3a511dac5f9`  
Head: `a992326bdc71238cd5556773183515fa0806ffb6`

**Compatibility**

- Accord 11G behavior is selected only through the Accord 11G vehicle-policy helpers.
- Standard/Generic DOM behavior remains the default for every other platform.
- The existing older-Accord Bosch-A path is not treated as Accord 11G.
- No Honda CAN, radar, lateral-control, or Panda safety changes are included in this PR.

**Verification**

Current-DOM host verification:

- Full SCons build passed.
- Critical native extensions rebuilt successfully for x86-64.
- Python compilation passed.
- Ruff passed with `E501`, `F821`, and `ISC002` excluded only after `git blame` confirmed every reported occurrence predates this PR.
- Accord 11G native longitudinal tests: `38 passed`.
- DOM longitudinal planner regression: `486 passed`.
- Diff and source-integrity checks passed.

The existing StarPilot planner suite produced `11 passed, 1 failed`. The failure is pre-existing at the base: `get_force_stop_jerk_scale()` returns `0.20` for `OTHER_CAR`, while the unchanged upstream test expects `0.32`. This PR changes neither that helper nor its test.

Sealed verification evidence SHA-256:

`f399f14b1eb0c1c9823502315798f1e8f3477e773a77102d4e5b486ba9394b50`

**Road validation**

The complete native Accord 11G stack was road validated at:

`52c7e8160b9b67df5b1711dac92b8e071257a6b5`

Tag:

`accord11g-dom-native-full-road-validated-20260830`

Observed during validation:

- lateral and longitudinal control operated correctly;
- radar and LKAS behavior operated correctly;
- no persistent DTCs;
- smooth native UI without the experimental UI streamer.

The current-DOM PR1 replay has completed host regression verification but has not yet been independently road tested on the newer DOM base.