### PR TITLE
Honda Accord 11G: integrate native DOM control stack (NATIVE-01–14)

### DIFF
--- a/opendbc_repo/opendbc/can/parser.py
+++ b/opendbc_repo/opendbc/can/parser.py
@@ -9,6 +9,8 @@ from opendbc.can.dbc import DBC, Signal
 
 MAX_BAD_COUNTER = 5
 CAN_INVALID_CNT = 5
+CAN_DIAGNOSTIC_INTERVAL_NS = 1_000_000_000
+CAN_DIAGNOSTIC_MAX_OFFENDERS = 8
 
 
 def get_raw_value(dat: bytes | bytearray, sig: Signal) -> int:
@@ -126,7 +128,7 @@ class VLDict(dict):
 
 
 class CANParser:
-  def __init__(self, dbc_name: str, messages: list[tuple[str | int, int]], bus: int):
+  def __init__(self, dbc_name: str, messages: list[tuple[str | int, int]], bus: int, *, enable_can_valid_diagnostics: bool = False):
     self.dbc_name: str = dbc_name
     self.bus: int = bus
     self.dbc: DBC = DBC(dbc_name)
@@ -137,6 +139,11 @@ class CANParser:
     self.ts_nanos: dict[int | str, dict[str, int]] = {}
     self.addresses: set[int] = set()
     self.message_states: dict[int, MessageState] = {}
+
+    self._enable_can_valid_diagnostics = enable_can_valid_diagnostics
+    self._seen_valid = False
+    self._previous_can_valid = False
+    self._last_diagnostic_nanos: int | None = None
 
     for name_or_addr, freq in messages:
       if isinstance(name_or_addr, numbers.Number):
@@ -217,7 +224,52 @@ class CANParser:
 
     # TODO: probably only want to increment this once per update() call
     self.can_invalid_cnt = 0 if valid else min(self.can_invalid_cnt + 1, CAN_INVALID_CNT)
-    return self.can_invalid_cnt < CAN_INVALID_CNT and counters_valid
+    result = self.can_invalid_cnt < CAN_INVALID_CNT and counters_valid
+
+    if self._enable_can_valid_diagnostics:
+      if result:
+        self._seen_valid = True
+      if self._seen_valid and self._previous_can_valid and not result:
+        if self._last_diagnostic_nanos is None or (self._last_update_nanos - self._last_diagnostic_nanos) >= CAN_DIAGNOSTIC_INTERVAL_NS:
+          offenders = []
+          for state in sorted(self.message_states.values(), key=lambda s: s.address):
+            causes = []
+            if state.counter_fail >= MAX_BAD_COUNTER:
+              causes.append("counter-invalid")
+            if not state.ignore_alive:
+              if not state.timestamps:
+                causes.append("missing")
+              else:
+                if not state.valid(self._last_update_nanos, bus_timeout):
+                  causes.append("stale")
+            if causes:
+              if state.timestamps:
+                age_ms = max(0, (self._last_update_nanos - state.timestamps[-1]) * 1e-6)
+              else:
+                age_ms = "unknown"
+              if state.frequency > 0:
+                frequency_hz = state.frequency
+              elif not state.ignore_alive and state.timeout_threshold > 0:
+                frequency_hz = 10_000_000_000 / state.timeout_threshold
+              else:
+                frequency_hz = "unknown"
+              offenders.append({
+                "address": hex(state.address),
+                "name": state.name,
+                "causes": ", ".join(causes),
+                "frequency_hz": frequency_hz,
+                "age_ms": age_ms,
+              })
+          omitted = max(0, len(offenders) - CAN_DIAGNOSTIC_MAX_OFFENDERS)
+          if omitted > 0:
+            offenders = offenders[:CAN_DIAGNOSTIC_MAX_OFFENDERS]
+          diagnostic = f"CANParser canValid falling edge: bus={self.bus}, offender_count={len(offenders) + omitted}, "
+          diagnostic += f"offenders={offenders}, omitted={omitted}"
+          carlog.error(diagnostic)
+          self._last_diagnostic_nanos = self._last_update_nanos
+
+    self._previous_can_valid = result
+    return result
 
   def update(self, strings, sendcan: bool = False):
     if strings and not isinstance(strings[0], list | tuple):

--- a/opendbc_repo/opendbc/can/tests/test_packer_parser.py
+++ b/opendbc_repo/opendbc/can/tests/test_packer_parser.py
@@ -1,7 +1,9 @@
 import pytest
 import random
 
+import opendbc.can.parser as parser_module
 from opendbc.can import CANPacker, CANParser
+from opendbc.can.parser import CAN_DIAGNOSTIC_INTERVAL_NS, CAN_DIAGNOSTIC_MAX_OFFENDERS, CAN_INVALID_CNT, MessageState
 from opendbc.can.tests import TEST_DBC
 
 MAX_BAD_COUNTER = 5
@@ -366,3 +368,144 @@ class TestCanParserPacker:
     assert packer.make_can_msg("ACC_CONTROL", 0, {"UNKNOWN_SIGNAL": 0}) == (835, b'\x00\x00\x00\x00\x00\x00\x00N', 0)
     assert packer.make_can_msg("UNKNOWN_MESSAGE", 0, {"UNKNOWN_SIGNAL": 0}) == (0, b'', 0)
     assert packer.make_can_msg(0, 0, {"UNKNOWN_SIGNAL": 0}) == (0, b'', 0)
+
+  def test_can_valid_diagnostic_startup_and_disabled_regression(self, monkeypatch):
+    dbc_file = "honda_civic_touring_2016_can_generated"
+    packer = CANPacker(dbc_file)
+    error_calls = []
+    monkeypatch.setattr(parser_module.carlog, "error", error_calls.append)
+
+    enabled_parser = CANParser(dbc_file, [("VSA_STATUS", 50)], 0, enable_can_valid_diagnostics=True)
+    for _ in range(CAN_INVALID_CNT + 2):
+      assert not enabled_parser.can_valid
+    t0 = 1_000_000_000
+    enabled_parser.update([t0, [packer.make_can_msg("VSA_STATUS", 0, {})]])
+    assert enabled_parser.can_valid
+    assert error_calls == []
+
+    disabled_parser = CANParser(dbc_file, [("VSA_STATUS", 50)], 0)
+    disabled_parser.update([t0, [packer.make_can_msg("VSA_STATUS", 0, {})]])
+    assert disabled_parser.can_valid
+    state = next(iter(disabled_parser.message_states.values()))
+    disabled_parser.update([t0 + int(state.timeout_threshold) + 1, []])
+    results = [disabled_parser.can_valid for _ in range(CAN_INVALID_CNT)]
+    assert results == [True] * (CAN_INVALID_CNT - 1) + [False]
+    assert error_calls == []
+
+  def test_can_valid_diagnostic_falling_edge_recovery_and_rate_limit(self, monkeypatch):
+    dbc_file = "honda_civic_touring_2016_can_generated"
+    packer = CANPacker(dbc_file)
+    parser = CANParser(dbc_file, [("VSA_STATUS", 50)], 1, enable_can_valid_diagnostics=True)
+    state = next(iter(parser.message_states.values()))
+    error_calls = []
+    monkeypatch.setattr(parser_module.carlog, "error", error_calls.append)
+
+    t0 = 1_000_000_000
+    parser.update([t0, [packer.make_can_msg("VSA_STATUS", 1, {})]])
+    assert parser.can_valid
+    first_timeout = t0 + int(state.timeout_threshold) + 1
+    parser.update([first_timeout, []])
+    results = [parser.can_valid for _ in range(CAN_INVALID_CNT)]
+    assert results == [True] * (CAN_INVALID_CNT - 1) + [False]
+    assert len(error_calls) == 1
+
+    event = error_calls[0]
+    assert "CANParser canValid falling edge:" in event
+    assert "bus=1" in event
+    assert "offender_count=1" in event
+    assert hex(state.address) in event
+    assert "VSA_STATUS" in event
+    assert "stale" in event
+    assert "frequency_hz" in event
+    assert "age_ms" in event
+    assert "omitted=0" in event
+
+    for _ in range(CAN_INVALID_CNT + 2):
+      assert not parser.can_valid
+    assert len(error_calls) == 1
+
+    recovery_time = first_timeout + 1
+    parser.update([recovery_time, [packer.make_can_msg("VSA_STATUS", 1, {})]])
+    assert parser.can_valid
+    second_timeout = max(
+      recovery_time + int(state.timeout_threshold) + 1,
+      first_timeout + CAN_DIAGNOSTIC_INTERVAL_NS,
+    )
+    parser.update([second_timeout, []])
+    results = [parser.can_valid for _ in range(CAN_INVALID_CNT)]
+    assert results == [True] * (CAN_INVALID_CNT - 1) + [False]
+    assert len(error_calls) == 2
+    assert "CANParser canValid falling edge:" in error_calls[1]
+
+  def test_can_valid_diagnostic_counter_failure(self, monkeypatch):
+    dbc_file = "honda_civic_touring_2016_can_generated"
+    packer = CANPacker(dbc_file)
+    parser = CANParser(dbc_file, [("STEERING_CONTROL", 100)], 0, enable_can_valid_diagnostics=True)
+    state = next(iter(parser.message_states.values()))
+    error_calls = []
+    monkeypatch.setattr(parser_module.carlog, "error", error_calls.append)
+
+    t0 = 1_000_000_000
+    values = {"COUNTER": 1}
+    parser.update([t0, [packer.make_can_msg("STEERING_CONTROL", 0, values)]])
+    assert parser.can_valid
+
+    results = []
+    for i in range(1, MAX_BAD_COUNTER + 1):
+      timestamp = t0 + i * 10_000_000
+      parser.update([timestamp, [packer.make_can_msg("STEERING_CONTROL", 0, values)]])
+      results.append(parser.can_valid)
+
+    assert results == [True] * (MAX_BAD_COUNTER - 1) + [False]
+    assert state.counter_fail >= MAX_BAD_COUNTER
+    assert len(error_calls) == 1
+    event = error_calls[0]
+    assert "CANParser canValid falling edge:" in event
+    assert hex(state.address) in event
+    assert "STEERING_CONTROL" in event
+    assert "counter-invalid" in event
+    assert "stale" not in event
+
+  def test_can_valid_diagnostic_bounded_missing_offenders(self, monkeypatch):
+    dbc_file = "honda_civic_touring_2016_can_generated"
+    packer = CANPacker(dbc_file)
+    parser = CANParser(dbc_file, [("VSA_STATUS", 50)], 0, enable_can_valid_diagnostics=True)
+    original_state = next(iter(parser.message_states.values()))
+    error_calls = []
+    monkeypatch.setattr(parser_module.carlog, "error", error_calls.append)
+
+    t0 = 1_000_000_000
+    parser.update([t0, [packer.make_can_msg("VSA_STATUS", 0, {})]])
+    assert parser.can_valid
+
+    base_address = max(parser.message_states) + 1
+    for i in range(9):
+      address = base_address + i
+      parser.message_states[address] = MessageState(
+        address=address,
+        name=f"MISSING_{i}",
+        size=8,
+        signals=[],
+        frequency=10,
+        timeout_threshold=1_000_000_000,
+      )
+
+    timeout = t0 + int(original_state.timeout_threshold) + 1
+    parser.update([timeout, []])
+    results = [parser.can_valid for _ in range(CAN_INVALID_CNT)]
+    assert results == [True] * (CAN_INVALID_CNT - 1) + [False]
+    assert len(error_calls) == 1
+
+    event = error_calls[0]
+    assert "CANParser canValid falling edge:" in event
+    assert "offender_count=10" in event
+    assert "omitted=2" in event
+    assert "missing" in event
+    assert "stale" in event
+    assert "'age_ms': 'unknown'" in event
+    assert event.count("'address':") == CAN_DIAGNOSTIC_MAX_OFFENDERS
+
+    displayed_addresses = [original_state.address, *(base_address + i for i in range(7))]
+    positions = [event.find(hex(address)) for address in displayed_addresses]
+    assert all(position >= 0 for position in positions)
+    assert positions == sorted(positions)

--- a/opendbc_repo/opendbc/car/honda/carcontroller.py
+++ b/opendbc_repo/opendbc/car/honda/carcontroller.py
@@ -24,6 +24,11 @@ VisualAlert = structs.CarControl.HUDControl.VisualAlert
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 
 
+ACCORD11G_BRAKE_PID_MIN_SPEED = 1e-3
+ACCORD11G_BRAKE_PID_MAX_SPEED = 3.0
+ACCORD11G_BRAKE_PID_RELEASE_PER_UPDATE = 0.02
+
+
 def get_civic_bosch_modified_torque_lpf_tau(torque_cmd: float, prev_torque_cmd: float, v_ego: float) -> float:
   torque_delta = abs(float(torque_cmd) - float(prev_torque_cmd))
   torque_cmd_abs = abs(float(torque_cmd))
@@ -94,6 +99,30 @@ def get_civic_bosch_modified_steering_pressed(
 
 def get_honda_bosch_wind_brake_mps2(v_ego: float) -> float:
   return float(np.interp(v_ego, [0.0, 13.4, 22.4, 31.3, 40.2], [0.000, 0.049, 0.136, 0.267, 0.441]))
+
+
+def update_accord11g_low_speed_brake_pid(
+  brake_pid: PIDController,
+  accel: float,
+  actual_accel: float,
+  v_ego: float,
+  active_accel_threshold: float,
+  long_active: bool,
+) -> float:
+  if not long_active:
+    brake_pid.reset()
+    return accel
+
+  if accel < active_accel_threshold and ACCORD11G_BRAKE_PID_MIN_SPEED < v_ego < ACCORD11G_BRAKE_PID_MAX_SPEED:
+    brake_addon = brake_pid.update(error=accel - actual_accel, speed=v_ego)
+  else:
+    if brake_pid.i < 0.0:
+      brake_pid.i = min(0.0, brake_pid.i + ACCORD11G_BRAKE_PID_RELEASE_PER_UPDATE)
+    else:
+      brake_pid.reset()
+    brake_addon = brake_pid.i
+
+  return min(accel, accel + brake_addon)
 
 
 def update_honda_bosch_live_learning(
@@ -437,17 +466,18 @@ class CarController(CarControllerBase):
         ts = self.frame * DT_CTRL
 
         if self.CP.carFingerprint in HONDA_BOSCH:
-          if self.mvl_accord_mode and (accel < min_gas) and (1e-3 < CS.out.vEgo < 3.0):
-            brake_addon = self.mvl_brake_pid.update(error=accel - CS.out.aEgo, speed=CS.out.vEgo)
-            target_accel = min(accel, accel + brake_addon)
-          else:
-            if self.mvl_accord_mode:
-              self.mvl_brake_pid.reset()
-            target_accel = accel
+          target_accel = update_accord11g_low_speed_brake_pid(
+            self.mvl_brake_pid,
+            accel,
+            CS.out.aEgo,
+            CS.out.vEgo,
+            min_gas,
+            CC.longActive,
+          ) if self.mvl_accord_mode else accel
 
           self.accel = float(np.clip(target_accel, self.params.BOSCH_ACCEL_MIN, self.params.BOSCH_ACCEL_MAX))
-          # MVL uses requested accel (not extra-brake-adjusted accel) to decide propulsion crossover.
-          gas_pedal_force = (accel if self.mvl_accord_mode else self.accel) + hill_brake
+          # Keep propulsion inhibited while the Accord's extra-brake integrator releases.
+          gas_pedal_force = (target_accel if self.mvl_accord_mode else self.accel) + hill_brake
 
           if self.CP.carFingerprint not in HONDA_BOSCH_RADARLESS:
             gas_pedal_force += wind_brake_mps2 * self.bosch_wind_factor

--- a/opendbc_repo/opendbc/car/honda/carcontroller.py
+++ b/opendbc_repo/opendbc/car/honda/carcontroller.py
@@ -24,6 +24,7 @@ VisualAlert = structs.CarControl.HUDControl.VisualAlert
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 
 
+ACCORD11G_BRAKE_PID_DECEL_THRESHOLD = 1e-3
 ACCORD11G_BRAKE_PID_MIN_SPEED = 1e-3
 ACCORD11G_BRAKE_PID_MAX_SPEED = 3.0
 ACCORD11G_BRAKE_PID_RELEASE_PER_UPDATE = 0.02
@@ -471,7 +472,7 @@ class CarController(CarControllerBase):
             accel,
             CS.out.aEgo,
             CS.out.vEgo,
-            min_gas,
+            ACCORD11G_BRAKE_PID_DECEL_THRESHOLD,
             CC.longActive,
           ) if self.mvl_accord_mode else accel
 

--- a/opendbc_repo/opendbc/car/honda/carcontroller.py
+++ b/opendbc_repo/opendbc/car/honda/carcontroller.py
@@ -204,6 +204,26 @@ def process_hud_alert(hud_alert):
   return alert_fcw, alert_steer_required
 
 
+def persist_honda_learned_params_nonblocking(params, gas_factor, wind_factor):
+  # Persist gas and wind factors asynchronously using put_nonblocking
+  params.put_nonblocking("HondaGasFactorParams", float(gas_factor))
+  params.put_nonblocking("HondaWindFactorParams", float(wind_factor))
+
+
+LKAS_STATE_CHANGE_PULSE_FRAMES = 30
+
+
+def update_accord11g_lkas_state_change(last_key, remaining_frames, hud_key):
+  if hud_key != last_key:
+    last_key = hud_key
+    remaining_frames = LKAS_STATE_CHANGE_PULSE_FRAMES
+
+  state_change = remaining_frames > 0
+  remaining_frames = max(0, remaining_frames - 1)
+
+  return last_key, remaining_frames, state_change
+
+
 class CarController(CarControllerBase):
   def __init__(self, dbc_names, CP):
     super().__init__(dbc_names, CP)
@@ -220,6 +240,11 @@ class CarController(CarControllerBase):
     self.last_acc_enabled = False
     self.lkas_button_send_remaining = 0
     self.last_lkas_button_frame = 0
+
+    # Accord 11G stock-style cluster state-change pulse.
+    # Inactive for every other Honda.
+    self.lkas_hud_key = None
+    self.lkas_state_change_frames = 0
 
     self.braking = False
     self.brake_steady = 0.0
@@ -538,9 +563,32 @@ class CarController(CarControllerBase):
 
       steering_available = CS.out.cruiseState.available and CS.out.vEgo > self.CP.minSteerSpeed
       reduced_steering = filtered_steering_pressed
+
+      lkas_state_change = None
+
+      if self.mvl_accord_mode:
+        lanes_visible = bool(hud_control.lanesVisible or CC.latActive)
+
+        hud_key = (
+          lanes_visible,
+          bool(alert_steer_required),
+        )
+
+        (
+          self.lkas_hud_key,
+          self.lkas_state_change_frames,
+          lkas_state_change,
+        ) = update_accord11g_lkas_state_change(
+          self.lkas_hud_key,
+          self.lkas_state_change_frames,
+          hud_key,
+        )
+
       can_sends.extend(
         hondacan.create_lkas_hud(
-          self.packer, self.CAN.lkas, self.CP, hud_control, CC.latActive, steering_available, reduced_steering, alert_steer_required, CS.lkas_hud
+          self.packer, self.CAN.lkas, self.CP, hud_control, CC.latActive,
+          steering_available, reduced_steering, alert_steer_required,
+          CS.lkas_hud, lkas_state_change=lkas_state_change,
         )
       )
 
@@ -581,8 +629,7 @@ class CarController(CarControllerBase):
       ))
 
     if self.frame > 0 and self.frame % 6000 == 0:
