### PR TITLE
Keep soundd alive when custom clips are missing

### DIFF
--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -212,7 +212,7 @@ class Soundd:
       for path in self._sound_candidates(filename):
         try:
           sound_data = self._read_sound(path)
-        except (FileNotFoundError, OSError, EOFError, ValueError, wave.Error):
+        except Exception:
           cloudlog.exception(f"soundd: failed to load {path}")
           continue
         if sound_data is not None:

--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -208,7 +208,7 @@ class Soundd:
       for path in self._sound_candidates(filename):
         try:
           sound_data = self._read_sound(path)
-        except (FileNotFoundError, OSError, wave.Error):
+        except (FileNotFoundError, OSError, EOFError, wave.Error):
           cloudlog.exception(f"soundd: failed to load {path}")
           continue
         if sound_data is not None:
@@ -263,6 +263,12 @@ class Soundd:
       self.bluetooth_audio = None
       sink.close()
 
+  def select_critical_alert(self, stock_alert, goat_scream_critical):
+    goat_alert = starpilot_alert_key(StarPilotAudibleAlert.goat)
+    if goat_scream_critical and goat_alert in self.loaded_sounds:
+      return goat_alert
+    return stock_alert
+
   def update_alert(self, new_alert):
     if new_alert != AudibleAlert.none and new_alert not in self.loaded_sounds:
       new_alert = AudibleAlert.none
@@ -295,8 +301,10 @@ class Soundd:
 
       critical_full_alert = sm['selfdriveState'].alertStatus == log.SelfdriveState.AlertStatus.critical
       critical_full_alert &= sm['selfdriveState'].alertSize == log.SelfdriveState.AlertSize.full
-      if self.starpilot_toggles.goat_scream_critical_alerts and critical_full_alert:
-        new_alert = starpilot_alert_key(StarPilotAudibleAlert.goat)
+      new_alert = self.select_critical_alert(
+        new_alert,
+        self.starpilot_toggles.goat_scream_critical_alerts and critical_full_alert,
+      )
 
       new_starpilot_alert = sm['starpilotSelfdriveState'].alertSound.raw
       if new_alert == AudibleAlert.none and new_starpilot_alert != StarPilotAudibleAlert.none:

--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -192,7 +192,11 @@ class Soundd:
       if length <= 0:
         cloudlog.warning(f"soundd: empty audio {path}, skipping")
         return None
-      sound = np.frombuffer(wavefile.readframes(length), dtype=np.int16).astype(np.float32) / (2**16/2)
+      raw = wavefile.readframes(length)
+      if len(raw) < 2 or (len(raw) % 2) != 0:
+        cloudlog.warning(f"soundd: truncated audio {path}, skipping")
+        return None
+      sound = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / (2**16/2)
       if sound.size == 0:
         cloudlog.warning(f"soundd: empty audio {path}, skipping")
         return None
@@ -208,7 +212,7 @@ class Soundd:
       for path in self._sound_candidates(filename):
         try:
           sound_data = self._read_sound(path)
-        except (FileNotFoundError, OSError, EOFError, wave.Error):
+        except (FileNotFoundError, OSError, EOFError, ValueError, wave.Error):
           cloudlog.exception(f"soundd: failed to load {path}")
           continue
         if sound_data is not None:

--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -180,26 +180,32 @@ class Soundd:
           sounds_path = standard_path
 
       if random_events_path.exists():
-        wavefile = wave.open(str(random_events_path), 'r')
+        path = random_events_path
       elif sounds_path.exists():
-        wavefile = wave.open(str(sounds_path), 'r')
+        path = sounds_path
       else:
         if filename == "startup.wav":
           filename = "engage.wav"
-        wavefile = wave.open(BASEDIR + "/selfdrive/assets/sounds/" + filename, 'r')
+        path = Path(BASEDIR) / "selfdrive" / "assets" / "sounds" / filename
+        if not path.exists():
+          cloudlog.warning(f"soundd: missing {filename}, skipping")
+          continue
 
