### PR TITLE
Allow Silverado cruise engage at a stop

### DIFF
--- a/opendbc_repo/opendbc/car/gm/carcontroller.py
+++ b/opendbc_repo/opendbc/car/gm/carcontroller.py
@@ -172,7 +172,7 @@ def should_send_cc_button_spam(CP, CC, CS):
   return (
     bool(CP.flags & GMFlags.CC_LONG.value) and
     CC.longActive and
-    CS.out.vEgo > CP.minEnableSpeed
+    CS.out.vEgo >= CP.minEnableSpeed
   )
 
 

--- a/opendbc_repo/opendbc/car/gm/interface.py
+++ b/opendbc_repo/opendbc/car/gm/interface.py
@@ -503,6 +503,7 @@ class CarInterface(CarInterfaceBase):
       # On the Bolt, the ECM and camera independently check that you are either above 5 kph or at a stop
       # with foot on brake to allow engagement, but this platform only has that check in the camera.
       # TODO: check if this is split by EV/ICE with more platforms in the future
+      ret.minEnableSpeed = 0.
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
     elif candidate in (CAR.CHEVROLET_EQUINOX, CAR.CHEVROLET_EQUINOX_CC):

--- a/opendbc_repo/opendbc/car/gm/interface.py
+++ b/opendbc_repo/opendbc/car/gm/interface.py
@@ -667,7 +667,8 @@ class CarInterface(CarInterfaceBase):
       ret.alphaLongitudinalAvailable = False
       ret.openpilotLongitudinalControl = not disable_openpilot_long
       ret.pcmCruise = False
-      ret.minEnableSpeed = 24 * CV.MPH_TO_MS
+      if candidate not in (CAR.CHEVROLET_SILVERADO, CAR.CHEVROLET_SILVERADO_CC):
+        ret.minEnableSpeed = 24 * CV.MPH_TO_MS
       ret.radarUnavailable = True
       ret.safetyConfigs[0].safetyParam |= GMSafetyFlags.FLAG_GM_CC_LONG.value
 

--- a/opendbc_repo/opendbc/car/gm/tests/test_gm.py
+++ b/opendbc_repo/opendbc/car/gm/tests/test_gm.py
@@ -628,6 +628,13 @@ class TestGMCarController:
     assert not should_send_cc_button_spam(SimpleNamespace(flags=GMFlags.CC_LONG.value, minEnableSpeed=10.0), cc, cs)
     assert not should_send_cc_button_spam(SimpleNamespace(flags=0, minEnableSpeed=10.0), cc, cs)
 
+  def test_cc_button_spam_allows_standstill_when_min_enable_is_zero(self):
+    cp = SimpleNamespace(flags=GMFlags.CC_LONG.value, minEnableSpeed=0.0)
+    cc = SimpleNamespace(longActive=True)
+    cs = SimpleNamespace(out=SimpleNamespace(vEgo=0.0, cruiseState=SimpleNamespace(enabled=False)))
+
+    assert should_send_cc_button_spam(cp, cc, cs)
+
   def test_volt_cc_redneck_spam_is_mirrored_to_camera_bus(self):
     packer = CANPacker(DBC[CAR.CHEVROLET_VOLT_CC][Bus.pt])
     controller = SimpleNamespace(frame=int(0.3 / DT_CTRL), last_button_frame=0, apply_speed=0, malibu_button_phase=0)

--- a/opendbc_repo/opendbc/car/gm/tests/test_gm.py
+++ b/opendbc_repo/opendbc/car/gm/tests/test_gm.py
@@ -303,6 +303,7 @@ class TestGMInterface:
 
     assert car_params.openpilotLongitudinalControl
     assert not car_params.enableGasInterceptorDEPRECATED
+    assert car_params.minEnableSpeed == pytest.approx(0.0)
     assert list(car_params.longitudinalTuning.kpBP) == pytest.approx([0.0, 5.0, 15.0, 35.0])
     assert list(car_params.longitudinalTuning.kpV) == pytest.approx([0.02, 0.03, 0.028, 0.022])
     assert list(car_params.longitudinalTuning.kiBP) == pytest.approx([0.0, 5.0, 15.0, 35.0])

--- a/opendbc_repo/opendbc/car/gm/tests/test_gm.py
+++ b/opendbc_repo/opendbc/car/gm/tests/test_gm.py
@@ -309,6 +309,30 @@ class TestGMInterface:
     assert list(car_params.longitudinalTuning.kiBP) == pytest.approx([0.0, 5.0, 15.0, 35.0])
     assert list(car_params.longitudinalTuning.kiV) == pytest.approx([0.20, 0.18, 0.13, 0.08])
 
+  def test_silverado_camera_acc_allows_engage_from_stop(self):
+    CarInterface = interfaces[CAR.CHEVROLET_SILVERADO]
+    fingerprint = _empty_fingerprint()
+    fingerprint[0] = FINGERPRINTS[CAR.CHEVROLET_SILVERADO][0].copy()
+
+    car_params = CarInterface.get_params(CAR.CHEVROLET_SILVERADO, fingerprint, [], alpha_long=False, is_release=False,
+                                         docs=False, starpilot_toggles=_test_starpilot_toggles())
+
+    assert car_params.minEnableSpeed == pytest.approx(0.0)
+
+  def test_silverado_cc_allows_engage_from_stop(self):
+    CarInterface = interfaces[CAR.CHEVROLET_SILVERADO_CC]
+    car_params = CarInterface.get_params(
+      CAR.CHEVROLET_SILVERADO_CC,
+      _empty_fingerprint(),
+      [],
+      alpha_long=False,
+      is_release=False,
+      docs=False,
+      starpilot_toggles=_test_starpilot_toggles(),
+    )
+
+    assert car_params.minEnableSpeed == pytest.approx(0.0)
+
   def test_blazer_uses_softer_low_speed_stop_hold_tune(self):
     CarInterface = interfaces[CAR.CHEVROLET_BLAZER]
     fingerprint = _empty_fingerprint()


### PR DESCRIPTION
## Summary
- GM camera-ACC Silverado used `minEnableSpeed = 5 kph` (~3.1 mph). That is what blocked cruise initiate below walking speed (`belowEngageSpeed`).
- `CHEVROLET_SILVERADO` and `CHEVROLET_SILVERADO_CC` now use `minEnableSpeed = 0`.
- CC-long used to overwrite that floor back to 24 mph. Silverado is excluded from that overwrite so the 0 sticks.
- CC-long button spam used `vEgo > minEnableSpeed`. At a complete stop that is `0 > 0`, so no buttons went out. It is now `>=`.

The camera can still refuse stock ACC below 5 kph unless you are stopped with the brake. This only removes openpilot's own engage-speed gate.

## Test plan
- [ ] Camera Silverado: initiate cruise from a stop with brake applied
- [ ] Camera Silverado: confirm rolling below ~3 mph is no longer a hard openpilot NO_ENTRY
- [ ] Silverado CC-long: confirm buttons still fire at 0 m/s
- [ ] Confirm other GM CC-only cars still keep the 24 mph CC-long floor

Made with [Cursor](https://cursor.com)