-      self.param_store.put_float("HondaGasFactorParams", self.bosch_gas_factor)
-      self.param_store.put_float("HondaWindFactorParams", self.bosch_wind_factor)
+      persist_honda_learned_params_nonblocking(self.param_store, self.bosch_gas_factor, self.bosch_wind_factor)
 
     new_actuators = actuators.as_builder()
     new_actuators.speed = self.speed

--- a/opendbc_repo/opendbc/car/honda/carstate.py
+++ b/opendbc_repo/opendbc/car/honda/carstate.py
@@ -354,26 +354,27 @@ class CarState(CarStateBase):
 
   def get_can_parsers(self, CP):
     pt_messages = [("GAS_SENSOR", 0)] if CP.enableGasInterceptorDEPRECATED else []
+    enable_can_valid_diagnostics = CP.carFingerprint == CAR.HONDA_ACCORD_11G
     if CP.carFingerprint == CAR.HONDA_ACCORD_11G:
       # Both deliberately go silent during the handover, so skip alive/timeout checks.
       pt_messages += [("ACC_CONTROL", float("nan")), ("STEERING_CONTROL", float("nan"))]
 
-    pt_parser = CANParser(DBC[CP.carFingerprint][Bus.pt], pt_messages, CanBus(CP).pt)
+    pt_parser = CANParser(DBC[CP.carFingerprint][Bus.pt], pt_messages, CanBus(CP).pt, enable_can_valid_diagnostics=enable_can_valid_diagnostics)
     if CP.enableGasInterceptorDEPRECATED:
       pt_parser.message_states[0x201].ignore_checksum = True
       pt_parser.message_states[0x201].ignore_counter = True
 
     parsers = {
       Bus.pt: pt_parser,
-      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).camera),
+      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).camera, enable_can_valid_diagnostics=enable_can_valid_diagnostics),
     }
     if CP.enableBsm:
-      parsers[Bus.body] = CANParser(DBC[CP.carFingerprint][Bus.body], [], CanBus(CP).radar)
+      parsers[Bus.body] = CANParser(DBC[CP.carFingerprint][Bus.body], [], CanBus(CP).radar, enable_can_valid_diagnostics=enable_can_valid_diagnostics)
     if CP.carFingerprint == CAR.HONDA_ACCORD_11G:
       parsers[Bus.radar] = CANParser(DBC[CP.carFingerprint][Bus.radar], [
         ("RADAR_SUPP_TICK_REFERENCE", 0),
         ("RADAR_HUD_TICK_REFERENCE", 0),
         ("RADAR_50HZ_TICK_REFERENCE", 0),
-      ], CanBus(CP).radar)
+      ], CanBus(CP).radar, enable_can_valid_diagnostics=enable_can_valid_diagnostics)
 
     return parsers

--- a/opendbc_repo/opendbc/car/honda/hondacan.py
+++ b/opendbc_repo/opendbc/car/honda/hondacan.py
@@ -178,7 +178,8 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, 
   return packer.make_can_msg("ACC_HUD", bus, acc_hud_values)
 
 
-def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available, reduced_steering, alert_steer_required, lkas_hud):
+def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available, reduced_steering, alert_steer_required, lkas_hud,
+                    lkas_state_change=None):
   commands = []
   lanes_visible = bool(hud_control.lanesVisible or lat_active)
 
@@ -189,6 +190,11 @@ def create_lkas_hud(packer, bus, CP, hud_control, lat_active, steering_available
     'SOLID_LANES': lanes_visible,
     'BEEP': 0,
   }
+
+  # Preserve historical behavior for existing callers.
+  # Accord 11G explicitly supplies the stock-style pulse.
+  if lkas_state_change is not None:
+    lkas_hud_values['LKAS_STATE_CHANGE'] = int(lkas_state_change)
 
   if CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
     lkas_hud_values['LANE_LINES'] = 3

--- a/opendbc_repo/opendbc/car/honda/tests/test_honda.py
+++ b/opendbc_repo/opendbc/car/honda/tests/test_honda.py
@@ -10,6 +10,7 @@ from opendbc.car.honda.interface import CarInterface
 from opendbc.car.honda.carcontroller import (
   CarController,
   persist_honda_learned_params_nonblocking,
+  update_accord11g_low_speed_brake_pid,
   get_civic_bosch_modified_steering_pressed,
   get_civic_bosch_modified_torque_lpf_tau,
   get_honda_bosch_wind_brake_mps2,
@@ -28,7 +29,74 @@ def get_test_toggles() -> SimpleNamespace:
   return SimpleNamespace(always_on_lateral_lkas=False, force_torque_controller=False, nnff=False, nnff_lite=False)
 
 
+class FakeBrakePid:
+  def __init__(self, i=0.0, update_result=-0.25):
+    self.i = i
+    self.update_result = update_result
+    self.updates = []
+    self.reset_count = 0
+
+  def update(self, *, error, speed):
+    self.updates.append((error, speed))
+    self.i = self.update_result
+    return self.update_result
+
+  def reset(self):
+    self.i = 0.0
+    self.reset_count += 1
+
+
 class TestHondaFingerprint:
+  def test_accord11g_low_speed_brake_pid_tracks_below_existing_crossover(self):
+    pid = FakeBrakePid(update_result=-0.25)
+
+    target_accel = update_accord11g_low_speed_brake_pid(
+      pid, accel=-0.3, actual_accel=-0.1, v_ego=1.0,
+      active_accel_threshold=-0.2, long_active=True,
+    )
+
+    assert target_accel == pytest.approx(-0.55)
+    assert pid.updates == [pytest.approx((-0.2, 1.0))]
+    assert pid.reset_count == 0
+
+  def test_accord11g_low_speed_brake_pid_releases_before_allowing_gas(self):
+    pid = FakeBrakePid(i=-0.4)
+
+    target_accel = update_accord11g_low_speed_brake_pid(
+      pid, accel=0.1, actual_accel=0.0, v_ego=1.0,
+      active_accel_threshold=-0.2, long_active=True,
+    )
+
+    assert pid.i == pytest.approx(-0.38)
+    assert target_accel == pytest.approx(-0.28)
+    assert not pid.updates
+    assert pid.reset_count == 0
+
+  def test_accord11g_low_speed_brake_pid_resets_immediately_when_disengaged(self):
+    pid = FakeBrakePid(i=-0.4)
+
+    target_accel = update_accord11g_low_speed_brake_pid(
+      pid, accel=0.0, actual_accel=0.0, v_ego=1.0,
+      active_accel_threshold=-0.2, long_active=False,
+    )
+
+    assert target_accel == pytest.approx(0.0)
+    assert pid.i == pytest.approx(0.0)
+    assert pid.reset_count == 1
+    assert not pid.updates
+
+  def test_accord11g_low_speed_brake_pid_clears_nonnegative_state(self):
+    pid = FakeBrakePid(i=0.0)
+
+    target_accel = update_accord11g_low_speed_brake_pid(
+      pid, accel=0.1, actual_accel=0.0, v_ego=1.0,
+      active_accel_threshold=-0.2, long_active=True,
+    )
+
+    assert target_accel == pytest.approx(0.1)
+    assert pid.reset_count == 1
+    assert not pid.updates
+
   def test_honda_lkas_hud_shows_lane_lines_when_lateral_only_is_active(self):
     class FakePacker:
       @staticmethod

--- a/opendbc_repo/opendbc/car/honda/tests/test_honda.py
+++ b/opendbc_repo/opendbc/car/honda/tests/test_honda.py
@@ -5,6 +5,7 @@ import pytest
 from opendbc.car import Bus, structs
 from opendbc.car.structs import CarParams
 from opendbc.car import gen_empty_fingerprint
+from opendbc.car.honda.carstate import CarState
 from opendbc.car.honda.interface import CarInterface
 from opendbc.car.honda.carcontroller import (
   CarController,
@@ -277,6 +278,19 @@ class TestHondaFingerprint:
     assert Bus.radar not in DBC[crv_cp.carFingerprint]
     assert accord_cp.safetyConfigs[-1].safetyParam & HondaSafetyFlags.BOSCH_CANFD_MVL
     assert not crv_cp.safetyConfigs[-1].safetyParam & HondaSafetyFlags.BOSCH_CANFD_MVL
+
+  def test_can_valid_diagnostics_are_scoped_to_accord_11g(self):
+    fpcp = SimpleNamespace(flags=0)
+    accord_cp = CarInterface.get_non_essential_params(CAR.HONDA_ACCORD_11G)
+    civic_cp = CarInterface.get_non_essential_params(CAR.HONDA_CIVIC_BOSCH)
+
+    accord_parsers = CarState(accord_cp, fpcp).get_can_parsers(accord_cp)
+    civic_parsers = CarState(civic_cp, fpcp).get_can_parsers(civic_cp)
+
+    assert accord_parsers
+    assert all(parser._enable_can_valid_diagnostics for parser in accord_parsers.values())
+    assert civic_parsers
+    assert all(not parser._enable_can_valid_diagnostics for parser in civic_parsers.values())
 
   def test_nidec_pedal_detection_enables_interceptor_path(self):
     toggles = get_test_toggles()

--- a/opendbc_repo/opendbc/car/honda/tests/test_honda.py
+++ b/opendbc_repo/opendbc/car/honda/tests/test_honda.py
@@ -8,6 +8,7 @@ from opendbc.car import gen_empty_fingerprint
 from opendbc.car.honda.carstate import CarState
 from opendbc.car.honda.interface import CarInterface
 from opendbc.car.honda.carcontroller import (
+  ACCORD11G_BRAKE_PID_DECEL_THRESHOLD,
   CarController,
   persist_honda_learned_params_nonblocking,
   update_accord11g_low_speed_brake_pid,
@@ -96,6 +97,44 @@ class TestHondaFingerprint:
     assert target_accel == pytest.approx(0.1)
     assert pid.reset_count == 1
     assert not pid.updates
+
+  @pytest.mark.parametrize("accel, expected_active", (
+    (-0.2, True),
+    (0.0, True),
+    (0.0005, True),
+    (ACCORD11G_BRAKE_PID_DECEL_THRESHOLD, False),
+    (0.01, False),
+  ))
+  def test_accord11g_low_speed_brake_pid_uses_all_decel_requests(self, accel, expected_active):
+    pid = FakeBrakePid(update_result=-0.1)
+
+    update_accord11g_low_speed_brake_pid(
+      pid, accel=accel, actual_accel=0.0, v_ego=1.0,
+      active_accel_threshold=ACCORD11G_BRAKE_PID_DECEL_THRESHOLD, long_active=True,
+    )
+
+    assert bool(pid.updates) is expected_active
+    assert (pid.reset_count == 0) is expected_active
+
+  @pytest.mark.parametrize("v_ego, expected_active", (
+    (0.0, False),
+    (0.001, False),
+    (0.01, True),
+    (1.0, True),
+    (2.999, True),
+    (3.0, False),
+    (3.1, False),
+  ))
+  def test_accord11g_low_speed_brake_pid_preserves_speed_envelope(self, v_ego, expected_active):
+    pid = FakeBrakePid(update_result=-0.1)
+
+    update_accord11g_low_speed_brake_pid(
+      pid, accel=-0.1, actual_accel=0.0, v_ego=v_ego,
+      active_accel_threshold=ACCORD11G_BRAKE_PID_DECEL_THRESHOLD, long_active=True,
+    )
+
+    assert bool(pid.updates) is expected_active
+    assert (pid.reset_count == 0) is expected_active
 
   def test_honda_lkas_hud_shows_lane_lines_when_lateral_only_is_active(self):
     class FakePacker:

--- a/opendbc_repo/opendbc/car/honda/tests/test_honda.py
+++ b/opendbc_repo/opendbc/car/honda/tests/test_honda.py
@@ -8,10 +8,12 @@ from opendbc.car import gen_empty_fingerprint
 from opendbc.car.honda.interface import CarInterface
 from opendbc.car.honda.carcontroller import (
   CarController,
+  persist_honda_learned_params_nonblocking,
   get_civic_bosch_modified_steering_pressed,
   get_civic_bosch_modified_torque_lpf_tau,
   get_honda_bosch_wind_brake_mps2,
   update_honda_bosch_live_learning,
+  update_accord11g_lkas_state_change,
 )
 from opendbc.car.honda.hondacan import create_lkas_hud
 from opendbc.car.honda.fingerprints import FW_VERSIONS
@@ -38,6 +40,76 @@ class TestHondaFingerprint:
     cmds = create_lkas_hud(FakePacker(), 0, CP, hud_control, True, True, False, False, {})
 
     assert cmds[0][2]["SOLID_LANES"] is True
+
+  def test_accord11g_lkas_state_change_pulse(self):
+    key = None
+    frames = 0
+    hud_key = (False, False)
+
+    # First observed state starts one stock-style 3-second pulse.
+    key, frames, state_change = update_accord11g_lkas_state_change(
+      key, frames, hud_key
+    )
+
+    assert state_change
+    assert frames == 29
+
+    # Remaining 29 10-Hz messages stay high.
+    for _ in range(29):
+      key, frames, state_change = update_accord11g_lkas_state_change(
+        key, frames, hud_key
+      )
+      assert state_change
+
+    assert frames == 0
+
+    # Unchanged state is normally low afterward.
+    key, frames, state_change = update_accord11g_lkas_state_change(
+      key, frames, hud_key
+    )
+
+    assert not state_change
+    assert frames == 0
+
+    # A real HUD-state transition retriggers the pulse.
+    key, frames, state_change = update_accord11g_lkas_state_change(
+      key, frames, (True, False)
+    )
+
+    assert state_change
+    assert frames == 29
+
+  def test_accord11g_lkas_hud_dynamic_state_change(self):
+    class FakePacker:
+      @staticmethod
+      def make_can_msg(name, bus, values):
+        return name, bus, values
+
+    CP = CarInterface.get_non_essential_params(CAR.HONDA_ACCORD_11G)
+    hud_control = SimpleNamespace(lanesVisible=True)
+
+    # Existing/default behavior remains high.
+    cmds = create_lkas_hud(
+      FakePacker(), 0, CP, hud_control,
+      True, True, False, False, {}
+    )
+    assert cmds[0][2]["LKAS_STATE_CHANGE"] == 1
+
+    # Accord controller may explicitly hold it low.
+    cmds = create_lkas_hud(
+      FakePacker(), 0, CP, hud_control,
+      True, True, False, False, {},
+      lkas_state_change=False,
+    )
+    assert cmds[0][2]["LKAS_STATE_CHANGE"] == 0
+
+    # And pulse it high.
+    cmds = create_lkas_hud(
+      FakePacker(), 0, CP, hud_control,
+      True, True, False, False, {},
+      lkas_state_change=True,
+    )
+    assert cmds[0][2]["LKAS_STATE_CHANGE"] == 1
 
   def test_fw_version_format(self):
     # Asserts all FW versions follow an expected format
@@ -246,6 +318,31 @@ class TestHondaFingerprint:
 
     assert controller.bosch_gas_factor == pytest.approx(1.25)
     assert controller.bosch_wind_factor == pytest.approx(0.85)
+
+  def test_honda_param_writer_persists_snapshot_asynchronously(self):
+    class FakeParams:
+      def __init__(self):
+        self.values = []
+        self.put_nonblocking_called = False
+
+      def put_nonblocking(self, key, value):
+        self.put_nonblocking_called = True
+        self.values.append((key, float(value)))
+
+      def put_float(self, key, value):
+        # This should never be called in our test
+        raise AssertionError("put_float should not be called")
+
+    params = FakeParams()
+
+    # Test the helper function directly
+    persist_honda_learned_params_nonblocking(params, 1.25, 0.875)
+
+    # Verify exactly two calls in order with correct values
+    assert len(params.values) == 2
+    assert params.values[0] == ("HondaGasFactorParams", 1.25)
+    assert params.values[1] == ("HondaWindFactorParams", 0.875)
+    assert params.put_nonblocking_called
 
   def test_honda_bosch_controller_does_not_deepen_planner_braking(self, monkeypatch):
     toggles = get_test_toggles()

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -282,6 +282,13 @@ def update_twitch_guard(remaining: float, v_ego: float, standstill: bool) -> flo
   return max(remaining - DT_CTRL, 0.0)
 
 
+def twitch_guard_allowed(honda_accord_11g: bool, blinker_active: bool,
+                         turn_hold_active: bool, lane_change_active: bool) -> bool:
+  if honda_accord_11g:
+    return not (blinker_active or turn_hold_active or lane_change_active)
+  return not (blinker_active or turn_hold_active)
+
+
 def get_control_lateral_smooth_seconds(brand: str, v_ego: float, vehicle_smooth_seconds: float) -> float:
   if brand == "rivian" or (brand == "subaru" and vehicle_smooth_seconds > 0.0):
     return get_car_lateral_smooth_seconds(brand, v_ego, vehicle_smooth_seconds)
@@ -403,6 +410,7 @@ class Controls:
     self.turn_hold_done = False
     self.turn_blinker_swept = 0.0
     self.twitch_guard_remaining = 0.0
+    self.honda_accord_11g_lateral = self.CP.brand == "honda" and self.CP.carFingerprint == HONDA_CAR.HONDA_ACCORD_11G
     self.kona_non_scc_lateral_active = False
     self.kona_non_scc_lateral_faulted = False
     self.elantra_hev_2024_lateral_faulted = False
@@ -590,9 +598,14 @@ class Controls:
     # here is positive for RIGHT turns (pauseturn log: left turn at +148 deg steering
     # angle logs desiredCurvature -0.07), so the blinker maps right=+1, left=-1.
     blinker_dir = float(CS.rightBlinker) - float(CS.leftBlinker)
+    lane_change_active = model_v2.meta.laneChangeState != LaneChangeState.off
     if (CC.latActive and self.twitch_guard_remaining > 0.0 and
-        blinker_dir == 0.0 and self.turn_hold_curvature == 0.0):
+        twitch_guard_allowed(self.honda_accord_11g_lateral, blinker_dir != 0.0,
+                             self.turn_hold_curvature != 0.0, lane_change_active)):
       new_desired_curvature = limit_curvature_to_plan(model_v2, new_desired_curvature, CS.vEgo)
+    # The validated Accord path keeps the native model/action curvature and does not
+    # inherit generic turn-hold or turn-lead shaping. Lane centering remains downstream.
+    accord11g_raw_curvature = new_desired_curvature
     # heading swept in the blinker's direction over the whole blinker cycle (any speed):
     # discriminates a turn not yet made from one being exited (see the re-arm below)
     if blinker_dir == 0.0:
@@ -741,6 +754,11 @@ class Controls:
             held_mag = min(lead_curvature * blinker_dir, abs(self.turn_hold_curvature) + CURVATURE_HOLD_RATCHET_RATE * DT_CTRL)
             self.turn_hold_curvature = math.copysign(held_mag, lead_curvature)
 
+    if self.honda_accord_11g_lateral:
+      new_desired_curvature = accord11g_raw_curvature
+      self.turn_hold_curvature = 0.0
+      self.turn_hold_done = False
+
     new_desired_curvature = self.lane_centering.update(
       new_desired_curvature, model_v2, CS.vEgo,
       self.starpilot_toggles.lane_centering,
@@ -786,9 +804,14 @@ class Controls:
           jerk_factor = self.lc_arrest_jerk_factor + rise_alpha * (jerk_factor - self.lc_arrest_jerk_factor)
       self.lc_arrest_jerk_factor = jerk_factor
 
+    if self.honda_accord_11g_lateral:
+      jerk_factor = 1.0
+
     self.desired_curvature, curvature_limited = clip_curvature(CS.vEgo, self.desired_curvature, new_desired_curvature, lp.roll,
                                                                jerk_factor)
-    lat_smooth_seconds = get_control_lateral_smooth_seconds(self.CP.brand, CS.vEgo, self.CP.lateralSmoothSeconds)
+    lat_smooth_seconds = 0.0 if self.honda_accord_11g_lateral else get_control_lateral_smooth_seconds(
+      self.CP.brand, CS.vEgo, self.CP.lateralSmoothSeconds,
+    )
     lat_delay = self.sm["liveDelay"].lateralDelay + lat_smooth_seconds
 
     actuators.curvature = self.desired_curvature

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -101,6 +101,7 @@ class LatControlPID(LatControl):
     self.ff_factor = CP.lateralTuning.pid.kf
     self.get_steer_feedforward = CI.get_steer_feedforward_function()
     self.is_honda_pid_lateral = CP.brand == "honda"
+    self.is_honda_accord_11g = self.is_honda_pid_lateral and CP.carFingerprint == HONDA.HONDA_ACCORD_11G
     self.honda_lateral_pid_kp_scale = 1.0
     self.honda_lateral_pid_ki_scale = 1.0
     self.is_civic_bosch_modified = CP.carFingerprint == HONDA.HONDA_CIVIC_BOSCH and bool(CP.flags & HondaFlags.EPS_MODIFIED)
@@ -113,7 +114,7 @@ class LatControlPID(LatControl):
     self.prev_output_torque = 0.0
 
   def update_honda_lateral_pid_gain_scale(self, starpilot_toggles):
-    if not self.is_honda_pid_lateral:
+    if not self.is_honda_pid_lateral or self.is_honda_accord_11g:
       return
 
     kp_scale = get_honda_lateral_pid_gain_scale(getattr(starpilot_toggles, "honda_lateral_pid_kp_scale", 1.0))

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -6,6 +6,7 @@ from openpilot.common.pid import PIDController
 from openpilot.selfdrive.modeld.constants import ModelConstants
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.selfdrive.controls.lib.longcontrol_vehicle_tunes import LongControlVehicleTuning
+from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import is_honda_accord_11g
 
 CONTROL_N_T_IDX = ModelConstants.T_IDXS[:CONTROL_N]
 clip = np.clip
@@ -22,6 +23,23 @@ TESLA_PEDAL_RELEASE_GUARD_TIME = 0.15
 TESLA_PEDAL_RELEASE_GUARD_MAX_DECEL = 0.35
 
 LongCtrlState = car.CarControl.Actuators.LongControlState
+
+
+def honda_accord_11g_long_control_state_trans(CP, active, long_control_state, should_stop,
+                                               brake_pressed, cruise_standstill):
+  """Road-validated Accord 11G state machine without shared start shaping."""
+  cruise_standstill = cruise_standstill and not bool(getattr(CP, "enableGasInterceptorDEPRECATED", False))
+  release_condition = not should_stop and not cruise_standstill and not brake_pressed
+
+  if not active:
+    return LongCtrlState.off
+  if long_control_state == LongCtrlState.off:
+    return LongCtrlState.pid if release_condition else LongCtrlState.stopping
+  if long_control_state == LongCtrlState.stopping and release_condition:
+    return LongCtrlState.pid
+  if long_control_state == LongCtrlState.pid and should_stop:
+    return LongCtrlState.stopping
+  return long_control_state
 
 def apply_deadzone(error, deadzone):
   if error > deadzone:
@@ -130,6 +148,29 @@ class LongControl:
     self.pedal_override_active = False
     self.pedal_override_release_frames = 0
     self.vehicle_tuning = LongControlVehicleTuning(CP)
+    self.honda_accord_11g = is_honda_accord_11g(CP)
+
+  def _update_honda_accord_11g(self, active, CS, a_target, should_stop, accel_limits):
+    """Use the validated Accord output policy inside the native LongControl."""
+    self.long_control_state = honda_accord_11g_long_control_state_trans(
+      self.CP, active, self.long_control_state, should_stop,
+      CS.brakePressed, CS.cruiseState.standstill,
+    )
+
+    if self.long_control_state == LongCtrlState.off:
+      self.pid.reset()
+      output_accel = 0.0
+    elif self.long_control_state == LongCtrlState.stopping:
+      output_accel = self.last_output_accel
+      if output_accel > self.CP.stopAccel:
+        output_accel = min(output_accel, 0.0) - DT_CTRL
+      self.pid.reset()
+    else:
+      error = a_target - CS.aEgo
+      output_accel = self.pid.update(error, speed=CS.vEgo, feedforward=a_target)
+
+    self.last_output_accel = float(clip(output_accel, accel_limits[0], accel_limits[1]))
+    return self.last_output_accel
 
   def update_mpc_mode(self, experimental_mode):
     new_mode = 'blended' if experimental_mode else 'acc'
@@ -237,6 +278,9 @@ class LongControl:
     """Update longitudinal control. This updates the state machine and runs a PID loop"""
     self.pid.neg_limit = accel_limits[0]
     self.pid.pos_limit = accel_limits[1]
+
+    if self.honda_accord_11g:
+      return self._update_honda_accord_11g(active, CS, a_target, should_stop, accel_limits)
 
     if pedal_override:
       self.pedal_override_active = True

--- a/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
+++ b/selfdrive/controls/lib/longitudinal_mpc_lib/long_mpc.py
@@ -14,6 +14,7 @@ from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.realtime import DT_MDL
 from openpilot.common.swaglog import cloudlog
 from openpilot.selfdrive.controls.lib.lead_behavior import get_tracked_lead_catchup_bias, is_radarless_matched_follow_window
+from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import get_honda_accord_11g_mpc_policy
 # WARNING: imports outside of constants will not trigger a rebuild
 from openpilot.selfdrive.modeld.constants import index_function, ModelConstants
 
@@ -428,10 +429,11 @@ def gen_long_ocp():
 
 
 class LongitudinalMpc:
-  def __init__(self, mode='acc', dt=DT_MDL):
+  def __init__(self, mode='acc', dt=DT_MDL, CP=None, solver=None):
     self.mode = mode
     self.dt = dt
-    self.solver = AcadosOcpSolverCython(MODEL_NAME, ACADOS_SOLVER_TYPE, N)
+    self.honda_accord_11g_policy = get_honda_accord_11g_mpc_policy(CP)
+    self.solver = solver if solver is not None else AcadosOcpSolverCython(MODEL_NAME, ACADOS_SOLVER_TYPE, N)
     self.source = SOURCES[2]
     # Initialize smoothing filters with default time constants
     self.current_filter_time = LEAD_FILTER_TIME_LOW
@@ -508,6 +510,19 @@ class LongitudinalMpc:
                   personality=log.LongitudinalPersonality.standard, v_ego=0.0, lead_dist=50.0,
                   uncertainty=0.0, accel_reengage=False, panic_bypass=False,
                   filter_time_factor_floor=0.0):
+    if self.honda_accord_11g_policy is not None:
+      policy = self.honda_accord_11g_policy
+      jerk_factor = get_jerk_factor(personality=personality)[0]
+      self.current_x_ego_cost = policy["obstacle_cost"]
+      self.current_j_ego_cost = policy["jerk_cost"]
+      self.current_a_change_cost = policy["accel_change_cost"]
+      self.current_dist_adapt = 0.0
+      a_change_cost = jerk_factor * policy["accel_change_cost"] if prev_accel_constraint else 0.0
+      cost_weights = [policy["obstacle_cost"], X_EGO_COST, V_EGO_COST, A_EGO_COST,
+                      a_change_cost, jerk_factor * policy["jerk_cost"]]
+      self.set_cost_weights(cost_weights, [LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST])
+      return
+
     # Update parameters based on current speed with interpolation for smooth scaling
     speed_mph = v_ego * CV.MS_TO_MPH  # Convert m/s to mph
 
@@ -601,7 +616,13 @@ class LongitudinalMpc:
         self.solver.set(i, 'x', self.x0)
 
   @staticmethod
-  def extrapolate_lead(x_lead, v_lead, a_lead, a_lead_tau, v_ego=0.0):
+  def extrapolate_lead(x_lead, v_lead, a_lead, a_lead_tau, v_ego=0.0, *, raw_decay=False):
+    if raw_decay:
+      a_lead_traj = a_lead * np.exp(-a_lead_tau * (T_IDXS ** 2) / 2.0)
+      v_lead_traj = np.clip(v_lead + np.cumsum(T_DIFFS * a_lead_traj), 0.0, 1e8)
+      x_lead_traj = x_lead + np.cumsum(T_DIFFS * v_lead_traj)
+      return np.column_stack((x_lead_traj, v_lead_traj))
+
     speed_mph = v_ego * CV.MS_TO_MPH
     bp = [0, 20, 35]
     exp_weight = np.interp(speed_mph, bp, [1.0, 1.0, 0.0])  # Full exp at <20, blend to constant at 35
@@ -630,6 +651,24 @@ class LongitudinalMpc:
                    smooth_duplicate_vision=False, model_lead=None):
     v_ego = self.x0[1]
     lead_active = lead is not None and lead.status and tracking_lead
+    if self.honda_accord_11g_policy is not None:
+      if lead_active:
+        x_lead = lead.dRel
+        v_lead = lead.vLead
+        a_lead = lead.aLeadK
+        a_lead_tau = lead.aLeadTau
+      else:
+        x_lead = 50.0
+        v_lead = v_ego + 10.0
+        a_lead = 0.0
+        a_lead_tau = self.honda_accord_11g_policy["lead_accel_tau"]
+
+      min_x_lead = ((v_ego + v_lead) / 2) * (v_ego - v_lead) / (-ACCEL_MIN * 2)
+      x_lead = np.clip(x_lead, min_x_lead, 1e8)
+      v_lead = np.clip(v_lead, 0.0, 1e8)
+      a_lead = np.clip(a_lead, -10.0, 5.0)
+      return self.extrapolate_lead(x_lead, v_lead, a_lead, a_lead_tau, raw_decay=True)
+
     if lead_active:
       model_lead_xv = build_model_lead_trajectory(model_lead, lead, v_ego)
       if model_lead_xv is not None:
@@ -928,6 +967,19 @@ class LongitudinalMpc:
              tracked_lead_catchup_bias_gain=None, tracked_lead_catchup_bias_cap=None,
              tracked_lead_catchup_speed_range=None, tracked_lead_catchup_fade_margins=None,
              tracked_lead_catchup_cruise_error_full=None):