-      assert wavefile.getnchannels() == 1
-      assert wavefile.getsampwidth() == 2
-      assert wavefile.getframerate() == SAMPLE_RATE
-
-      length = wavefile.getnframes()
-      self.loaded_sounds[sound] = np.frombuffer(wavefile.readframes(length), dtype=np.int16).astype(np.float32) / (2**16/2)
+      try:
+        with wave.open(str(path), 'r') as wavefile:
+          if wavefile.getnchannels() != 1 or wavefile.getsampwidth() != 2 or wavefile.getframerate() != SAMPLE_RATE:
+            cloudlog.warning(f"soundd: invalid format {path}, skipping")
+            continue
+          length = wavefile.getnframes()
+          self.loaded_sounds[sound] = np.frombuffer(wavefile.readframes(length), dtype=np.int16).astype(np.float32) / (2**16/2)
+      except (FileNotFoundError, OSError, wave.Error):
+        cloudlog.exception(f"soundd: failed to load {path}")
 
   def get_sound_data(self, frames): # get "frames" worth of data from the current alert sound, looping when required
 
     ret = np.zeros(frames, dtype=np.float32)
 
-    if self.current_alert != AudibleAlert.none:
+    if self.current_alert != AudibleAlert.none and self.current_alert in self.loaded_sounds:
       num_loops = sound_list[self.current_alert][1]
       sound_data = self.loaded_sounds[self.current_alert]
       written_frames = 0
@@ -239,7 +245,10 @@ class Soundd:
       sink.close()
 
   def update_alert(self, new_alert):
-    current_alert_played_once = self.current_alert == AudibleAlert.none or self.current_sound_frame > len(self.loaded_sounds[self.current_alert])
+    if new_alert != AudibleAlert.none and new_alert not in self.loaded_sounds:
+      new_alert = AudibleAlert.none
+    loaded = self.loaded_sounds.get(self.current_alert)
+    current_alert_played_once = self.current_alert == AudibleAlert.none or loaded is None or self.current_sound_frame > len(loaded)
     if self.current_alert != new_alert and (new_alert != AudibleAlert.none or current_alert_played_once):
       self.current_alert = new_alert
       self.current_sound_frame = 0

--- a/selfdrive/ui/soundd.py
+++ b/selfdrive/ui/soundd.py
@@ -164,42 +164,59 @@ class Soundd:
 
     return str(resolved_path), sound_files
 
+  def _sound_candidates(self, filename: str) -> list[Path]:
+    random_events_path = self.random_events_directory / filename
+    sounds_path = self.sound_directory / filename
+
+    if not sounds_path.exists() and "_tizi" in filename:
+      standard_path = self.sound_directory / filename.replace("_tizi", "")
+      if standard_path.exists():
+        sounds_path = standard_path
+
+    stock_filename = "engage.wav" if filename == "startup.wav" else filename
+    stock_path = Path(BASEDIR) / "selfdrive" / "assets" / "sounds" / stock_filename
+
+    candidates = []
+    for path in (random_events_path, sounds_path, stock_path):
+      if path.exists() and path not in candidates:
+        candidates.append(path)
+    return candidates
+
+  @staticmethod
+  def _read_sound(path: Path) -> np.ndarray | None:
+    with wave.open(str(path), 'r') as wavefile:
+      if wavefile.getnchannels() != 1 or wavefile.getsampwidth() != 2 or wavefile.getframerate() != SAMPLE_RATE:
+        cloudlog.warning(f"soundd: invalid format {path}, skipping")
+        return None
+      length = wavefile.getnframes()
+      if length <= 0:
+        cloudlog.warning(f"soundd: empty audio {path}, skipping")
+        return None
+      sound = np.frombuffer(wavefile.readframes(length), dtype=np.int16).astype(np.float32) / (2**16/2)
+      if sound.size == 0:
+        cloudlog.warning(f"soundd: empty audio {path}, skipping")
+        return None
+      return sound
+
   def load_sounds(self):
     self.loaded_sounds: dict[int, np.ndarray] = {}
 
