### PR TITLE
Tesla Shananigans

### DIFF
--- a/opendbc_repo/opendbc/safety/modes/tesla_preap.h
+++ b/opendbc_repo/opendbc/safety/modes/tesla_preap.h
@@ -224,10 +224,17 @@ static void tesla_preap_rx_hook(const CANPacket_t *msg) {
   }
 
   if (msg->addr == 0x368U) {
-    const int cruise_state = (msg->data[1] >> 4) & 0x07U;
+    const int cruise_state = (msg->data[1] >> 4) & 0x0FU;
     if (cruise_state == 3) {
       vehicle_moving = false;
     }
+    // Pre-AP uses valid non-off DI_cruiseState values as the cruise-main signal.
+    acc_main_on = (cruise_state == 1) ||
+                  (cruise_state == 2) ||
+                  (cruise_state == 3) ||
+                  (cruise_state == 4) ||
+                  (cruise_state == 6) ||
+                  (cruise_state == 7);
   }
 
   if (msg->addr == 0x118U) {

--- a/opendbc_repo/opendbc/safety/tests/test_tesla_preap.py
+++ b/opendbc_repo/opendbc/safety/tests/test_tesla_preap.py
@@ -2,6 +2,7 @@
 import unittest
 
 from opendbc.car.tesla.preap.interface import SAFETY_TESLA_PREAP
+from opendbc.safety import ALTERNATIVE_EXPERIENCE
 from opendbc.safety.tests.libsafety import libsafety_py
 import opendbc.safety.tests.common as common
 
@@ -35,6 +36,13 @@ class TestTeslaPreAPSafety(common.SafetyTestBase):
     dat = bytearray(8)
     dat[0] = lever & 0x3F
     return common.make_msg(0, 0x45, 8, dat)
+
+  @staticmethod
+  def _di_state_msg(cruise_state: int):
+    # DI_cruiseState is the high nibble of DI_state byte 1.
+    dat = bytearray(8)
+    dat[1] = (cruise_state & 0x0F) << 4
+    return common.make_msg(0, 0x368, 8, dat)
 
   @staticmethod
   def _steering_status_msg(hands_on_level: int = 0, eac_status: int = 1, eac_error_code: int = 0, angle_tenths: int = 0):
@@ -122,6 +130,30 @@ class TestTeslaPreAPSafety(common.SafetyTestBase):
     self.assertFalse(self._tx(self._steer_cmd_msg(4000, 1)))
     self.assertTrue(self._tx(self._epas_control_msg(1)))
     self.assertFalse(self._tx(self._epas_control_msg(2)))
+
+  def test_always_on_lateral(self):
+    ENABLED, OFF = 2, 0
+    self.safety.set_controls_allowed(False)
+
+    self.safety.set_alternative_experience(0)
+    self.assertTrue(self._rx(self._di_state_msg(ENABLED)))
+    self.assertFalse(self._tx(self._steer_cmd_msg(0, 1)))
+
+    self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.ALWAYS_ON_LATERAL)
+    self.assertTrue(self._rx(self._di_state_msg(OFF)))
+    self.assertFalse(self.safety.get_controls_allowed())
+    self.assertFalse(self._tx(self._steer_cmd_msg(0, 1)))
+
+    self.assertTrue(self._rx(self._di_state_msg(ENABLED)))
+    self.assertFalse(self.safety.get_controls_allowed())
+    self.assertTrue(self._tx(self._steer_cmd_msg(0, 1)))
+
+    self.assertTrue(self._rx(self._di_state_msg(OFF)))
+    self.assertFalse(self._tx(self._steer_cmd_msg(0, 1)))
+
+    self.assertTrue(self._rx(self._di_state_msg(9)))
+    self.assertFalse(self.safety.get_aol_allowed())
+    self.assertFalse(self._tx(self._steer_cmd_msg(0, 1)))
 
   def test_aeb_is_blocked(self):
     self.safety.set_controls_allowed(True)

--- a/selfdrive/pandad/pandad.cc
+++ b/selfdrive/pandad/pandad.cc
@@ -45,8 +45,7 @@ ExitHandler do_exit;
 
 static uint64_t last_door_lock_command_time = 0;
 
-static bool is_tesla_preap(Params &params) {
-  const std::string car_params = params.get("CarParams");
+static bool is_tesla_preap(const std::string &car_params) {
   if (car_params.empty()) {
     return false;
   }
@@ -483,6 +482,9 @@ void pandad_run(std::vector<Panda *> &pandas) {
   Panda *peripheral_panda = pandas[0];
   bool engaged = false;
   bool is_onroad = false;
+  bool was_onroad = false;
+  bool tesla_preap = false;
+  bool tesla_preap_checked = false;
 
   // Main loop: receive CAN data and process states
   while (!do_exit && check_all_connected(pandas)) {
@@ -496,13 +498,26 @@ void pandad_run(std::vector<Panda *> &pandas) {
     // Process panda state at 10 Hz
     if (rk.frame() % 10 == 0) {
       sm.update(0);
-      const bool preap_aol_engaged = is_tesla_preap(params) &&
+      is_onroad = params.getBool("IsOnroad");
+      const bool ignore_ignition_line = params.getBool("IgnoreIgnitionLine");
+
+      // Re-evaluate after each drive transition once fingerprinting is ready.
+      if (is_onroad && !was_onroad) {
+        tesla_preap = false;
+        tesla_preap_checked = false;
+      }
+      was_onroad = is_onroad;
+
+      if (is_onroad && !tesla_preap_checked && params.getBool("ControlsReady")) {
+        tesla_preap = is_tesla_preap(params.get("CarParams"));
+        tesla_preap_checked = true;
+      }
+
+      const bool preap_aol_engaged = tesla_preap &&
                                      sm["starpilotCarState"].getStarpilotCarState().getAlwaysOnLateralEnabled();
       engaged = sm.allAliveAndValid({"selfdriveState", "starpilotCarState"}) && (
         sm["selfdriveState"].getSelfdriveState().getEnabled() || preap_aol_engaged
       );
-      is_onroad = params.getBool("IsOnroad");
-      const bool ignore_ignition_line = params.getBool("IgnoreIgnitionLine");
       process_panda_state(pandas, &pm, engaged, is_onroad, spoofing_started, ignore_ignition_line);
       panda_safety.configureSafetyMode(is_onroad);
     }


### PR DESCRIPTION
Pandad was reading and parsing CarParams at 10 Hz solely to determine Tesla pre-AP Always On Lateral engagement, including while offroad or indefinitely when CarParams was unavailable causing high cpu usage.

While investigating the original CPU error, I found that repeatedly parsing CarParams was unnecessary hot-loop work in relation to Feature Request - Pre-AP Support for Tesla in StarPilot (3621863)

  This change:

  - performs detection after each offroad-to-onroad transition
  - waits for fingerprinting to populate `CarParams`
  - latches the result for the remainder of the drive
  - stops repeatedly reading and parsing `CarParams`
  - avoids unnecessary work on bench or carless setups
  - preserves the existing Always On Lateral behavior for Tesla pre-AP vehicles
  - adds coverage for Always On Lateral transitions and invalid cruise states

  **Verification**

  - Refreshed the AGNOS-based sysroot and passed the laptop device-build doctor checks
  - Confirmed the builder is Linux AArch64 with Cap’n Proto 1.0.2
  - Successfully built `selfdrive/pandad/pandad` as a Linux ARM64 executable