+    if self.honda_accord_11g_policy is not None:
+      t_follow = get_T_FOLLOW(personality=personality)
+      optional_far_lead_comfort = False
+      smooth_duplicate_vision = False
+      modelV2 = None
+      lead_obstacle_bias = (0.0, 0.0)
+      tracked_lead_catchup_headway_margins = None
+      tracked_lead_catchup_bias_gain = None
+      tracked_lead_catchup_bias_cap = None
+      tracked_lead_catchup_speed_range = None
+      tracked_lead_catchup_fade_margins = None
+      tracked_lead_catchup_cruise_error_full = None
+
     v_ego = self.x0[1]
     lead_one = radarstate.leadOne
     lead_two = radarstate.leadTwo
@@ -951,7 +1003,7 @@ class LongitudinalMpc:
     lead_1_obstacle -= float(lead_obstacle_bias[1])
 
     self.params[:,0] = ACCEL_MIN
-    self.params[:,1] = max(0.0, self.max_a)
+    self.params[:,1] = ACCEL_MAX if self.honda_accord_11g_policy is not None else max(0.0, self.max_a)
 
     # Update in ACC mode or ACC/e2e blend
     if self.mode == 'acc':
@@ -959,9 +1011,17 @@ class LongitudinalMpc:
 
       # Fake an obstacle for cruise, this ensures smooth acceleration to set speed
       # when the leads are no factor.
-      v_lower = v_ego + (T_IDXS * self.cruise_min_a * 1.05)
+      cruise_min_a = (
+        self.honda_accord_11g_policy["cruise_min_accel"]
+        if self.honda_accord_11g_policy is not None else self.cruise_min_a
+      )
+      cruise_max_a = (
+        self.honda_accord_11g_policy["cruise_max_accel"]
+        if self.honda_accord_11g_policy is not None else self.max_a
+      )
+      v_lower = v_ego + (T_IDXS * cruise_min_a * 1.05)
       # TODO does this make sense when max_a is negative?
-      v_upper = v_ego + (T_IDXS * self.max_a * 1.05)
+      v_upper = v_ego + (T_IDXS * cruise_max_a * 1.05)
       v_cruise_clipped = np.clip(v_cruise * np.ones(N+1),
                                  v_lower,
                                  v_upper)

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -22,6 +22,9 @@ from openpilot.selfdrive.controls.lib.lead_follow_policy import is_nonurgent_dup
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_far_follow_output_slew_rates,
   get_follow_prebrake_min_headway,
+  get_honda_accord_11g_cruise_accel_max,
+  get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_total_accel_max,
   get_honda_accord_lead_departure_tune,
   get_honda_accord_stop_go_accel_cap,
   get_honda_accord_stop_go_accel_rise_rate,
@@ -340,7 +343,10 @@ def get_longitudinal_personality(sm):
   return sm['selfdriveState'].personality
 
 
-def get_max_accel(v_ego):
+def get_max_accel(v_ego, CP=None):
+  accord_11g_max = get_honda_accord_11g_cruise_accel_max(CP, v_ego) if CP is not None else None
+  if accord_11g_max is not None:
+    return accord_11g_max
   return np.interp(v_ego, A_CRUISE_MAX_BP, A_CRUISE_MAX_VALS)
 
 def get_coast_accel(pitch):