-    # Load all sounds
+    # Load all sounds. Prefer theme/random-event clips, then packaged stock.
     for sound in sound_list:
       filename, play_count, volume = sound_list[sound]
-
-      random_events_path = self.random_events_directory / filename
-      sounds_path = self.sound_directory / filename
-
-      if not sounds_path.exists() and "_tizi" in filename:
-        standard_path = self.sound_directory / filename.replace("_tizi", "")
-        if standard_path.exists():
-          sounds_path = standard_path
-
-      if random_events_path.exists():
-        path = random_events_path
-      elif sounds_path.exists():
-        path = sounds_path
-      else:
-        if filename == "startup.wav":
-          filename = "engage.wav"
-        path = Path(BASEDIR) / "selfdrive" / "assets" / "sounds" / filename
-        if not path.exists():
-          cloudlog.warning(f"soundd: missing {filename}, skipping")
+      loaded = False
+      for path in self._sound_candidates(filename):
+        try:
+          sound_data = self._read_sound(path)
+        except (FileNotFoundError, OSError, wave.Error):
+          cloudlog.exception(f"soundd: failed to load {path}")
           continue
-
-      try:
-        with wave.open(str(path), 'r') as wavefile:
-          if wavefile.getnchannels() != 1 or wavefile.getsampwidth() != 2 or wavefile.getframerate() != SAMPLE_RATE:
-            cloudlog.warning(f"soundd: invalid format {path}, skipping")
-            continue
-          length = wavefile.getnframes()
-          self.loaded_sounds[sound] = np.frombuffer(wavefile.readframes(length), dtype=np.int16).astype(np.float32) / (2**16/2)
-      except (FileNotFoundError, OSError, wave.Error):
-        cloudlog.exception(f"soundd: failed to load {path}")
+        if sound_data is not None:
+          self.loaded_sounds[sound] = sound_data
+          loaded = True
+          break
+      if not loaded:
+        cloudlog.warning(f"soundd: missing {filename}, skipping")
 
   def get_sound_data(self, frames): # get "frames" worth of data from the current alert sound, looping when required
 
@@ -208,6 +225,8 @@ class Soundd:
     if self.current_alert != AudibleAlert.none and self.current_alert in self.loaded_sounds:
       num_loops = sound_list[self.current_alert][1]
       sound_data = self.loaded_sounds[self.current_alert]
+      if sound_data.size == 0:
+        return ret * self.current_volume
       written_frames = 0
 
       current_sound_frame = self.current_sound_frame % len(sound_data)

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -13,6 +13,7 @@ from openpilot.selfdrive.ui.soundd import (
 
 import numpy as np
 import time
+import wave
 
 AudibleAlert = log.SelfdriveState.AudibleAlert
 StarPilotAudibleAlert = custom.StarPilotCarControl.HUDControl.AudibleAlert
@@ -46,11 +47,50 @@ class TestSoundd:
     soundd.load_sounds()
 
     assert AudibleAlert.engage in soundd.loaded_sounds
+    assert AudibleAlert.warningImmediate in soundd.loaded_sounds
     assert starpilot_alert_key(StarPilotAudibleAlert.angry) not in soundd.loaded_sounds
     soundd.current_alert = starpilot_alert_key(StarPilotAudibleAlert.angry)
     soundd.current_volume = 1.0
     soundd.current_sound_frame = 0
     np.testing.assert_array_equal(soundd.get_sound_data(4), np.zeros(4, dtype=np.float32))
+
+  def test_load_sounds_falls_back_to_stock_when_custom_is_invalid(self, tmp_path):
+    soundd = Soundd.__new__(Soundd)
+    soundd.sound_directory = tmp_path / "sounds"
+    soundd.sound_directory.mkdir()
+    soundd.random_events_directory = tmp_path / "random_events"
+    soundd.random_events_directory.mkdir()
+
+    invalid = soundd.sound_directory / "warning_immediate.wav"
+    with wave.open(str(invalid), "w") as wav:
+      wav.setnchannels(2)
+      wav.setsampwidth(2)
+      wav.setframerate(44100)
+      wav.writeframes(b"\x00\x00" * 64)
+
+    soundd.load_sounds()
+
+    assert AudibleAlert.warningImmediate in soundd.loaded_sounds
+    assert soundd.loaded_sounds[AudibleAlert.warningImmediate].size > 0
+
+  def test_load_sounds_skips_empty_wav(self, tmp_path):
+    soundd = Soundd.__new__(Soundd)
+    soundd.sound_directory = tmp_path / "sounds"
+    soundd.sound_directory.mkdir()
+    soundd.random_events_directory = tmp_path / "random_events"
+    soundd.random_events_directory.mkdir()
+
+    empty = soundd.sound_directory / "engage.wav"
+    with wave.open(str(empty), "w") as wav:
+      wav.setnchannels(1)
+      wav.setsampwidth(2)
+      wav.setframerate(48000)
+      wav.writeframes(b"")
+
+    soundd.load_sounds()
+
+    assert AudibleAlert.engage in soundd.loaded_sounds
+    assert soundd.loaded_sounds[AudibleAlert.engage].size > 0
 
   def test_bluetooth_audio_mutes_local_only_while_healthy(self):
     soundd = Soundd.__new__(Soundd)

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -92,6 +92,38 @@ class TestSoundd:
     assert AudibleAlert.engage in soundd.loaded_sounds
     assert soundd.loaded_sounds[AudibleAlert.engage].size > 0
 
+  def test_load_sounds_falls_back_when_custom_wav_is_truncated(self, tmp_path):
+    soundd = Soundd.__new__(Soundd)
+    soundd.sound_directory = tmp_path / "sounds"
+    soundd.sound_directory.mkdir()
+    soundd.random_events_directory = tmp_path / "random_events"
+    soundd.random_events_directory.mkdir()
+
+    (soundd.sound_directory / "warning_immediate.wav").write_bytes(b"RIFF")
+
+    soundd.load_sounds()
+
+    assert AudibleAlert.warningImmediate in soundd.loaded_sounds
+    assert soundd.loaded_sounds[AudibleAlert.warningImmediate].size > 0
+
+  def test_missing_goat_keeps_stock_critical_alert(self, tmp_path):
+    soundd = Soundd.__new__(Soundd)
+    soundd.sound_directory = tmp_path / "sounds"
+    soundd.sound_directory.mkdir()
+    soundd.random_events_directory = tmp_path / "random_events"
+    soundd.random_events_directory.mkdir()
+    soundd.load_sounds()
+
+    goat_alert = starpilot_alert_key(StarPilotAudibleAlert.goat)
+    assert goat_alert not in soundd.loaded_sounds
+    assert AudibleAlert.warningImmediate in soundd.loaded_sounds
+
+    assert soundd.select_critical_alert(AudibleAlert.warningImmediate, True) == AudibleAlert.warningImmediate
+
+    soundd.loaded_sounds[goat_alert] = soundd.loaded_sounds[AudibleAlert.warningImmediate]
+    assert soundd.select_critical_alert(AudibleAlert.warningImmediate, True) == goat_alert
+    assert soundd.select_critical_alert(AudibleAlert.warningImmediate, False) == AudibleAlert.warningImmediate
+
   def test_bluetooth_audio_mutes_local_only_while_healthy(self):
     soundd = Soundd.__new__(Soundd)
     samples = np.array([0.25, -0.5], dtype=np.float32)

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -106,6 +106,26 @@ class TestSoundd:
     assert AudibleAlert.warningImmediate in soundd.loaded_sounds
     assert soundd.loaded_sounds[AudibleAlert.warningImmediate].size > 0
 
+  def test_load_sounds_falls_back_when_custom_wav_has_odd_payload(self, tmp_path):
+    soundd = Soundd.__new__(Soundd)
+    soundd.sound_directory = tmp_path / "sounds"
+    soundd.sound_directory.mkdir()
+    soundd.random_events_directory = tmp_path / "random_events"
+    soundd.random_events_directory.mkdir()
+
+    odd = soundd.sound_directory / "warning_immediate.wav"
+    with wave.open(str(odd), "w") as wav:
+      wav.setnchannels(1)
+      wav.setsampwidth(2)
+      wav.setframerate(48000)
+      wav.writeframes(b"\x00\x00\x00\x00")
+    odd.write_bytes(odd.read_bytes()[:-1])
+
+    soundd.load_sounds()
+
+    assert AudibleAlert.warningImmediate in soundd.loaded_sounds
+    assert soundd.loaded_sounds[AudibleAlert.warningImmediate].size > 0
+
   def test_missing_goat_keeps_stock_critical_alert(self, tmp_path):
     soundd = Soundd.__new__(Soundd)
     soundd.sound_directory = tmp_path / "sounds"

--- a/selfdrive/ui/tests/test_soundd.py
+++ b/selfdrive/ui/tests/test_soundd.py
@@ -1,4 +1,4 @@
-from cereal import log
+from cereal import custom, log
 from cereal import messaging
 from cereal.messaging import SubMaster, PubMaster
 from openpilot.selfdrive.ui.soundd import (
@@ -8,12 +8,14 @@ from openpilot.selfdrive.ui.soundd import (
   check_selfdrive_timeout_alert,
   is_turn_steering_limit_alert,
   should_mute_turn_steering_limit_alert,
+  starpilot_alert_key,
 )
 
 import numpy as np
 import time
 
 AudibleAlert = log.SelfdriveState.AudibleAlert
+StarPilotAudibleAlert = custom.StarPilotCarControl.HUDControl.AudibleAlert
 
 
 class TestSoundd:
@@ -33,6 +35,22 @@ class TestSoundd:
     assert not should_mute_turn_steering_limit_alert("steerSaturated/warning", 30.0, 25.0)
     assert not should_mute_turn_steering_limit_alert("steerSaturated/warning", 10.0, 0.0)
     assert not should_mute_turn_steering_limit_alert("laneChangeBlocked/warning", 10.0, 25.0)
+
+  def test_load_sounds_skips_missing_custom_clips(self, tmp_path):
+    soundd = Soundd.__new__(Soundd)
+    soundd.sound_directory = tmp_path / "sounds"
+    soundd.sound_directory.mkdir()
+    soundd.random_events_directory = tmp_path / "random_events"
+    soundd.random_events_directory.mkdir()
+
+    soundd.load_sounds()
+
+    assert AudibleAlert.engage in soundd.loaded_sounds
+    assert starpilot_alert_key(StarPilotAudibleAlert.angry) not in soundd.loaded_sounds
+    soundd.current_alert = starpilot_alert_key(StarPilotAudibleAlert.angry)
+    soundd.current_volume = 1.0
+    soundd.current_sound_frame = 0
+    np.testing.assert_array_equal(soundd.get_sound_data(4), np.zeros(4, dtype=np.float32))
 
   def test_bluetooth_audio_mutes_local_only_while_healthy(self):
     soundd = Soundd.__new__(Soundd)


### PR DESCRIPTION
## Summary
- `load_sounds()` required every random-event clip (`angry.wav`, `goat.wav`, and the rest). Those files are not in the tree, so soundd raised `FileNotFoundError` in `__init__` and never started. Stock chimes never played.
- Missing, invalid, empty, or truncated theme WAVs are skipped. Packaged stock still loads from `selfdrive/assets/sounds`.
- A malformed custom override no longer silences a critical alert. The loader tries theme / random-event, then stock. One broken file cannot abort startup.
- Goat Scream only replaces a critical chime when `goat.wav` actually loaded. Otherwise the stock warning stays.

## Test plan
- [ ] Boot a fresh image with no random-event assets and confirm engage / disengage chimes play
- [ ] Confirm a missing custom clip no longer kills `soundd` in manager
- [ ] Confirm Goat Scream off, or a missing goat clip, still plays `warning_immediate`

Made with [Cursor](https://cursor.com)