@@ -354,7 +360,8 @@ def limit_accel_in_turns(v_ego, angle_steers, a_target, CP):
   """
   # FIXME: This function to calculate lateral accel is incorrect and should use the VehicleModel
   # The lookup table for turns should also be updated if we do this
-  a_total_max = np.interp(v_ego, _A_TOTAL_MAX_BP, _A_TOTAL_MAX_V)
+  accord_11g_total_max = get_honda_accord_11g_total_accel_max(CP, v_ego)
+  a_total_max = accord_11g_total_max if accord_11g_total_max is not None else np.interp(v_ego, _A_TOTAL_MAX_BP, _A_TOTAL_MAX_V)
   a_y = v_ego ** 2 * angle_steers * CV.DEG_TO_RAD / (CP.steerRatio * CP.wheelbase)
   a_x_allowed = math.sqrt(max(a_total_max ** 2 - a_y ** 2, 0.))
 
@@ -529,12 +536,16 @@ def get_accel_from_plan_classic(CP, speeds, accels, vEgoStopping):
   return a_target, should_stop
 
 
-def get_accel_from_plan(speeds, accels, action_t=DT_MDL, vEgoStopping=0.05):
+def get_accel_from_plan(speeds, accels, action_t=DT_MDL, vEgoStopping=0.05, min_stable_delay=0.0):
   if len(speeds) == CONTROL_N:
     v_now = speeds[0]
     a_now = accels[0]
 
-    v_target = np.interp(action_t, CONTROL_N_T_IDX, speeds)
+    if 0.0 < action_t < min_stable_delay:
+      stable_v_target = np.interp(min_stable_delay, CONTROL_N_T_IDX, speeds)
+      v_target = v_now + (action_t / min_stable_delay) * (stable_v_target - v_now)
+    else:
+      v_target = np.interp(action_t, CONTROL_N_T_IDX, speeds)
     a_target = 2 * (v_target - v_now) / (action_t) - a_now
     v_target_1sec = np.interp(action_t + 1.0, CONTROL_N_T_IDX, speeds)
   else:
@@ -1988,7 +1999,11 @@ class LongitudinalPlanner:
     prev_accel_constraint = not (reset_state or sm['carState'].standstill)
 
     if self.mpc.mode == 'acc':
-      accel_limits = [sm['starpilotPlan'].minAcceleration, sm['starpilotPlan'].maxAcceleration]
+      accord_11g_accel_max = get_honda_accord_11g_cruise_accel_max(self.CP, v_ego)
+      if accord_11g_accel_max is not None:
+        accel_limits = [ACCEL_MIN, accord_11g_accel_max]
+      else:
+        accel_limits = [sm['starpilotPlan'].minAcceleration, sm['starpilotPlan'].maxAcceleration]
       steer_angle_without_offset = sm['carState'].steeringAngleDeg - sm['liveParameters'].angleOffsetDeg
       accel_limits_turns = limit_accel_in_turns(v_ego, steer_angle_without_offset, accel_limits, self.CP)
       accel_limits_turns[0] = max(get_vehicle_min_accel(self.CP, v_ego), accel_limits_turns[0])
@@ -2373,6 +2388,7 @@ class LongitudinalPlanner:
     tinygrad_model = bool(getattr(starpilot_toggles, "tinygrad_model", False))
     experimental_mlsim = bool(tinygrad_model and self.mlsim and self.mode != 'acc')
     action_t = self.CP.longitudinalActuatorDelay + DT_MDL
+    accord_11g_min_action_delay = get_honda_accord_11g_min_action_delay(self.CP) or 0.0
     prev_output_a_target = float(self.output_a_target)
     model_launch_accel = None
     if self.model_launch_armed and not bool(sm['modelV2'].action.shouldStop):
@@ -2384,7 +2400,8 @@ class LongitudinalPlanner:
     elif tinygrad_model:
       output_a_target_mpc, output_should_stop_mpc = get_accel_from_plan(
         self.v_desired_trajectory, self.a_desired_trajectory,
-        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping)
+        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping,
+        min_stable_delay=accord_11g_min_action_delay)
       output_a_target_e2e = sm['modelV2'].action.desiredAcceleration
       output_should_stop_e2e = sm['modelV2'].action.shouldStop
 
@@ -2397,7 +2414,8 @@ class LongitudinalPlanner:
     else:
       output_a_target, output_should_stop = get_accel_from_plan(
         self.v_desired_trajectory, self.a_desired_trajectory,
-        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping)
+        action_t=action_t, vEgoStopping=starpilot_toggles.vEgoStopping,
+        min_stable_delay=accord_11g_min_action_delay)
 
     comfort_output_accel_min = get_vehicle_min_accel(self.CP, v_ego) if experimental_mlsim else accel_limits_turns[0]
     vision_cap_accel_min = min(comfort_output_accel_min, get_vehicle_min_accel(self.CP, v_ego))

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -22,8 +22,11 @@ from openpilot.selfdrive.controls.lib.lead_follow_policy import is_nonurgent_dup
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_far_follow_output_slew_rates,
   get_follow_prebrake_min_headway,
+  get_honda_accord_11g_allow_throttle,
   get_honda_accord_11g_cruise_accel_max,
   get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_no_throttle_accel_max,
+  get_honda_accord_11g_reduction_only_v_cruise,
   get_honda_accord_11g_total_accel_max,
   get_honda_accord_lead_departure_tune,
   get_honda_accord_stop_go_accel_cap,
@@ -57,7 +60,7 @@ from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_tracked_lead_catchup_headway_margins,
 )
 from openpilot.selfdrive.controls.lib.drive_helpers import CONTROL_N
-from openpilot.selfdrive.car.cruise import V_CRUISE_UNSET
+from openpilot.selfdrive.car.cruise import V_CRUISE_MAX, V_CRUISE_UNSET
 from openpilot.common.swaglog import cloudlog
 from cereal import log
 
@@ -1981,10 +1984,18 @@ class LongitudinalPlanner:
 
     v_ego = get_planner_v_ego(self.CP, sm['carState'])
     scene_v_ego = float(sm['carState'].vEgo)
-    v_cruise = sm['starpilotPlan'].vCruise
-    if not np.isfinite(v_cruise):
-      cloudlog.error(f"Longitudinal planner received non-finite vCruise={v_cruise}, falling back to v_ego={v_ego:.2f}")
-      v_cruise = max(v_ego, 0.0)
+    starpilot_v_cruise = float(sm['starpilotPlan'].vCruise)
+    stock_v_cruise = min(float(sm['carState'].vCruise), V_CRUISE_MAX) * CV.KPH_TO_MS
+    accord_11g_v_cruise = get_honda_accord_11g_reduction_only_v_cruise(
+      self.CP, stock_v_cruise, starpilot_v_cruise,
+    )
+    if accord_11g_v_cruise is not None:
+      v_cruise = accord_11g_v_cruise
+    else:
+      v_cruise = starpilot_v_cruise
+      if not np.isfinite(v_cruise):
+        cloudlog.error(f"Longitudinal planner received non-finite vCruise={v_cruise}, falling back to v_ego={v_ego:.2f}")
+        v_cruise = max(v_ego, 0.0)
     v_cruise_initialized = sm['carState'].vCruise != V_CRUISE_UNSET
 
     long_control_off = sm['controlsState'].longControlState == LongCtrlState.off
@@ -2038,29 +2049,42 @@ class LongitudinalPlanner:
     # Don't clip at low speeds since throttle_prob doesn't account for creep. Raw
     # gasPressProb can cross both hysteresis thresholds for only a few model frames,
     # so confirm transitions before changing the physical coast cap.
-    if v_ego <= MIN_ALLOW_THROTTLE_SPEED:
-      self.model_allow_throttle = True
+    accord_11g_allow_throttle = get_honda_accord_11g_allow_throttle(self.CP, throttle_prob, v_ego)
+    if accord_11g_allow_throttle is not None:
+      self.model_allow_throttle = accord_11g_allow_throttle
       self.model_allow_throttle_transition_t = 0.0
     else:
-      transition_requested = (
-        throttle_prob <= ALLOW_THROTTLE_DISABLE_THRESHOLD if self.model_allow_throttle
-        else throttle_prob > ALLOW_THROTTLE_ENABLE_THRESHOLD
-      )
-      if transition_requested:
-        self.model_allow_throttle_transition_t += self.dt
-        if self.model_allow_throttle_transition_t + 1e-6 >= ALLOW_THROTTLE_TRANSITION_CONFIRM_TIME:
-          self.model_allow_throttle = not self.model_allow_throttle
-          self.model_allow_throttle_transition_t = 0.0
-      else:
+      if v_ego <= MIN_ALLOW_THROTTLE_SPEED:
+        self.model_allow_throttle = True
         self.model_allow_throttle_transition_t = 0.0
-    self.allow_throttle = self.model_allow_throttle and not sm['starpilotPlan'].disableThrottle
+      else:
+        transition_requested = (
+          throttle_prob <= ALLOW_THROTTLE_DISABLE_THRESHOLD if self.model_allow_throttle
+          else throttle_prob > ALLOW_THROTTLE_ENABLE_THRESHOLD
+        )
+        if transition_requested:
+          self.model_allow_throttle_transition_t += self.dt
+          if self.model_allow_throttle_transition_t + 1e-6 >= ALLOW_THROTTLE_TRANSITION_CONFIRM_TIME:
+            self.model_allow_throttle = not self.model_allow_throttle
+            self.model_allow_throttle_transition_t = 0.0
+        else:
+          self.model_allow_throttle_transition_t = 0.0
+    self.allow_throttle = self.model_allow_throttle and (
+      accord_11g_allow_throttle is not None or not sm['starpilotPlan'].disableThrottle
+    )
 
     if not self.allow_throttle:
-      clipped_accel_coast = max(accel_coast, accel_limits_turns[0])
-      # Hold the output cap to the physical coasting limit until throttle is
-      # allowed again. Relaxing back toward positive accel while the gate is
-      # still closed can stall downhill coastdown well above the target speed.
-      accel_limits_turns[1] = min(accel_limits_turns[1], clipped_accel_coast)
+      accord_11g_coast_cap = get_honda_accord_11g_no_throttle_accel_max(
+        self.CP, v_ego, accel_limits_turns[0], accel_limits_turns[1], accel_coast,
+      )
+      if accord_11g_coast_cap is not None:
+        accel_limits_turns[1] = accord_11g_coast_cap
+      else:
+        clipped_accel_coast = max(accel_coast, accel_limits_turns[0])
+        # Hold the output cap to the physical coasting limit until throttle is
+        # allowed again. Relaxing back toward positive accel while the gate is
+        # still closed can stall downhill coastdown well above the target speed.
+        accel_limits_turns[1] = min(accel_limits_turns[1], clipped_accel_coast)
     no_throttle_output_max = accel_limits_turns[1]
 
     if force_slow_decel:

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -563,7 +563,7 @@ def get_accel_from_plan(speeds, accels, action_t=DT_MDL, vEgoStopping=0.05, min_
 class LongitudinalPlanner:
   def __init__(self, CP, init_v=0.0, init_a=0.0, dt=DT_MDL):
     self.CP = CP
-    self.mpc = LongitudinalMpc(dt=dt)
+    self.mpc = LongitudinalMpc(dt=dt, CP=CP)
     self.fcw = False
     self.dt = dt
     self.model_allow_throttle = True
@@ -655,6 +655,8 @@ class LongitudinalPlanner:
     return is_tinygrad_model_version(self.generation)
 
   def get_mpc_mode(self) -> str:
+    if getattr(self.mpc, 'honda_accord_11g_policy', None) is not None:
+      return 'acc'
     if not self.mlsim:
       return self.mode
     return getattr(self.mpc, 'mode', 'acc')
@@ -1973,9 +1975,7 @@ class LongitudinalPlanner:
     self.generation = getattr(starpilot_toggles, "model_version", None)
     experimental_mode = bool(sm['selfdriveState'].experimentalMode)
     self.mode = 'blended' if experimental_mode else 'acc'
-    self.mpc.mode = 'acc'
-    if not self.mlsim:
-      self.mpc.mode = self.mode
+    self.mpc.mode = self.get_mpc_mode()
 
     if len(sm['carControl'].orientationNED) == 3:
       accel_coast = get_coast_accel(sm['carControl'].orientationNED[1])

--- a/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
+++ b/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
@@ -27,6 +27,14 @@ HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD = 0.4
 HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED = 2.5
 HONDA_ACCORD_11G_MIN_ACTION_DELAY = 0.3
 HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP = 0.05
+HONDA_ACCORD_11G_MPC_POLICY = {
+  "obstacle_cost": 3.0,
+  "jerk_cost": 5.0,
+  "accel_change_cost": 200.0,
+  "cruise_min_accel": -1.2,
+  "cruise_max_accel": 1.6,
+  "lead_accel_tau": 1.5,
+}
 HYUNDAI_ELANTRA_LEAD_FOLLOW_JERK_SCALE = 1.25
 GENESIS_GV70_ELECTRIFIED_LEAD_FOLLOW_JERK_SCALE = 1.75
 FORD_LIGHTNING_LEAD_FOLLOW_JERK_SCALE = 1.35
@@ -186,6 +194,10 @@ def get_honda_accord_11g_min_action_delay(CP):
 
 def get_honda_accord_11g_accel_clip_slew_step(CP):
   return HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP if is_honda_accord_11g(CP) else None
+
+
+def get_honda_accord_11g_mpc_policy(CP):
+  return HONDA_ACCORD_11G_MPC_POLICY if is_honda_accord_11g(CP) else None
 
 
 def get_honda_accord_11g_reduction_only_v_cruise(CP, stock_v_cruise, starpilot_v_cruise):

--- a/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
+++ b/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
@@ -19,6 +19,14 @@ HONDA_ACCORD_STOP_GO_MAX_LEAD_BRAKE = 0.25
 HONDA_ACCORD_STOP_GO_MAX_LATERAL_OFFSET = 1.25
 HONDA_ACCORD_STOP_GO_MIN_MODEL_PROB = 0.95
 HONDA_ACCORD_STOP_GO_ACCEL_RISE_RATE = 4.0
+HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_BP = (0.0, 10.0, 25.0, 40.0)
+HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_V = (1.6, 1.2, 0.8, 0.6)
+HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_BP = (20.0, 40.0)
+HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_V = (1.7, 3.2)
+HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD = 0.4
+HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED = 2.5
+HONDA_ACCORD_11G_MIN_ACTION_DELAY = 0.3
+HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP = 0.05
 HYUNDAI_ELANTRA_LEAD_FOLLOW_JERK_SCALE = 1.25
 GENESIS_GV70_ELECTRIFIED_LEAD_FOLLOW_JERK_SCALE = 1.75
 FORD_LIGHTNING_LEAD_FOLLOW_JERK_SCALE = 1.35
@@ -121,6 +129,50 @@ DEFAULT_FORCE_STOP_HANDOFF_M = 6.0
 HYUNDAI_SANTA_FE_2022_FORCE_STOP_REANCHOR_SPEED_TOLERANCE = 0.25
 HYUNDAI_SANTA_FE_2022_FORCE_STOP_LOW_SPEED_HOLD = 2.5
 KIA_CARNIVAL_2025_STOP_SIGN_LOW_SPEED_HOLD = 0.75
+
+
+def is_honda_accord_11g(CP):
+  return (
+    getattr(CP, "brand", "") == "honda" and
+    str(getattr(CP, "carFingerprint", "")) == "HONDA_ACCORD_11G"
+  )
+
+
+def get_honda_accord_11g_cruise_accel_max(CP, v_ego):
+  """Return the validated Accord 11G cruise acceleration ceiling."""
+  if not is_honda_accord_11g(CP):
+    return None
+  return float(np.interp(v_ego, HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_BP, HONDA_ACCORD_11G_CRUISE_ACCEL_MAX_V))
+
+
+def get_honda_accord_11g_total_accel_max(CP, v_ego):
+  """Return the validated Accord 11G combined longitudinal/lateral envelope."""
+  if not is_honda_accord_11g(CP):
+    return None
+  return float(np.interp(v_ego, HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_BP, HONDA_ACCORD_11G_TOTAL_ACCEL_MAX_V))
+
+
+def get_honda_accord_11g_throttle_policy(CP):
+  if not is_honda_accord_11g(CP):
+    return None
+  return HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD, HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED
+
+
+def get_honda_accord_11g_min_action_delay(CP):
+  return HONDA_ACCORD_11G_MIN_ACTION_DELAY if is_honda_accord_11g(CP) else None
+
+
+def get_honda_accord_11g_accel_clip_slew_step(CP):
+  return HONDA_ACCORD_11G_ACCEL_CLIP_SLEW_STEP if is_honda_accord_11g(CP) else None
+
+
+def get_honda_accord_11g_reduction_only_v_cruise(CP, stock_v_cruise, starpilot_v_cruise):
+  """Keep StarPilot as a reduction-only speed constraint for the Accord 11G."""
+  if not is_honda_accord_11g(CP):
+    return None
+  if np.isfinite(starpilot_v_cruise) and starpilot_v_cruise >= 0.0:
+    return float(min(stock_v_cruise, starpilot_v_cruise))
+  return float(stock_v_cruise)
 
 
 def get_toyota_prius_stopped_lead_obstacle_bias(CP, lead, v_ego):

--- a/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
+++ b/selfdrive/controls/lib/longitudinal_vehicle_tunes.py
@@ -158,6 +158,28 @@ def get_honda_accord_11g_throttle_policy(CP):
   return HONDA_ACCORD_11G_THROTTLE_PROB_THRESHOLD, HONDA_ACCORD_11G_MIN_ALLOW_THROTTLE_SPEED
 
 
+def get_honda_accord_11g_allow_throttle(CP, throttle_prob, v_ego):
+  policy = get_honda_accord_11g_throttle_policy(CP)
+  if policy is None:
+    return None
+  threshold, min_allow_speed = policy
+  return bool(throttle_prob > threshold or v_ego <= min_allow_speed)
+
+
+def get_honda_accord_11g_no_throttle_accel_max(CP, v_ego, accel_min, accel_max, accel_coast):
+  policy = get_honda_accord_11g_throttle_policy(CP)
+  if policy is None:
+    return None
+  _, min_allow_speed = policy
+  clipped_accel_coast = max(float(accel_coast), float(accel_min))
+  coast_cap = np.interp(
+    v_ego,
+    [min_allow_speed, min_allow_speed * 2.0],
+    [accel_max, clipped_accel_coast],
+  )
+  return float(min(accel_max, coast_cap))
+
+
 def get_honda_accord_11g_min_action_delay(CP):
   return HONDA_ACCORD_11G_MIN_ACTION_DELAY if is_honda_accord_11g(CP) else None
 

--- a/selfdrive/controls/radard.py
+++ b/selfdrive/controls/radard.py
@@ -15,11 +15,13 @@ from openpilot.common.simple_kalman import KF1D
 from openpilot.selfdrive.controls.lib.desire_helper import LaneChangeDirection, LaneChangeState
 from openpilot.starpilot.common.starpilot_variables import get_starpilot_toggles
 from opendbc.car.honda.radar_interface import BOSCH_A_FREQ_HZ
-from opendbc.car.honda.values import HONDA_BOSCH_A
+from opendbc.car.honda.values import CAR as HONDA_CAR, HONDA_BOSCH_A
 
 
 # Default lead acceleration decay set to 50% at 1s
 _LEAD_ACCEL_TAU = 0.6
+HONDA_ACCORD_11G_LEAD_ACCEL_TAU = 1.5
+HONDA_ACCORD_11G_MODEL_LEAD_PROBABILITY = 0.5
 
 # radar tracks
 SPEED, ACCEL = 0, 1     # Kalman filter states enum
@@ -40,6 +42,10 @@ HONDA_BOSCH_A_GROSS_DISTANCE_M = 25.0
 
 def is_bosch_a_radar_car(CP) -> bool:
   return CP.brand == "honda" and CP.carFingerprint in HONDA_BOSCH_A and not CP.radarUnavailable
+
+
+def is_honda_accord_11g_radar_car(CP) -> bool:
+  return CP.brand == "honda" and CP.carFingerprint == HONDA_CAR.HONDA_ACCORD_11G
 
 
 # Adjacent-lane stopped-vehicle detector, used as a stop-line hint on red-light
@@ -77,10 +83,13 @@ class KalmanParams:
 
 
 class Track:
-  def __init__(self, identifier: int, v_lead: float, kalman_params: KalmanParams):
+  def __init__(self, identifier: int, v_lead: float, kalman_params: KalmanParams,
+               honda_accord_11g_radar: bool = False):
     self.identifier = identifier
     self.cnt = 0
-    self.aLeadTau = FirstOrderFilter(_LEAD_ACCEL_TAU, 0.45, DT_MDL)
+    self.honda_accord_11g_radar = honda_accord_11g_radar
+    lead_accel_tau = HONDA_ACCORD_11G_LEAD_ACCEL_TAU if honda_accord_11g_radar else _LEAD_ACCEL_TAU
+    self.aLeadTau = FirstOrderFilter(lead_accel_tau, 0.45, DT_MDL)
     self.K_A = kalman_params.A
     self.K_C = kalman_params.C
     self.K_K = kalman_params.K
@@ -119,7 +128,9 @@ class Track:
 
     if measurement_update:
       # Learn if constant acceleration
-      if abs(self.aLeadK) < 0.5:
+      if self.honda_accord_11g_radar:
+        update_honda_accord_11g_accel_tau(self.aLeadTau, self.aLeadK)
+      elif abs(self.aLeadK) < 0.5:
         self.aLeadTau.x = min(max(self.aLeadTau.x, 1e-2) * 1.1, _LEAD_ACCEL_TAU)
       else:
         self.aLeadTau.update(0.0)
@@ -214,12 +225,78 @@ def laplacian_pdf(x: float, mu: float, b: float):
   return math.exp(-abs(x-mu)/b)
 
 
+def update_honda_accord_11g_accel_tau(a_lead_tau, a_lead_k: float) -> None:
+  if abs(a_lead_k) < 0.5:
+    a_lead_tau.x = HONDA_ACCORD_11G_LEAD_ACCEL_TAU
+  else:
+    a_lead_tau.update(0.0)
+
+
 def vision_track_probability(track: Track, lead: capnp._DynamicStructReader, v_ego: float) -> float:
   offset_vision_dist = lead.x[0] - RADAR_TO_CAMERA
   prob_d = laplacian_pdf(track.dRel, offset_vision_dist, lead.xStd[0])
   prob_y = laplacian_pdf(track.yRel, -lead.y[0], lead.yStd[0])
   prob_v = laplacian_pdf(track.vRel + v_ego, lead.v[0], lead.vStd[0])
   return prob_d * prob_y * prob_v
+
+
+def match_honda_accord_11g_vision_to_track(v_ego: float, lead, tracks: dict[int, Track]):
+  """Validated Accord association without DOM preferred-track shaping."""
+  if not tracks:
+    return None
+
+  offset_vision_dist = lead.x[0] - RADAR_TO_CAMERA
+  track = max(tracks.values(), key=lambda candidate: vision_track_probability(candidate, lead, v_ego))
+  dist_sane = abs(track.dRel - offset_vision_dist) < max(offset_vision_dist * 0.25, 5.0)
+  vel_sane = abs(track.vRel + v_ego - lead.v[0]) < 10.0 or v_ego + track.vRel > 3.0
+  return track if dist_sane and vel_sane else None
+
+
+def get_honda_accord_11g_radar_state_from_vision(lead, v_ego: float, model_v_ego: float,
+                                                  lead_prob: float) -> dict[str, Any]:
+  lead_v_rel_pred = lead.v[0] - model_v_ego
+  return {
+    "dRel": float(lead.x[0] - RADAR_TO_CAMERA),
+    "yRel": float(-lead.y[0]),
+    "vRel": float(lead_v_rel_pred),
+    "vLead": float(v_ego + lead_v_rel_pred),
+    "vLeadK": float(v_ego + lead_v_rel_pred),
+    "aLeadK": float(lead.a[0]),
+    "aLeadTau": 0.3,
+    "fcw": False,
+    "modelProb": float(lead_prob),
+    "status": True,
+    "radar": False,
+    "radarTrackId": -1,
+  }
+
+
+def get_honda_accord_11g_lead(v_ego: float, ready: bool, tracks: dict[int, Track], lead,
+                               model_v_ego: float, lead_prob: float,
+                               low_speed_override: bool = True) -> dict[str, Any]:
+  """Select an Accord lead without preferred-track, distance-offset, or target shaping."""
+  if tracks and ready and lead_prob > HONDA_ACCORD_11G_MODEL_LEAD_PROBABILITY:
+    track = match_honda_accord_11g_vision_to_track(v_ego, lead, tracks)
+  else:
+    track = None
+
+  lead_dict: dict[str, Any] = {"status": False}
+  if track is not None:
+    lead_dict = track.get_RadarState(lead_prob)
+  elif ready and lead_prob > HONDA_ACCORD_11G_MODEL_LEAD_PROBABILITY:
+    lead_dict = get_honda_accord_11g_radar_state_from_vision(lead, v_ego, model_v_ego, lead_prob)
+
+  if low_speed_override:
+    low_speed_tracks = [candidate for candidate in tracks.values() if candidate.potential_low_speed_lead(v_ego)]
+    if low_speed_tracks:
+      closest_track = min(low_speed_tracks, key=lambda candidate: candidate.dRel)
+      if not lead_dict["status"] or closest_track.dRel < lead_dict["dRel"]:
+        lead_dict = closest_track.get_RadarState()
+
+  for radar_track in tracks.values():
+    radar_track.leadTrackID = lead_dict.get("radarTrackId", -1)
+
+  return lead_dict
 
 
 def g90_radar_lead_lateral_sane(track: Track) -> bool:
@@ -432,11 +509,12 @@ def get_adjacent_stopped(tracks: dict[int, Track], model_data: capnp._DynamicStr
 
 class RadarD:
   def __init__(self, radar_ts: float = DT_MDL, delay: float = 0.0, g90_radar_filter: bool = False,
-               honda_bosch_a_radar: bool = False):
+               honda_bosch_a_radar: bool = False, honda_accord_11g_radar: bool = False):
     self.current_time = 0.0
 
     self.tracks: dict[int, Track] = {}
     self.honda_bosch_a_radar = honda_bosch_a_radar
+    self.honda_accord_11g_radar = honda_accord_11g_radar
     # The lead KF consumes Bosch measurements at the physical radar cadence. Lead probability
     # filters, however, consume modelV2 leads every model cycle and must retain model-loop timing.
     kf_dt = HONDA_BOSCH_A_RADAR_TS if self.honda_bosch_a_radar else radar_ts
@@ -547,7 +625,8 @@ class RadarD:
 
       # create the track if it doesn't exist or it's a new track
       if ids not in self.tracks:
-        self.tracks[ids] = Track(ids, v_lead, self.kalman_params)
+        self.tracks[ids] = Track(ids, v_lead, self.kalman_params,
+                                 honda_accord_11g_radar=self.honda_accord_11g_radar)
       measured = rpt[3] if not self.honda_bosch_a_radar else bool(rpt[3] and radar_fresh)
       # Non-Bosch sources retain the historical per-model-cycle update semantics. Only Civic Bosch
       # suppresses duplicate measurement updates when liveTracks has not advanced.
@@ -577,28 +656,39 @@ class RadarD:
         else:
           self.lead_prob_filters[i].update(lead_prob)
 
-        self._update_honda_bosch_a_preferred_staleness(i, leads_v3[i], self.lead_prob_filters[i].x)
+        if not self.honda_accord_11g_radar:
+          self._update_honda_bosch_a_preferred_staleness(i, leads_v3[i], self.lead_prob_filters[i].x)
 
-      self.radar_state.leadOne = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[0], model_v_ego, sm['modelV2'],
-                                          sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=True,
-                                          g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[0].x,
-                                          preferred_track_id=self.prev_lead_track_ids[0],
-                                          honda_bosch_a_radar=self.honda_bosch_a_radar)
-      self.radar_state.leadTwo = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego, sm['modelV2'],
-                                          sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=False,
-                                          g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[1].x,
-                                          preferred_track_id=self.prev_lead_track_ids[1],
-                                          honda_bosch_a_radar=self.honda_bosch_a_radar)
+      if self.honda_accord_11g_radar:
+        self.radar_state.leadOne = get_honda_accord_11g_lead(
+          self.v_ego, self.ready, self.tracks, leads_v3[0], model_v_ego,
+          self.lead_prob_filters[0].x, low_speed_override=True,
+        )
+        self.radar_state.leadTwo = get_honda_accord_11g_lead(
+          self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego,
+          self.lead_prob_filters[1].x, low_speed_override=False,
+        )
+      else:
+        self.radar_state.leadOne = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[0], model_v_ego, sm['modelV2'],
+                                            sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=True,
+                                            g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[0].x,
+                                            preferred_track_id=self.prev_lead_track_ids[0],
+                                            honda_bosch_a_radar=self.honda_bosch_a_radar)
+        self.radar_state.leadTwo = get_lead(self.v_ego, self.ready, self.tracks, leads_v3[1], model_v_ego, sm['modelV2'],
+                                            sm['carState'].standstill, sm['starpilotPlan'], self.starpilot_toggles, low_speed_override=False,
+                                            g90_radar_filter=self.g90_radar_filter, lead_prob=self.lead_prob_filters[1].x,
+                                            preferred_track_id=self.prev_lead_track_ids[1],
+                                            honda_bosch_a_radar=self.honda_bosch_a_radar)
 
-      for i, lead in enumerate((self.radar_state.leadOne, self.radar_state.leadTwo)):
-        if lead.status and getattr(lead, "radar", False):
-          track_id = int(getattr(lead, "radarTrackId", -1))
-          if track_id != self.prev_lead_track_ids[i]:
-            self._reset_preferred_stale_evidence(i, track_id)
-          self.prev_lead_track_ids[i] = track_id
-        elif (not lead.status) or (self.prev_lead_track_ids[i] not in self.tracks):
-          self.prev_lead_track_ids[i] = -1
-          self._reset_preferred_stale_evidence(i)
+        for i, lead in enumerate((self.radar_state.leadOne, self.radar_state.leadTwo)):
+          if lead.status and getattr(lead, "radar", False):
+            track_id = int(getattr(lead, "radarTrackId", -1))
+            if track_id != self.prev_lead_track_ids[i]:
+              self._reset_preferred_stale_evidence(i, track_id)
+            self.prev_lead_track_ids[i] = track_id
+          elif (not lead.status) or (self.prev_lead_track_ids[i] not in self.tracks):
+            self.prev_lead_track_ids[i] = -1
+            self._reset_preferred_stale_evidence(i)
 
     if self.ready and (self.starpilot_toggles.adjacent_lead_tracking or self.starpilot_toggles.human_lane_changes):
       self.starpilot_radar_state.leadLeft = get_adjacent_lead(self.tracks, sm['carState'].standstill, sm['modelV2'], left=True)
@@ -646,8 +736,9 @@ def main() -> None:
 
   g90_radar_filter = CP.brand == "hyundai" and CP.carFingerprint == "GENESIS_G90"
   honda_bosch_a_radar = is_bosch_a_radar_car(CP)
+  honda_accord_11g_radar = is_honda_accord_11g_radar_car(CP)
   RD = RadarD(radar_ts=radar_ts, delay=CP.radarDelay, g90_radar_filter=g90_radar_filter,
-              honda_bosch_a_radar=honda_bosch_a_radar)
+              honda_bosch_a_radar=honda_bosch_a_radar, honda_accord_11g_radar=honda_accord_11g_radar)
 
   sm = sm.extend(['starpilotPlan'])
   pm = pm.extend(['starpilotRadarState'])

--- a/selfdrive/controls/tests/test_accord11g_native_lateral.py
+++ b/selfdrive/controls/tests/test_accord11g_native_lateral.py
@@ -1,0 +1,167 @@
+import sys
+import types
+from types import SimpleNamespace
+
+from cereal import car, log, messaging
+import numpy as np
+import pytest
+
+from opendbc.car.honda.values import CAR as HONDA_CAR
+from openpilot.selfdrive.controls.controlsd import (
+  TWITCH_GUARD_DURATION,
+  limit_curvature_to_plan,
+  twitch_guard_allowed,
+  update_twitch_guard,
+)
+from openpilot.selfdrive.locationd import lagd
+from openpilot.selfdrive.locationd.lagd import (
+  ACCORD_11G_MIN_LAG,
+  ACCORD_11G_MIN_VEGO,
+  BLOCK_NUM_NEEDED,
+  LateralLagEstimator,
+  MAX_LAG,
+  retrieve_initial_lag,
+)
+
+
+def _model(curvature: float = 0.0, reach: float = 20.0, lane_change: int = 0):
+  xs = np.linspace(0.0, reach, 41)
+  ys = 0.5 * curvature * xs ** 2
+  return SimpleNamespace(
+    position=SimpleNamespace(x=xs, y=ys),
+    meta=SimpleNamespace(laneChangeState=lane_change),
+  )
+
+
+def _cp(fingerprint=HONDA_CAR.HONDA_ACCORD_11G, delay=0.3):
+  return car.CarParams(brand="honda", carFingerprint=fingerprint, steerActuatorDelay=delay)
+
+
+def _estimator(fingerprint=HONDA_CAR.HONDA_ACCORD_11G):
+  estimator = LateralLagEstimator(_cp(fingerprint), 0.05)
+  estimator.starpilot_toggles = SimpleNamespace(use_custom_steerActuatorDelay=False, steerActuatorDelay=0.0)
+  return estimator
+
+
+def test_native_takeoff_guard_rejects_only_straight_launch_spike():
+  assert limit_curvature_to_plan(_model(0.0), 0.05, 1.0) == pytest.approx(0.002)
+  assert limit_curvature_to_plan(_model(0.01), 0.015, 1.0) == pytest.approx(0.015)
+  assert limit_curvature_to_plan(_model(0.08), 0.08, 1.0) == pytest.approx(0.08)
+
+
+def test_native_takeoff_guard_fades_and_rearms_at_stop():
+  assert limit_curvature_to_plan(_model(0.0), 0.05, 3.5) == pytest.approx(0.026)
+  assert limit_curvature_to_plan(_model(0.0), 0.05, 4.0) == pytest.approx(0.05)
+  remaining = update_twitch_guard(0.0, 0.0, True)
+  assert remaining == pytest.approx(TWITCH_GUARD_DURATION)
+  for _ in range(150):
+    remaining = update_twitch_guard(remaining, 1.0, False)
+  assert remaining == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+  ("blinker", "turn_hold", "lane_change", "expected"),
+  [(False, False, False, True), (True, False, False, False),
+   (False, True, False, False), (False, False, True, False)],
+)
+def test_accord_takeoff_guard_respects_maneuver_bypasses(blinker, turn_hold, lane_change, expected):
+  assert twitch_guard_allowed(True, blinker, turn_hold, lane_change) is expected
+
+
+def test_non_accord_guard_preserves_native_lane_change_behavior():
+  assert twitch_guard_allowed(False, False, False, True)
+
+
+def test_native_model_route_ignores_planplus_without_changing_default(monkeypatch):
+  fake_commonmodel = types.ModuleType("openpilot.selfdrive.modeld.models.commonmodel_pyx")
+  fake_commonmodel.DrivingModelFrame = object
+  fake_commonmodel.CLContext = object
+  monkeypatch.setitem(sys.modules, fake_commonmodel.__name__, fake_commonmodel)
+  from openpilot.selfdrive.modeld import modeld
+  from openpilot.selfdrive.modeld.constants import ModelConstants, Plan
+
+  plan = np.zeros((1, ModelConstants.IDX_N, ModelConstants.PLAN_WIDTH), dtype=np.float32)
+  planplus = np.ones_like(plan)
+  captured = []
+  monkeypatch.setattr(modeld, "get_accel_from_plan_tomb_raider", lambda *args, **kwargs: (0.0, False))
+
+  def capture_curvature(_output, selected_plan, *_args, **_kwargs):
+    captured.append(selected_plan.copy())
+    return 0.0
+
+  monkeypatch.setattr(modeld, "get_curvature_from_output", capture_curvature)
+  previous = log.ModelDataV2.Action.new_message()
+  toggles = SimpleNamespace(vEgoStopping=0.3, recovery_power=1.0)
+  kwargs = dict(lat_action_t=0.2, long_action_t=0.5, v_ego=5.0, mlsim=True,
+                is_v9=False, is_v14=False, is_v15=False, starpilot_toggles=toggles,
+                lat_smooth_seconds=0.0, long_smooth_seconds=0.0)
+  output = {"plan": plan, "planplus": planplus}
+  modeld.get_action_from_model(output, previous, honda_accord_11g_lateral=True, **kwargs)
+  modeld.get_action_from_model(output, previous, honda_accord_11g_lateral=False, **kwargs)
+  np.testing.assert_allclose(captured[0], 0.0)
+  np.testing.assert_allclose(captured[1][:, Plan.VELOCITY], 1.0)
+
+
+def test_accord_delay_initialization_and_learning_scope():
+  estimator = _estimator()
+  assert estimator.honda_accord_11g_lateral
+  assert estimator.initial_lag == pytest.approx(0.5)
+  assert estimator.min_vego == pytest.approx(ACCORD_11G_MIN_VEGO)
+  assert estimator.get_msg(True).liveDelay.lateralDelay == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize(("learned", "expected"), [(0.10, 0.15), (0.30, 0.30), (0.80, 0.65)])
+def test_accord_published_delay_is_bounded(learned, expected):
+  estimator = _estimator()
+  estimator.block_avg.values[:] = learned
+  estimator.block_avg.valid_blocks = BLOCK_NUM_NEEDED
+  assert estimator.get_msg(True).liveDelay.lateralDelay == pytest.approx(expected)
+
+
+def test_accord_ignores_custom_delay_while_generic_honda_is_unchanged():
+  accord = _estimator()
+  accord.starpilot_toggles = SimpleNamespace(use_custom_steerActuatorDelay=True, steerActuatorDelay=0.01)
+  assert accord.get_msg(True).liveDelay.lateralDelay == pytest.approx(0.5)
+  generic = _estimator(HONDA_CAR.HONDA_CRV_6G)
+  generic.starpilot_toggles = SimpleNamespace(use_custom_steerActuatorDelay=True, steerActuatorDelay=0.27)
+  assert not generic.honda_accord_11g_lateral
+  assert generic.min_vego == pytest.approx(lagd.MIN_VEGO)
+  assert generic.get_msg(True).liveDelay.lateralDelay == pytest.approx(0.27)
+
+
+class FakeParams:
+  def __init__(self, data):
+    self.data = data
+    self.removed = []
+
+  def get(self, key):
+    return self.data.get(key)
+
+  def remove(self, key):
+    self.removed.append(key)
+    self.data.pop(key, None)
+
+
+@pytest.mark.parametrize(("cached", "accepted"), [(0.15, True), (0.65, True), (0.149, False), (0.651, False)])
+def test_accord_delay_cache_range_guard(cached, accepted):
+  cp = _cp()
+  event = messaging.new_message("liveDelay")
+  event.liveDelay.status = "estimated"
+  event.liveDelay.lateralDelayEstimate = cached
+  event.liveDelay.validBlocks = 3
+  params = FakeParams({"LiveDelay": event.to_bytes(), "CarParamsPrevRoute": cp.to_bytes()})
+  result = retrieve_initial_lag(params, cp)
+  if accepted:
+    assert result == pytest.approx((cached, 3))
+    assert not params.removed
+  else:
+    assert result is None
+    assert params.removed == ["LiveDelay"]
+
+
+def test_accord_delay_search_excludes_below_minimum_peak():
+  dt = 0.05
+  signal = np.sin(np.arange(400) * 0.17) + 0.3 * np.sin(np.arange(400) * 0.037)
+  actual = np.roll(signal, 1)
+  delay, _, _ = LateralLagEstimator.actuator_delay(signal, actual, np.ones(signal.size, dtype=bool), dt, MAX_LAG, ACCORD_11G_MIN_LAG)
+  assert ACCORD_11G_MIN_LAG <= delay <= MAX_LAG

--- a/selfdrive/controls/tests/test_accord11g_native_longcontrol.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longcontrol.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+import pytest
+from cereal import car
+from opendbc.car.honda.values import CAR as HONDA_CAR
+from openpilot.common.realtime import DT_CTRL
+from openpilot.selfdrive.controls.lib.longcontrol import (
+  LongControl,
+  LongCtrlState,
+  honda_accord_11g_long_control_state_trans,
+)
+
+
+def make_cp(*, brand="honda", fingerprint=HONDA_CAR.HONDA_ACCORD_11G):
+  CP = car.CarParams.new_message()
+  CP.brand = brand
+  CP.carFingerprint = fingerprint
+  CP.stopAccel = -2.0
+  CP.vEgoStarting = 0.5
+  CP.longitudinalTuning.kpBP = [0.0]
+  CP.longitudinalTuning.kpV = [0.0]
+  CP.longitudinalTuning.kiBP = [0.0]
+  CP.longitudinalTuning.kiV = [0.0]
+  return CP
+
+
+def make_car_state(v_ego=10.0, a_ego=0.0, *, brake_pressed=False, standstill=False):
+  CS = car.CarState.new_message()
+  CS.vEgo = v_ego
+  CS.aEgo = a_ego
+  CS.brakePressed = brake_pressed
+  CS.cruiseState.standstill = standstill
+  return CS
+
+
+@pytest.mark.parametrize(
+  "active,state,should_stop,brake_pressed,standstill,expected",
+  [
+    (False, LongCtrlState.pid, False, False, False, LongCtrlState.off),
+    (True, LongCtrlState.off, False, False, False, LongCtrlState.pid),
+    (True, LongCtrlState.off, True, False, False, LongCtrlState.stopping),
+    (True, LongCtrlState.off, False, True, False, LongCtrlState.stopping),
+    (True, LongCtrlState.off, False, False, True, LongCtrlState.stopping),
+    (True, LongCtrlState.stopping, False, False, False, LongCtrlState.pid),
+    (True, LongCtrlState.pid, True, False, False, LongCtrlState.stopping),
+  ],
+)
+def test_accord11g_native_longcontrol_state_machine(active, state, should_stop, brake_pressed, standstill, expected):
+  CP = make_cp()
+  result = honda_accord_11g_long_control_state_trans(
+    CP, active, state, should_stop, brake_pressed, standstill,
+  )
+  assert result == expected
+  assert result != LongCtrlState.starting
+
+
+def test_accord11g_native_longcontrol_pid_ignores_shared_shaping_inputs():
+  controller = LongControl(make_cp())
+  CS = make_car_state()
+
+  output = controller.update(
+    True, CS, 0.8, False, [-3.5, 2.0], object(),
+    has_lead=True, traffic_mode_enabled=True, profile_max_accel=0.1,
+    pedal_override=True, leads=[object()],
+  )
+  assert controller.honda_accord_11g
+  assert controller.long_control_state == LongCtrlState.pid
+  assert output == pytest.approx(0.8)
+
+  output = controller.update(
+    True, CS, -0.6, False, [-3.5, 2.0], object(),
+    has_lead=True, traffic_mode_enabled=True, profile_max_accel=0.1,
+  )
+  assert output == pytest.approx(-0.6)
+
+
+def test_accord11g_native_longcontrol_stopping_ramp_hold_release_and_off():
+  controller = LongControl(make_cp())
+  CS = make_car_state(v_ego=0.1)
+  controller.last_output_accel = 0.4
+
+  assert controller.update(True, CS, -1.0, True, [-3.5, 2.0], object()) == pytest.approx(-DT_CTRL)
+  assert controller.long_control_state == LongCtrlState.stopping
+
+  for _ in range(400):
+    controller.update(True, CS, -1.0, True, [-3.5, 2.0], object())
+  assert controller.last_output_accel == pytest.approx(controller.CP.stopAccel)
+
+  assert controller.update(True, CS, 0.3, False, [-3.5, 2.0], object()) == pytest.approx(0.3)
+  assert controller.long_control_state == LongCtrlState.pid
+  assert controller.update(False, CS, 0.3, False, [-3.5, 2.0], object()) == pytest.approx(0.0)
+  assert controller.long_control_state == LongCtrlState.off
+
+
+def test_non_accord_longcontrol_remains_on_native_dom_path():
+  civic = LongControl(make_cp(fingerprint=HONDA_CAR.HONDA_CIVIC_BOSCH))
+  assert not civic.honda_accord_11g
+
+  toggles = SimpleNamespace(
+    vEgoStarting=0.5,
+    stopAccel=-2.0,
+    stoppingDecelRate=0.2,
+    startAccel=1.0,
+    custom_accel_profile=False,
+  )
+  civic.CP.startingState = True
+  output = civic.update(True, make_car_state(v_ego=0.0), 0.5, False, [-3.5, 2.0], toggles)
+
+  assert civic.long_control_state == LongCtrlState.starting
+  assert output == pytest.approx(toggles.startAccel)

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -2,9 +2,12 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from cereal import log
+from opendbc.car.interfaces import ACCEL_MAX, ACCEL_MIN
 
 from openpilot.selfdrive.controls.lib.longitudinal_planner import (
   CONTROL_N_T_IDX,
+  LongitudinalPlanner,
   get_accel_from_plan,
   get_max_accel,
   limit_accel_in_turns,
@@ -14,16 +17,56 @@ from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_honda_accord_11g_allow_throttle,
   get_honda_accord_11g_cruise_accel_max,
   get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_mpc_policy,
   get_honda_accord_11g_no_throttle_accel_max,
   get_honda_accord_11g_reduction_only_v_cruise,
   get_honda_accord_11g_throttle_policy,
   get_honda_accord_11g_total_accel_max,
   is_honda_accord_11g,
 )
+from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import (
+  COST_E_DIM,
+  DANGER_ZONE_COST,
+  FCW_IDXS,
+  LIMIT_COST,
+  N,
+  T_DIFFS,
+  T_IDXS,
+  LongitudinalMpc,
+  get_T_FOLLOW,
+)
 
 
 def make_cp(brand="honda", fingerprint="HONDA_ACCORD_11G"):
   return SimpleNamespace(brand=brand, carFingerprint=fingerprint)
+
+
+class FakeSolver:
+  def __init__(self):
+    self.costs = {}
+    self.values = {}
+
+  def reset(self):
+    pass
+
+  def cost_set(self, stage, field, value):
+    self.costs[(stage, field)] = np.array(value, copy=True)
+
+  def set(self, stage, field, value):
+    self.values[(stage, field)] = np.array(value, copy=True)
+
+
+def make_lead(status=False, d_rel=50.0, v_lead=30.0, a_lead=0.0, tau=1.5):
+  return SimpleNamespace(
+    status=status,
+    dRel=d_rel,
+    vLead=v_lead,
+    vRel=0.0,
+    aLeadK=a_lead,
+    aLeadTau=tau,
+    radar=True,
+    modelProb=1.0,
+  )
 
 
 @pytest.mark.parametrize("brand, fingerprint", [
@@ -41,6 +84,7 @@ def test_accord11g_native_contract_is_exactly_platform_scoped(brand, fingerprint
   assert get_honda_accord_11g_throttle_policy(other) is None
   assert get_honda_accord_11g_min_action_delay(other) is None
   assert get_honda_accord_11g_accel_clip_slew_step(other) is None
+  assert get_honda_accord_11g_mpc_policy(other) is None
   assert get_honda_accord_11g_reduction_only_v_cruise(other, 20.0, 15.0) is None
 
 
@@ -148,3 +192,80 @@ def test_native_plan_projection_uses_accord11g_stable_delay_without_changing_def
   assert stable_accel != pytest.approx(default_accel)
   assert not stable_should_stop
   assert not default_should_stop
+
+
+def test_accord11g_native_mpc_costs_match_validated_policy():
+  solver = FakeSolver()
+  mpc = LongitudinalMpc(CP=make_cp(), solver=solver)
+  policy = get_honda_accord_11g_mpc_policy(make_cp())
+
+  expected = np.diag([
+    policy["obstacle_cost"], 0.0, 0.0, 0.0,
+    policy["accel_change_cost"], policy["jerk_cost"],
+  ])
+  assert solver.costs[(0, "W")] == pytest.approx(expected)
+  assert solver.costs[(N, "W")].shape == (COST_E_DIM, COST_E_DIM)
+  assert solver.costs[(0, "Zl")] == pytest.approx([LIMIT_COST, LIMIT_COST, LIMIT_COST, DANGER_ZONE_COST])
+
+  mpc.set_weights(personality=log.LongitudinalPersonality.aggressive)
+  expected_aggressive = expected.copy()
+  expected_aggressive[4, 4] *= 0.5
+  expected_aggressive[5, 5] *= 0.5
+  assert solver.costs[(0, "W")] == pytest.approx(expected_aggressive)
+
+  mpc.set_weights(prev_accel_constraint=False)
+  assert solver.costs[(0, "W")][4, 4] == pytest.approx(0.0)
+
+
+def test_accord11g_native_mpc_uses_raw_lead_decay_without_changing_other_cars():
+  accord = LongitudinalMpc(CP=make_cp(), solver=FakeSolver())
+  civic = LongitudinalMpc(CP=make_cp(fingerprint="HONDA_CIVIC_BOSCH"), solver=FakeSolver())
+  for mpc in (accord, civic):
+    mpc.set_cur_state(35.0, 0.0)
+
+  lead = make_lead(True, 45.0, 25.0, -1.0, 0.8)
+  accord_lead_xv = accord.process_lead(lead)
+  civic_lead_xv = civic.process_lead(lead)
+  expected_a = lead.aLeadK * np.exp(-lead.aLeadTau * (T_IDXS ** 2) / 2.0)
+  expected_v = np.clip(lead.vLead + np.cumsum(T_DIFFS * expected_a), 0.0, 1e8)
+  expected_x = lead.dRel + np.cumsum(T_DIFFS * expected_v)
+
+  assert accord_lead_xv == pytest.approx(np.column_stack((expected_x, expected_v)))
+  assert not np.allclose(accord_lead_xv, civic_lead_xv)
+
+
+def test_accord11g_native_mpc_parameters_and_follow_time_match_validated_policy():
+  solver = FakeSolver()
+  mpc = LongitudinalMpc(CP=make_cp(), solver=solver)
+  mpc.set_cur_state(20.0, 0.0)
+  mpc.set_accel_limits(-0.4, 0.6)
+  mpc.run = lambda: None
+  radar_state = SimpleNamespace(leadOne=make_lead(), leadTwo=make_lead())
+  zeros = np.zeros(N + 1)
+
+  mpc.update(
+    radar_state, 25.0, zeros.copy(), zeros.copy(), zeros.copy(), zeros.copy(),
+    danger_factor=0.1, t_follow=9.0, personality=log.LongitudinalPersonality.aggressive,
+  )
+
+  assert mpc.source == "cruise"
+  assert mpc.params[:, 0] == pytest.approx(ACCEL_MIN)
+  assert mpc.params[:, 1] == pytest.approx(ACCEL_MAX)
+  assert mpc.params[:, 4] == pytest.approx(get_T_FOLLOW(personality=log.LongitudinalPersonality.aggressive))
+  assert mpc.params[:, 5] == pytest.approx(0.75)
+  assert not np.any(mpc.lead_xv_0[FCW_IDXS, 0] - mpc.x_sol[FCW_IDXS, 0] < 0.25)
+
+
+def test_accord11g_native_mpc_stays_in_acc_mode_without_changing_other_cars():
+  accord_planner = LongitudinalPlanner.__new__(LongitudinalPlanner)
+  accord_planner.generation = None
+  accord_planner.mode = "blended"
+  accord_planner.mpc = SimpleNamespace(honda_accord_11g_policy=get_honda_accord_11g_mpc_policy(make_cp()), mode="blended")
+
+  civic_planner = LongitudinalPlanner.__new__(LongitudinalPlanner)
+  civic_planner.generation = None
+  civic_planner.mode = "blended"
+  civic_planner.mpc = SimpleNamespace(honda_accord_11g_policy=None, mode="blended")
+
+  assert accord_planner.get_mpc_mode() == "acc"
+  assert civic_planner.get_mpc_mode() == "blended"

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -1,7 +1,14 @@
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
+from openpilot.selfdrive.controls.lib.longitudinal_planner import (
+  CONTROL_N_T_IDX,
+  get_accel_from_plan,
+  get_max_accel,
+  limit_accel_in_turns,
+)
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_honda_accord_11g_accel_clip_slew_step,
   get_honda_accord_11g_cruise_accel_max,
@@ -79,3 +86,37 @@ def test_accord11g_scalar_planner_contract_matches_road_validated_values():
 ])
 def test_accord11g_starpilot_v_cruise_is_reduction_only(starpilot_v_cruise, expected):
   assert get_honda_accord_11g_reduction_only_v_cruise(make_cp(), 20.0, starpilot_v_cruise) == pytest.approx(expected)
+
+
+def test_native_planner_uses_accord11g_acceleration_envelopes_only_for_accord():
+  accord = SimpleNamespace(brand="honda", carFingerprint="HONDA_ACCORD_11G", steerRatio=15.0, wheelbase=2.8)
+  civic = SimpleNamespace(brand="honda", carFingerprint="HONDA_CIVIC_BOSCH", steerRatio=15.0, wheelbase=2.8)
+
+  assert get_max_accel(17.5, accord) == pytest.approx(1.0)
+  assert get_max_accel(17.5, civic) == pytest.approx(1.1875)
+  assert limit_accel_in_turns(30.0, 0.0, [-3.5, 10.0], accord) == pytest.approx([-3.5, 2.45])
+  assert limit_accel_in_turns(30.0, 0.0, [-3.5, 10.0], civic) == pytest.approx([-3.5, 3.35])
+
+
+def test_native_plan_projection_uses_accord11g_stable_delay_without_changing_default():
+  control_t = np.asarray(CONTROL_N_T_IDX)
+  speeds = 10.0 + control_t ** 2
+  accels = np.zeros_like(control_t)
+  action_t = 0.2
+  stable_delay = 0.3
+  stable_speed = float(np.interp(stable_delay, CONTROL_N_T_IDX, speeds))
+  expected_stable_target = float(speeds[0] + (action_t / stable_delay) * (stable_speed - speeds[0]))
+  expected_stable_accel = 2.0 * (expected_stable_target - speeds[0]) / action_t
+  expected_default_target = float(np.interp(action_t, CONTROL_N_T_IDX, speeds))
+  expected_default_accel = 2.0 * (expected_default_target - speeds[0]) / action_t
+
+  stable_accel, stable_should_stop = get_accel_from_plan(
+    speeds, accels, action_t=action_t, min_stable_delay=stable_delay,
+  )
+  default_accel, default_should_stop = get_accel_from_plan(speeds, accels, action_t=action_t)
+
+  assert stable_accel == pytest.approx(expected_stable_accel)
+  assert default_accel == pytest.approx(expected_default_accel)
+  assert stable_accel != pytest.approx(default_accel)
+  assert not stable_should_stop
+  assert not default_should_stop

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -11,8 +11,10 @@ from openpilot.selfdrive.controls.lib.longitudinal_planner import (
 )
 from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
   get_honda_accord_11g_accel_clip_slew_step,
+  get_honda_accord_11g_allow_throttle,
   get_honda_accord_11g_cruise_accel_max,
   get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_no_throttle_accel_max,
   get_honda_accord_11g_reduction_only_v_cruise,
   get_honda_accord_11g_throttle_policy,
   get_honda_accord_11g_total_accel_max,
@@ -86,6 +88,32 @@ def test_accord11g_scalar_planner_contract_matches_road_validated_values():
 ])
 def test_accord11g_starpilot_v_cruise_is_reduction_only(starpilot_v_cruise, expected):
   assert get_honda_accord_11g_reduction_only_v_cruise(make_cp(), 20.0, starpilot_v_cruise) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("throttle_prob, v_ego, expected", [
+  (0.41, 10.0, True),
+  (0.40, 10.0, False),
+  (0.0, 2.5, True),
+  (0.0, 2.51, False),
+])
+def test_accord11g_throttle_gate_matches_validated_policy(throttle_prob, v_ego, expected):
+  assert get_honda_accord_11g_allow_throttle(make_cp(), throttle_prob, v_ego) is expected
+  assert get_honda_accord_11g_allow_throttle(make_cp(fingerprint="HONDA_CIVIC_BOSCH"), throttle_prob, v_ego) is None
+
+
+@pytest.mark.parametrize("v_ego, accel_coast, expected", [
+  (2.5, -0.3, 1.6),
+  (3.75, -0.3, 0.65),
+  (5.0, -0.3, -0.3),
+  (5.0, -5.0, -3.5),
+])
+def test_accord11g_no_throttle_coast_cap_matches_validated_interpolation(v_ego, accel_coast, expected):
+  assert get_honda_accord_11g_no_throttle_accel_max(
+    make_cp(), v_ego, accel_min=-3.5, accel_max=1.6, accel_coast=accel_coast,
+  ) == pytest.approx(expected)
+  assert get_honda_accord_11g_no_throttle_accel_max(
+    make_cp(fingerprint="HONDA_CIVIC_BOSCH"), v_ego, accel_min=-3.5, accel_max=1.6, accel_coast=accel_coast,
+  ) is None
 
 
 def test_native_planner_uses_accord11g_acceleration_envelopes_only_for_accord():

--- a/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
+++ b/selfdrive/controls/tests/test_accord11g_native_longitudinal.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+import pytest
+
+from openpilot.selfdrive.controls.lib.longitudinal_vehicle_tunes import (
+  get_honda_accord_11g_accel_clip_slew_step,
+  get_honda_accord_11g_cruise_accel_max,
+  get_honda_accord_11g_min_action_delay,
+  get_honda_accord_11g_reduction_only_v_cruise,
+  get_honda_accord_11g_throttle_policy,
+  get_honda_accord_11g_total_accel_max,
+  is_honda_accord_11g,
+)
+
+
+def make_cp(brand="honda", fingerprint="HONDA_ACCORD_11G"):
+  return SimpleNamespace(brand=brand, carFingerprint=fingerprint)
+
+
+@pytest.mark.parametrize("brand, fingerprint", [
+  ("honda", "HONDA_ACCORD"),
+  ("honda", "HONDA_CIVIC_BOSCH"),
+  ("toyota", "HONDA_ACCORD_11G"),
+  ("toyota", "TOYOTA_RAV4"),
+])
+def test_accord11g_native_contract_is_exactly_platform_scoped(brand, fingerprint):
+  other = make_cp(brand, fingerprint)
+
+  assert not is_honda_accord_11g(other)
+  assert get_honda_accord_11g_cruise_accel_max(other, 10.0) is None
+  assert get_honda_accord_11g_total_accel_max(other, 20.0) is None
+  assert get_honda_accord_11g_throttle_policy(other) is None
+  assert get_honda_accord_11g_min_action_delay(other) is None
+  assert get_honda_accord_11g_accel_clip_slew_step(other) is None
+  assert get_honda_accord_11g_reduction_only_v_cruise(other, 20.0, 15.0) is None
+
+
+@pytest.mark.parametrize("v_ego, expected", [
+  (-1.0, 1.6),
+  (0.0, 1.6),
+  (5.0, 1.4),
+  (10.0, 1.2),
+  (17.5, 1.0),
+  (25.0, 0.8),
+  (32.5, 0.7),
+  (40.0, 0.6),
+  (50.0, 0.6),
+])
+def test_accord11g_cruise_accel_ceiling_matches_validated_curve(v_ego, expected):
+  assert get_honda_accord_11g_cruise_accel_max(make_cp(), v_ego) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("v_ego, expected", [
+  (0.0, 1.7),
+  (20.0, 1.7),
+  (30.0, 2.45),
+  (40.0, 3.2),
+  (50.0, 3.2),
+])
+def test_accord11g_total_accel_envelope_matches_validated_curve(v_ego, expected):
+  assert get_honda_accord_11g_total_accel_max(make_cp(), v_ego) == pytest.approx(expected)
+
+
+def test_accord11g_scalar_planner_contract_matches_road_validated_values():
+  accord = make_cp()
+
+  assert is_honda_accord_11g(accord)
+  assert get_honda_accord_11g_throttle_policy(accord) == pytest.approx((0.4, 2.5))
+  assert get_honda_accord_11g_min_action_delay(accord) == pytest.approx(0.3)
+  assert get_honda_accord_11g_accel_clip_slew_step(accord) == pytest.approx(0.05)
+
+
+@pytest.mark.parametrize("starpilot_v_cruise, expected", [
+  (15.0, 15.0),
+  (20.0, 20.0),
+  (25.0, 20.0),
+  (float("nan"), 20.0),
+  (-1.0, 20.0),
+])
+def test_accord11g_starpilot_v_cruise_is_reduction_only(starpilot_v_cruise, expected):
+  assert get_honda_accord_11g_reduction_only_v_cruise(make_cp(), 20.0, starpilot_v_cruise) == pytest.approx(expected)

--- a/selfdrive/controls/tests/test_accord11g_native_radar.py
+++ b/selfdrive/controls/tests/test_accord11g_native_radar.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+import pytest
+from opendbc.car.honda.values import CAR as HONDA_CAR
+from openpilot.selfdrive.controls.radard import (
+  HONDA_ACCORD_11G_LEAD_ACCEL_TAU,
+  KalmanParams,
+  RadarD,
+  Track,
+  get_honda_accord_11g_lead,
+  get_honda_accord_11g_radar_state_from_vision,
+  is_honda_accord_11g_radar_car,
+  match_honda_accord_11g_vision_to_track,
+  update_honda_accord_11g_accel_tau,
+)
+
+
+class FakeTrack:
+  def __init__(self, identifier, d_rel, y_rel, v_rel, *, low_speed=False):
+    self.identifier = identifier
+    self.dRel = d_rel
+    self.yRel = y_rel
+    self.vRel = v_rel
+    self.vLead = v_rel + 10.0
+    self.vLeadK = self.vLead
+    self.aLeadK = 0.0
+    self.aLeadTau = SimpleNamespace(x=HONDA_ACCORD_11G_LEAD_ACCEL_TAU)
+    self.low_speed = low_speed
+    self.leadTrackID = 0
+
+  def get_RadarState(self, model_prob=0.0):
+    return {
+      "status": True,
+      "dRel": self.dRel,
+      "yRel": self.yRel,
+      "vRel": self.vRel,
+      "vLead": self.vLead,
+      "vLeadK": self.vLeadK,
+      "aLeadK": self.aLeadK,
+      "aLeadTau": self.aLeadTau.x,
+      "modelProb": model_prob,
+      "radar": True,
+      "radarTrackId": self.identifier,
+    }
+
+  def potential_low_speed_lead(self, _v_ego):
+    return self.low_speed
+
+
+class FakeFilter:
+  def __init__(self, value):
+    self.x = value
+
+  def update(self, value):
+    self.x = value
+
+
+def make_lead(*, x=31.52, y=0.0, v=10.0, a=-0.4):
+  return SimpleNamespace(
+    x=[x], y=[y], v=[v], a=[a],
+    xStd=[1.0], yStd=[1.0], vStd=[1.0],
+  )
+
+
+@pytest.mark.parametrize("brand,fingerprint,expected", [
+  ("honda", HONDA_CAR.HONDA_ACCORD_11G, True),
+  ("honda", HONDA_CAR.HONDA_CIVIC_BOSCH, False),
+  ("toyota", HONDA_CAR.HONDA_ACCORD_11G, False),
+])
+def test_accord11g_native_radar_scope_is_exact(brand, fingerprint, expected):
+  CP = SimpleNamespace(brand=brand, carFingerprint=fingerprint)
+  assert is_honda_accord_11g_radar_car(CP) is expected
+
+
+def test_accord11g_native_radar_track_tau_policy_is_isolated():
+  accord_track = Track(1, 10.0, KalmanParams(0.05), honda_accord_11g_radar=True)
+  generic_track = Track(2, 10.0, KalmanParams(0.05))
+  assert accord_track.aLeadTau.x == pytest.approx(HONDA_ACCORD_11G_LEAD_ACCEL_TAU)
+  assert generic_track.aLeadTau.x != pytest.approx(HONDA_ACCORD_11G_LEAD_ACCEL_TAU)
+
+  fake_filter = FakeFilter(0.1)
+  update_honda_accord_11g_accel_tau(fake_filter, 0.1)
+  assert fake_filter.x == pytest.approx(HONDA_ACCORD_11G_LEAD_ACCEL_TAU)
+  update_honda_accord_11g_accel_tau(fake_filter, 0.8)
+  assert fake_filter.x == pytest.approx(0.0)
+
+
+def test_accord11g_native_radar_matches_validated_track_without_preference():
+  lead = make_lead()
+  tracks = {
+    1: FakeTrack(1, 30.0, 0.0, 0.0),
+    2: FakeTrack(2, 45.0, 2.0, 8.0),
+  }
+  assert match_honda_accord_11g_vision_to_track(10.0, lead, tracks) is tracks[1]
+
+
+def test_accord11g_native_radar_vision_fallback_matches_validated_values():
+  lead = make_lead(x=41.52, y=1.5, v=8.0, a=-0.6)
+  result = get_honda_accord_11g_radar_state_from_vision(lead, 10.0, 9.0, 0.8)
+  assert result == {
+    "dRel": 40.0,
+    "yRel": -1.5,
+    "vRel": -1.0,
+    "vLead": 9.0,
+    "vLeadK": 9.0,
+    "aLeadK": -0.6,
+    "aLeadTau": 0.3,
+    "fcw": False,
+    "modelProb": 0.8,
+    "status": True,
+    "radar": False,
+    "radarTrackId": -1,
+  }
+
+
+def test_accord11g_native_radar_probability_and_low_speed_policy():
+  lead = make_lead()
+  model_track = FakeTrack(1, 30.0, 0.0, 0.0)
+  close_track = FakeTrack(2, 8.0, 0.0, -8.0, low_speed=True)
+  tracks = {1: model_track, 2: close_track}
+
+  assert not get_honda_accord_11g_lead(
+    10.0, True, tracks, lead, 10.0, 0.5, low_speed_override=False,
+  )["status"]
+
+  result = get_honda_accord_11g_lead(2.0, True, tracks, lead, 10.0, 0.8)
+  assert result["radarTrackId"] == close_track.identifier
+  assert all(track.leadTrackID == close_track.identifier for track in tracks.values())
+
+  second = get_honda_accord_11g_lead(2.0, True, tracks, lead, 10.0, 0.8, low_speed_override=False)
+  assert second["radarTrackId"] == model_track.identifier
+
+
+def test_non_accord_radard_keeps_native_dom_mode():
+  generic = RadarD(radar_ts=0.05)
+  accord = RadarD(radar_ts=0.05, honda_accord_11g_radar=True)
+  assert not generic.honda_accord_11g_radar
+  assert accord.honda_accord_11g_radar

--- a/selfdrive/controls/tests/test_latcontrol.py
+++ b/selfdrive/controls/tests/test_latcontrol.py
@@ -1906,6 +1906,20 @@ class TestLatControl:
     assert controller.pid._k_p[1] == pytest.approx([value * 2.0 for value in base_kp_v])
     assert controller.pid._k_i[1] == pytest.approx([value * 1.25 for value in base_ki_v])
 
+  def test_honda_accord_11g_pid_gain_scales_remain_fixed(self):
+    controller, VM, CS, params, _ = self._build_pid_controller(HONDA.HONDA_ACCORD_11G)
+    base_kp = [list(values) for values in controller.pid._k_p]
+    base_ki = [list(values) for values in controller.pid._k_i]
+
+    starpilot_toggles = SimpleNamespace(honda_lateral_pid_kp_scale=2.0, honda_lateral_pid_ki_scale=0.5)
+    controller.update(True, CS, VM, params, False, 0.0025, False, 0.2, None, None, starpilot_toggles)
+
+    assert controller.is_honda_accord_11g
+    assert controller.pid._k_p[0] == pytest.approx(base_kp[0])
+    assert controller.pid._k_p[1] == pytest.approx(base_kp[1])
+    assert controller.pid._k_i[0] == pytest.approx(base_ki[0])
+    assert controller.pid._k_i[1] == pytest.approx(base_ki[1])
+
   def test_honda_accord_torque_tune_uses_quick_curve_unwind(self):
     controller, _, _, _, _ = self._build_torque_controller(HONDA.HONDA_ACCORD, force_torque=True)
 

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -203,6 +203,7 @@ class LateralLagEstimator:
     self.steering_saturated = False
     self.desired_curvature = 0.0
     self.v_ego = 0.0
+    self.in_reverse = False
     self.yaw_rate = 0.0
     self.yaw_rate_std = 0.0
     self.pose_valid = False
@@ -271,6 +272,7 @@ class LateralLagEstimator:
     elif which == "carState":
       self.steering_pressed = msg.steeringPressed
       self.v_ego = msg.vEgo
+      self.in_reverse = msg.gearShifter == car.CarState.GearShifter.reverse
     elif which == "controlsState":
       self.steering_saturated = getattr(msg.lateralControlState, msg.lateralControlState.which()).saturated
       self.desired_curvature = msg.desiredCurvature
@@ -314,7 +316,7 @@ class LateralLagEstimator:
       for last_t in [self.last_lat_inactive_t, self.last_steering_pressed_t, self.last_steering_saturated_t, self.last_pose_invalid_t]
     )
     okay = self.lat_active and not self.steering_pressed and not self.steering_saturated and \
-           fast and turning and has_recovered and calib_valid and sensors_valid and la_valid
+           fast and turning and has_recovered and not self.in_reverse and calib_valid and sensors_valid and la_valid
 
     self.points.update(self.t, la_desired, la_actual_pose, okay)
 

--- a/selfdrive/locationd/lagd.py
+++ b/selfdrive/locationd/lagd.py
@@ -8,6 +8,8 @@ from functools import partial
 import cereal.messaging as messaging
 from cereal import car, log
 from cereal.services import SERVICE_LIST
+from opendbc.car.honda.values import CAR as HONDA_CAR
+from openpilot.common.constants import CV
 from openpilot.common.params import Params
 from openpilot.common.realtime import config_realtime_process
 from openpilot.common.swaglog import cloudlog
@@ -27,6 +29,8 @@ MIN_ABS_YAW_RATE = 0.0
 MAX_YAW_RATE_SANITY_CHECK = 1.0
 MIN_NCC = 0.95
 MAX_LAG = 0.65
+ACCORD_11G_MIN_LAG = 0.15
+ACCORD_11G_MIN_VEGO = 50.0 * CV.MPH_TO_MS
 MAX_LAG_STD = 0.1
 MAX_LAT_ACCEL = 2.0
 MAX_LAT_ACCEL_DIFF = 0.6
@@ -182,10 +186,11 @@ class LateralLagEstimator:
     self.okay_window_sec = okay_window_sec
     self.min_recovery_buffer_sec = min_recovery_buffer_sec
     self.initial_lag = full_lateral_delay(CP.steerActuatorDelay)
+    self.honda_accord_11g_lateral = CP.brand == "honda" and CP.carFingerprint == HONDA_CAR.HONDA_ACCORD_11G
     self.block_size = block_size
     self.block_count = block_count
     self.min_valid_block_count = min_valid_block_count
-    self.min_vego = min_vego
+    self.min_vego = ACCORD_11G_MIN_VEGO if self.honda_accord_11g_lateral else min_vego
     self.min_yr = min_yr
     self.min_ncc = min_ncc
     self.min_confidence = min_confidence
@@ -233,7 +238,12 @@ class LateralLagEstimator:
     else:
       liveDelay.status = log.LiveDelayData.Status.unestimated
 
-    if self.starpilot_toggles.use_custom_steerActuatorDelay:
+    if self.honda_accord_11g_lateral:
+      if liveDelay.status == log.LiveDelayData.Status.estimated:
+        liveDelay.lateralDelay = min(MAX_LAG, max(ACCORD_11G_MIN_LAG, valid_mean_lag))
+      else:
+        liveDelay.lateralDelay = self.initial_lag
+    elif self.starpilot_toggles.use_custom_steerActuatorDelay:
       liveDelay.lateralDelay = self.starpilot_toggles.steerActuatorDelay
     elif liveDelay.status == log.LiveDelayData.Status.estimated:
       liveDelay.lateralDelay = valid_mean_lag
@@ -322,7 +332,9 @@ class LateralLagEstimator:
     desired = masked_symmetric_moving_average(desired, okay, SMOOTH_K, SMOOTH_SIGMA)
     actual = masked_symmetric_moving_average(actual, okay, SMOOTH_K, SMOOTH_SIGMA)
 
-    delay, corr, confidence = self.actuator_delay(desired, actual, okay, self.dt, MAX_LAG)
+    delay, corr, confidence = self.actuator_delay(
+      desired, actual, okay, self.dt, MAX_LAG, ACCORD_11G_MIN_LAG if self.honda_accord_11g_lateral else 0.0,
+    )
     if corr < self.min_ncc or confidence < self.min_confidence or not is_valid:
       return
 
@@ -330,16 +342,18 @@ class LateralLagEstimator:
     self.last_estimate_t = self.t
 
   @staticmethod
-  def actuator_delay(expected_sig: np.ndarray, actual_sig: np.ndarray, mask: np.ndarray, dt: float, max_lag: float) -> tuple[float, float, float]:
+  def actuator_delay(expected_sig: np.ndarray, actual_sig: np.ndarray, mask: np.ndarray, dt: float,
+                     max_lag: float, min_lag: float = 0.0) -> tuple[float, float, float]:
     assert len(expected_sig) == len(actual_sig)
+    min_lag_samples = int(round(min_lag / dt))
     max_lag_samples = int(round(max_lag / dt))
     one_sec_samples = int(round(1.0 / dt))
     padded_size = fft_next_good_size(len(expected_sig) + max(max_lag_samples, one_sec_samples))
 
     ncc = masked_normalized_cross_correlation(expected_sig, actual_sig, mask, padded_size)
 
-    # only consider lags from 0 to max_lag
-    roi = np.s_[len(expected_sig) - 1: len(expected_sig) - 1 + max_lag_samples]
+    # only consider lags inside the platform-specific search interval
+    roi = np.s_[len(expected_sig) - 1 + min_lag_samples: len(expected_sig) - 1 + max_lag_samples]
     threshold_roi = np.s_[len(expected_sig) - 1: len(expected_sig) - 1 + one_sec_samples]
     confidence_roi = np.s_[threshold_roi.start - CORR_BORDER_OFFSET: threshold_roi.stop + CORR_BORDER_OFFSET]
     roi_ncc = ncc[roi]
@@ -348,7 +362,7 @@ class LateralLagEstimator:
 
     max_corr_index = np.argmax(roi_ncc)
     corr = roi_ncc[max_corr_index]
-    lag = parabolic_peak_interp(roi_ncc, max_corr_index) * dt
+    lag = parabolic_peak_interp(roi_ncc, max_corr_index) * dt + min_lag
 
     # to estimate lag confidence, gather all high-correlation candidates and see how spread they are
     # if e.g. 0.8 and 0.4 are both viable, this is an ambiguous case
@@ -377,6 +391,8 @@ def retrieve_initial_lag(params: Params, CP: car.CarParams):
         lag, valid_blocks, status = ld.lateralDelayEstimate, ld.validBlocks, ld.status
         assert valid_blocks <= BLOCK_NUM, "Invalid number of valid blocks"
         assert status != log.LiveDelayData.Status.invalid, "Lag estimate is invalid"
+        if CP.brand == "honda" and CP.carFingerprint == HONDA_CAR.HONDA_ACCORD_11G:
+          assert ACCORD_11G_MIN_LAG <= lag <= MAX_LAG, "Accord 11G LiveDelay outside validated range"
         return lag, valid_blocks
     except Exception as e:
       cloudlog.error(f"Failed to retrieve initial lag: {e}")

--- a/selfdrive/locationd/paramsd.py
+++ b/selfdrive/locationd/paramsd.py
@@ -131,7 +131,7 @@ class VehicleParamsLearner:
 
       in_linear_region = abs(steering_angle) < 45
       self.observed_speed = msg.vEgo
-      self.active = self.observed_speed > MIN_ACTIVE_SPEED and in_linear_region
+      self.active = self.observed_speed > MIN_ACTIVE_SPEED and in_linear_region and msg.gearShifter != car.CarState.GearShifter.reverse
 
       if self.active:
         self.kf.predict_and_observe(t, ObservationKind.STEER_ANGLE, np.array([[np.radians(steering_angle)]]))

--- a/selfdrive/locationd/test/test_lagd.py
+++ b/selfdrive/locationd/test/test_lagd.py
@@ -19,7 +19,7 @@ DT = 0.05
 LAGD_MAX_LAG_FRAMES = int(round(MAX_LAG / DT))
 
 
-def process_messages(estimator, lag_frames, n_frames, vego=20.0, rejection_threshold=0.0):
+def process_messages(estimator, lag_frames, n_frames, vego=20.0, rejection_threshold=0.0, gear_shifter=car.CarState.GearShifter.unknown):
   for i in range(n_frames):
     t = i * estimator.dt
     desired_la = np.cos(10 * t) * 0.3
@@ -34,7 +34,7 @@ def process_messages(estimator, lag_frames, n_frames, vego=20.0, rejection_thres
     actual_yr = float(actual_la / vego)
     msgs = [
       (t, "carControl", car.CarControl(latActive=not rejected)),
-      (t, "carState", car.CarState(vEgo=vego, steeringPressed=False)),
+      (t, "carState", car.CarState(vEgo=vego, steeringPressed=False, gearShifter=gear_shifter)),
       (t, "controlsState", log.ControlsState(desiredCurvature=desired_cuvature)),
       (t, "livePose", log.LivePose(angularVelocityDevice=log.LivePose.XYZMeasurement(z=actual_yr, valid=True),
                                    posenetOK=True, inputsOK=True)),
@@ -137,6 +137,15 @@ class TestLagd:
     assert np.allclose(msg.liveDelay.lateralDelayEstimate, lag_frames * DT, atol=0.01)
     assert np.allclose(msg.liveDelay.lateralDelayEstimateStd, 0.0, atol=0.01)
     assert msg.liveDelay.calPerc == 100
+
+  def test_estimator_rejects_reverse_samples(self):
+    mocked_CP = car.CarParams(steerActuatorDelay=0.5)
+    estimator = LateralLagEstimator(mocked_CP, DT, min_recovery_buffer_sec=0.0, min_yr=0.0)
+    estimator.starpilot_toggles = SimpleNamespace(use_custom_steerActuatorDelay=False)
+    process_messages(estimator, 5, 10, gear_shifter=car.CarState.GearShifter.reverse)
+    assert not bool(estimator.points.okay[-1])
+    process_messages(estimator, 5, 10, gear_shifter=car.CarState.GearShifter.drive)
+    assert bool(estimator.points.okay[-1])
 
   @pytest.mark.skipif(PC, reason="only on device")
   @pytest.mark.timeout(60)

--- a/selfdrive/locationd/test/test_paramsd.py
+++ b/selfdrive/locationd/test/test_paramsd.py
@@ -2,8 +2,14 @@ import random
 from types import SimpleNamespace
 import numpy as np
 
-from cereal import messaging
-from openpilot.selfdrive.locationd.paramsd import resolve_vehicle_model_params, retrieve_initial_vehicle_params, migrate_cached_vehicle_params_if_needed
+from cereal import car, messaging
+from openpilot.selfdrive.locationd.paramsd import (
+  resolve_vehicle_model_params,
+  retrieve_initial_vehicle_params,
+  migrate_cached_vehicle_params_if_needed,
+  VehicleParamsLearner,
+  MIN_ACTIVE_SPEED,
+)
 from openpilot.selfdrive.locationd.models.car_kf import CarKalman
 from openpilot.selfdrive.locationd.test.test_locationd_scenarios import TEST_ROUTE
 from openpilot.selfdrive.test.process_replay.migration import migrate, migrate_carParams
@@ -90,3 +96,21 @@ class TestParamsd:
     migrate_cached_vehicle_params_if_needed(params)
     assert params.get("LiveParameters") is None
     assert params.get("LiveParametersV2") is None
+
+  def test_vehicle_params_learner_rejects_reverse(self):
+    CP = car.CarParams(
+      mass=1500.0,
+      rotationalInertia=2500.0,
+      centerToFront=1.2,
+      wheelbase=2.8,
+      tireStiffnessFront=80000.0,
+      tireStiffnessRear=80000.0,
+      steerRatio=15.0,
+    )
+    learner = VehicleParamsLearner(CP, steer_ratio=15.0, stiffness_factor=1.0, angle_offset=0.0)
+    payload = car.CarState(vEgo=MIN_ACTIVE_SPEED + 1.0, steeringAngleDeg=0.0, gearShifter=car.CarState.GearShifter.reverse)
+    learner.handle_log(0.0, "carState", payload)
+    assert learner.active is False
+    payload.gearShifter = car.CarState.GearShifter.drive
+    learner.handle_log(0.0, "carState", payload)
+    assert learner.active is True

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -29,6 +29,7 @@ from openpilot.common.transformations.model import get_warp_matrix
 from openpilot.system.camerad.cameras.nv12_info import get_nv12_info
 from openpilot.system import sentry
 from opendbc.car.car_helpers import get_demo_car_params
+from opendbc.car.honda.values import CAR as HONDA_CAR
 from openpilot.selfdrive.controls.lib.desire_helper import DesireHelper
 from openpilot.selfdrive.controls.lib.drive_helpers import get_accel_from_plan_tomb_raider, smooth_value
 from openpilot.selfdrive.modeld.camera_offset import CameraOffset, DEFAULT_CAMERA_HEIGHT
@@ -329,7 +330,7 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
                           lat_action_t: float, long_action_t: float, v_ego: float, mlsim: bool,
                           is_v9: bool, is_v14: bool, is_v15: bool, starpilot_toggles,
                           lat_smooth_seconds=LAT_SMOOTH_SECONDS, long_smooth_seconds=LONG_SMOOTH_SECONDS,
-                          is_v16: bool = False) -> log.ModelDataV2.Action:
+                          honda_accord_11g_lateral: bool = False, is_v16: bool = False) -> log.ModelDataV2.Action:
     if is_v14 or is_v15 or is_v16:
       desired_curv_unscaled, desired_accel = model_output['action'][0]
       if is_v15 or is_v16:
@@ -349,7 +350,7 @@ def get_action_from_model(model_output: dict[str, np.ndarray], prev_action: log.
                                     shouldStop=bool(should_stop))
 
     plan = model_output['plan'][0]
-    if 'planplus' in model_output:
+    if 'planplus' in model_output and not honda_accord_11g_lateral:
       recovery_power = getattr(starpilot_toggles, "recovery_power", 1.0)
       plan = plan + recovery_power * model_output['planplus'][0]
       cloudlog.error(f"planplus applied: shape {model_output['planplus'].shape}, RECOVERY_POWER {recovery_power}")
@@ -855,8 +856,9 @@ def main(demo=False):
     else:
       CP = messaging.log_from_bytes(params.get("CarParams", block=True), car.CarParams)
   cloudlog.info("modeld got CarParams: %s", CP.brand)
+  honda_accord_11g_lateral = CP.brand == "honda" and CP.carFingerprint == HONDA_CAR.HONDA_ACCORD_11G
 
-  lat_smooth_seconds = _model_smooth_seconds(params, "LatSmoothSeconds", LAT_SMOOTH_SECONDS)
+  lat_smooth_seconds = 0.0 if honda_accord_11g_lateral else _model_smooth_seconds(params, "LatSmoothSeconds", LAT_SMOOTH_SECONDS)
   long_smooth_seconds = _model_smooth_seconds(params, "LongSmoothSeconds", LONG_SMOOTH_SECONDS)
   long_delay = CP.longitudinalActuatorDelay + long_smooth_seconds
   prev_action = log.ModelDataV2.Action()
@@ -908,8 +910,11 @@ def main(demo=False):
     v_ego = max(sm["carState"].vEgo, 0.)
     lat_smooth_default = CP.lateralSmoothSeconds if (CP.brand == "rivian" or CP.lateralSmoothSeconds > 0.0) else LAT_SMOOTH_SECONDS
     lat_smooth_maximum = _model_smooth_seconds(params, "LatSmoothSeconds", lat_smooth_default)
-    lat_smooth_seconds = get_car_lateral_smooth_seconds(CP.brand, v_ego, lat_smooth_maximum)
-    lat_delay = sm["liveDelay"].lateralDelay + lat_smooth_seconds
+    lat_smooth_seconds = 0.0 if honda_accord_11g_lateral else get_car_lateral_smooth_seconds(CP.brand, v_ego, lat_smooth_maximum)
+    if honda_accord_11g_lateral and not sm.seen['liveDelay']:
+      lat_delay = CP.steerActuatorDelay + 0.2
+    else:
+      lat_delay = sm["liveDelay"].lateralDelay + lat_smooth_seconds
     lateral_control_params = np.array([v_ego, lat_delay], dtype=np.float32)
     if sm.frame % 60 == 0:
       camera_offset.set_target(params.get_float("CameraOffset", return_default=True))
@@ -1025,7 +1030,8 @@ def main(demo=False):
         lat_action_t,
         long_action_t,
         v_ego, model.mlsim, model.is_v9, model.is_v14, model.is_v15, starpilot_toggles,
-        lat_smooth_seconds, long_smooth_seconds, is_v16=model.is_v16,
+        lat_smooth_seconds, long_smooth_seconds,
+        honda_accord_11g_lateral=honda_accord_11g_lateral, is_v16=model.is_v16,
       )
       prev_action = action
       fill_model_msg(drivingdata_send, modelv2_send, model_output, action,


### PR DESCRIPTION
## Description

This PR integrates the complete Honda Accord 11G control stack into StarPilot DOM's native architecture.

The implementation preserves DOM ownership of planning, MPC, longcontrol, radar, lateral control, model processing, delay estimation, Honda CAN handling, and parameter learning. Accord-specific behavior is applied through explicit `HONDA_ACCORD_11G` policy gates so generic DOM behavior and other Honda platforms retain their existing paths.

The current-DOM replay contains NATIVE-01 through NATIVE-14 as 13 commits (`NATIVE-09/10` remains intentionally combined). The earlier LKG-only AGNOS 19.6.13 compatibility commit was intentionally omitted because current DOM requires AGNOS 19.6.16. The series replaces the earlier replay-style integration with focused native policy, lifecycle, diagnostics, and regression coverage.

### Vehicle

- Honda Accord 11th generation
- Honda Bosch CAN-FD platform
- openpilot longitudinal control
- StarPilot DOM
- Current DOM software contract: AGNOS 19.6.16
- Road-validation environment for the predecessor head: AGNOS 19.6.13

## Architecture and safety boundaries

- Accord policy is gated by the Accord 11G fingerprint; it is not broadened to older `HONDA_ACCORD` platforms.
- The Accord 11G CAN-FD radar path remains separate from the older 2018–2022 Accord Bosch-A radar implementation.
- Non-Accord planner, MPC, longcontrol, radar, lateral, model, and location-learning behavior remains on DOM's native path.
- Longitudinal-control disengagement immediately clears the Accord low-speed brake-PID state.
- Parameter learning is prevented while reversing.
- CAN-validity diagnostics are bounded and the Accord-specific diagnostic path is explicitly scoped to Accord 11G.
- No Bluetooth cruise-control, wheel-control, UI-streaming, or unrelated vehicle feature is introduced by this series.

## Commit series

### NATIVE-01 — native longitudinal behavior contract

Defines the Accord 11G longitudinal policy in `longitudinal_vehicle_tunes.py` and adds a dedicated regression contract.

### NATIVE-02 — planner envelope and projection

Integrates the Accord acceleration envelope and stable actuation-delay projection into DOM's native longitudinal planner without changing the default projection path.

### NATIVE-03 — cruise and throttle policy

Integrates Accord-specific cruise acceleration limits and throttle permission behavior while preserving the existing DOM policy for all other vehicles.

### NATIVE-04 — native MPC policy

Integrates the Accord lead extrapolation, follow, acceleration, and MPC behavior into the native longitudinal MPC implementation.

### NATIVE-05 — native longitudinal control

Adds Accord-specific longitudinal state-transition and output policy to DOM's native longcontrol implementation, including stopping and starting behavior.

### NATIVE-06 — native radar lead policy

Adds Accord 11G lead association, filtering, smoothing, stale-lead handling, and cut-in/cut-out behavior to the native radar process.

### NATIVE-07 — native lateral and delay policy

Integrates Accord model-action scaling, lateral-delay behavior, model processing, controlsd policy, and lag estimation into the native DOM path.

### NATIVE-08 — fixed PID gains

Prevents dynamic gain scaling from altering the Accord's validated fixed lateral PID gains.

### NATIVE-09/10 — Honda lifecycle behavior

Adds the required LKAS HUD state-change pulse and moves learned Honda gas/wind persistence out of the real-time controller path.

### NATIVE-11 — reverse-learning protection

Prevents learned delay and vehicle-parameter updates while the vehicle is reversing.

### NATIVE-12 — bounded CAN-validity diagnostics

Adds bounded CAN parser diagnostics and Accord-only diagnostic context with parser and Honda regression coverage.

### Current-DOM OS compatibility

The replay inherits current DOM's AGNOS 19.6.16 manifest and launch contract unchanged. The former LKG3-only AGNOS 19.6.13 compatibility commit was deliberately excluded from the PR replay; carrying it forward would have replaced current DOM boot/system images with an older OS contract.

### NATIVE-13 — brake-to-gas handoff

Adapts the relevant behavior from MVL commit `314b3f16e14093db50648fc0dd2415de96babb19`:

- Retains negative low-speed brake-PID correction after the requested acceleration crosses the old brake/gas boundary.
- Releases the retained correction by `0.02` per controller update.
- Uses PID-adjusted target acceleration for the Accord propulsion crossover.
- Resets immediately when longitudinal control disengages.
- Clears stale nonnegative PID state.

This improves final brake release and avoids an abrupt brake-to-gas transition.

### NATIVE-14 — expanded low-speed brake PID

Adapts the relevant behavior from MVL commit `83bf1f7295876c71b02baca839a37ff02e2f3c4f`:

- Activates the Accord low-speed brake PID for all requested acceleration below `0.001 m/s²`, rather than only requests below the old `min_gas` crossover.
- Preserves the existing speed envelope: active above `0.001 m/s` and below `3.0 m/s`.
- Leaves behavior at zero speed, at/above 3 m/s, and on other vehicles unchanged.

This improves gentle final deceleration, creeping control, stop settling, and brake release.

## Files and scope

The conflict-resolved current-DOM PR contains 23 files covering only the native Accord integration and its tests:

- Honda controller, state, CAN, and Honda tests
- Native planner, MPC, longcontrol, radar, lateral, model, and delay paths
- Accord-specific control regression files
- CAN parser diagnostics and tests
- Current DOM AGNOS files remain unchanged

There are no Bluetooth, Galaxy, wheel-control, UI-streamer, or unrelated vehicle files in the DOM-targeted patch.

## Host verification

### Conflict-resolved current-DOM replay

- Current DOM base: `5122b8df4231f5eba95207cee538a595eaac9259`
- Resolved head: `a7ea595e0a9e1e81335b22e7ded3902ca17229d5`
- GitHub comparison: 13 commits ahead, 0 behind; merge base equals the current DOM base
- Scope: 23 files; 1,712 additions and 110 deletions
- NATIVE-01–14 replayed cleanly; only the obsolete AGNOS 19.6.13 compatibility commit was omitted
- Full SCons x86-64 host build: passed
- Dedicated Accord NATIVE suite: **74 passed**
- Affected controls regression group: **748 passed, 2 qualified current-DOM baseline failures**
- Honda regression: **40 passed**
- CAN parser regression: **20 passed**
- Location regression: **14 passed, 1 skipped, 12 subtests passed**
- Scoped Ruff with the previously documented DOM exclusions (`E501`, `F821`, `ISC002`): passed
- Python compilation and final diff check: passed
- Final source and index: clean

The two qualified controls failures are unrelated to this PR and reproduce current-DOM inconsistencies: the existing generic force-stop helper returns `0.20` while its unchanged test expects `0.32`, and a newly added Genesis G70 assertion expects differing outputs for two inputs that the unchanged Genesis helper currently maps to the same value. The PR does not modify either failed helper or either failing assertion.

### Road-validated predecessor candidate

- Python compile: passed
- Scoped Ruff: passed
- Focused Honda suite after NATIVE-13: **28 passed**
- Focused Honda suite after NATIVE-14: **40 passed**
- Native control/planner/MPC/radar/lateral regression group: **732 passed**
- Honda/CAN/location regression group: **74 passed, 1 skipped, 12 subtests passed**
- SCons host build: passed
- Final diff check: passed
- Final source worktree: clean

Candidate identity:

- Head: `3bda5ad69a423ef7e286f0d3c03ae2cfd9b8ad9d`
- Candidate diff SHA-256: `37250b72e86d64ebb40de3cc3192c72e19f397e7bc9e0db578406bce21d0f589`
- Sealed host-verification evidence SHA-256: `cdae492f25b2098ca2ffa68530b75fa120bf2a71e7f249ad5767cc8a350d31b9`

### Earlier cumulative native validation

The NATIVE-01–12 stack was cumulatively verified and replayed onto the LKG-derived validation line. Focused verification included:

- Native longitudinal policy tests
- DOM longitudinal planner/MPC regression tests
- Native longcontrol tests
- Native radar tests
- Native lateral and latcontrol tests
- Honda controller tests
- CAN parser tests
- Lag-estimation and parameter-learning tests
- Host build and architecture checks

## Road verification

The road evidence below applies to the behavior-equivalent predecessor stack ending at `3bda5ad69a423ef7e286f0d3c03ae2cfd9b8ad9d`. The current-DOM replay preserves the NATIVE patches but has not yet been installed on the vehicle; the PR therefore remains a draft pending a short device boot/smoke check and proportionate road confirmation.

### NATIVE-01–12 baseline

NATIVE-01–12 were road validated on the LKG-derived native full-validation stack:

- Reference commit: `52c7e8160b9b67df5b1711dac92b8e071257a6b5`
- Tag: `accord11g-dom-native-full-road-validated-20260830`
- Lateral and longitudinal control, radar, LKAS, UI behavior, and repeated complete vehicle shutdown/restart cycles were validated.
- The LKG-derived AGNOS 19.6.13 line completed repeated cold/full restart checks without the persistent startup DTC behavior observed on a separate newer-DOM device candidate.

### NATIVE-13/14 final road validation

The NATIVE-13/14 candidate was tested across extended morning and evening driving, including the intended low-speed operating region.

Driver-observed validation included:

- 0–3 m/s gentle deceleration
- creeping behavior
- complete-stop settling
- brake release
- brake-to-gas transition
- lead departure
- repeated stop-and-go
- normal engagement/disengagement
- repeated vehicle shutdown/restart
- stationary LKAS/radar/CAN checks

The low-speed changes behaved normally throughout the completed driving sessions. No behavior indicating a NATIVE-13/14 low-speed-control regression was observed.

### Evening connector incident

One evening-drive interruption occurred after a physical harness/connector disturbance. Focused qlog evidence provides the following sequence; wall-clock times are reconstructed from tar-preserved qlog segment-close timestamps because the embedded qlog clock was stale:

| Approximate UAE time | Evidence |
| --- | --- |
| 17:32 | openpilot engaged normally; Panda permitted controls. |
| 17:41 | Normal disengagement. |
| 17:51 | openpilot engaged again. |
| 18:04 | Abrupt `canValid=false`, `canTimeout=true`, cruise disabled, controls revoked, and Panda `relayMalfunction`. |
| 18:04 | UI emitted `CAN Bus Disconnected: Likely Faulty Cable` / `canBusMissing/permanent`. |
| 18:05 | CAN validity returned, but `relayMalfunction` and `steerUnavailable` remained latched; UI requested a vehicle restart. |
| 18:07 | Affected route ended. |
| 18:13 | New route after stopping and reseating the harness; the vehicle was engageable again. |
| 18:32 | Lane-change UI behavior was normal. |
| 18:36 | openpilot engaged again with `controlsAllowed=true` and cruise enabled. |

This is classified as a **high-confidence external harness/connector CAN-path interruption**:

- Expected CAN traffic disappeared abruptly rather than degrading with low-speed actuation.
- Panda recorded a relay/harness-related temporary fault.
- CAN validity recovered independently of the low-speed controller.
- The Honda LKAS fault remained latched until restart, consistent with a communication interruption.
- Reseating the connector and restarting restored normal engagement.
- NATIVE-13/14 modify low-speed gas/brake PID values only; they do not change Panda relay operation, CAN bus selection, CAN receive validity, firmware, startup sequencing, or harness behavior.

The incident is therefore documented as an external validation anomaly, not a merge blocker or evidence of a NATIVE-13/14 regression.

### Non-blocking observations

- Panda reported a temporary `interruptRateCan2` fault after reconnection. The system remained engageable and subsequently reached `controlsAllowed=true`. This should be monitored on future clean boots and investigated separately if it recurs without connector movement.
- Six `cruiseMismatch` observations occurred earlier in the route. They did not coincide with the CAN loss, did not prevent continued operation, and are not introduced by NATIVE-13/14.
- No automatic DTC-clearing mechanism was used or added.

## Validation evidence

### Compact road-validation bundle

- File: `native14-final-road-validation-20260902-203808.tar.gz`
- SHA-256: `98fd0043cd0e86bcfa6df145c076e366d28ec81c97f7d0764661953970b57d03`
- Captures candidate identity, AGNOS version, current journals, kernel log, tmux output, collection metadata, and the incident note.
- The included system journal begins after the connector cycle and confirms a clean post-recovery boot.

### Full forensic collection

- File: `accord-log-hub-20260902-195324.tar.gz`
- SHA-256: `31d890e6483be49fcc6b5d7cc43fd6955a64a440cc4d6376837caaa397d864e6`
- Size: 3,109,941,558 bytes
- Route telemetry files: 514
- Collection status: complete; source and copied hashes matched.

### Focused incident qlogs

- File: `native14-incident-qlogs-20260902-1720-1815-20260902-212755.tar.gz`
- SHA-256: `b114cc4ad18a684c0d5f95ca555c0dae3a7ea1ceddc4633a03a636e1ffbe2fa8`
- 95 qlogs, 45,257,693 uncompressed qlog bytes
- Coverage: 16:58–18:36 UAE
- Affected route: `0000006d--c77c455c32`
- Recovery route: `0000006f--f5c3bdebf5`
- 102 internal evidence files independently rehashed successfully after extraction.

Data-quality note: the selected qlogs contained a stale embedded wall clock reporting 28 July 2026. Selection used tar-preserved file modification times, and incident times are therefore approximate to the one-minute segment boundary. The raw qlogs remain intact. A first-pass summary decoder also stopped early on a structured radar/event wrapper in each qlog; this did not affect the CAN, Panda, controls, alert, and recovery transitions cited above.

The binary evidence bundles are retained outside the source branch and are available to maintainers on request. Their hashes are included here so transferred copies can be authenticated without adding large logs to the repository.

## Known exclusions and follow-up work

The following remain intentionally excluded and will be evaluated separately:

- Bluetooth cruise-control/startup sequencing and related DTC investigation
- AGNOS cross-layout `agnos.json` resolver changes
- UI streaming
- Additional PID gain or brake scaling changes
- Extending low-speed PID operation to exactly zero speed or above 3 m/s
- Automatic DTC clearing
- Wholesale replay of the rewritten MVL history

## Review request

This is a complete native Accord 11G integration rather than a generic DOM behavior change. Review should focus on:

1. Accord 11G fingerprint isolation.
2. Planner/MPC/longcontrol state and reset behavior.
3. Separation of Accord 11G CAN-FD radar from older Accord Bosch-A radar.
4. Lateral/model/delay compatibility.
5. Honda real-time lifecycle behavior.
6. Bounded CAN diagnostics.
7. Low-speed brake-PID release and activation boundaries.

## Submission status

**Merge conflicts are resolved and the current-DOM replay is host verified.** GitHub reports the head as 13 commits ahead, 0 behind, and mergeable.

The NATIVE behavior is road validated on the preserved predecessor head `3bda5ad69a…`. This PR remains a draft until the rebased head `a7ea595e0a…` receives a device boot/smoke check and proportionate road confirmation. The documented connector interruption remains non-blocking and is not attributed to this patch series.
