### PR TITLE
Galaxy: fix Force Offroad toggle's Park detection when offroad

### DIFF
--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -4167,6 +4167,7 @@ def _get_offroad_vehicle_parked():
         parser.update(frames)
       state, _ = car_state.update(parsers, toggles)
       car_state.out = state
+      now = time.clock_gettime_ns(clock_id)
       # can_valid can stay true after messages stop arriving.
       if all(
         message.frequency > 0 and message.valid(now, parser.bus_timeout)

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -4144,11 +4144,11 @@ def _get_offroad_vehicle_parked():
   with car.CarParams.from_bytes(cp_bytes) as cp, custom.StarPilotCarParams.from_bytes(fpcp_bytes) as fpcp:
     car_state = importlib.import_module(f"opendbc.car.{cp.brand}.carstate").CarState(cp, fpcp)
     parsers = car_state.get_can_parsers(cp)
-    # CarState needs these options, but they don't affect gear.
+    # These options don't affect gearShifter.
     toggles = SimpleNamespace(subaru_sng=False, cluster_offset=1.0)
-    car_state.update(parsers, toggles)  # The first update registers the messages CarState uses.
+    car_state.update(parsers, toggles)  # Register CAN messages before filtering frames.
     can_sock = messaging.sub_sock("can", timeout=100)
-    # Match pandad's clock (common/timing.h).
+    # pandad timestamps logMonoTime using CLOCK_BOOTTIME.
     clock_id = getattr(time, "CLOCK_BOOTTIME", time.CLOCK_MONOTONIC)
     started = time.clock_gettime_ns(clock_id)
     deadline = started + 3_000_000_000
@@ -4168,7 +4168,7 @@ def _get_offroad_vehicle_parked():
       state, _ = car_state.update(parsers, toggles)
       car_state.out = state
       now = time.clock_gettime_ns(clock_id)
-      # can_valid can stay true after messages stop arriving.
+      # Use current time since can_valid uses the last CAN timestamp.
       if all(
         message.frequency > 0 and message.valid(now, parser.bus_timeout)
         for parser in parsers.values() for message in parser.message_states.values() if not message.ignore_alive

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import importlib
 import math
@@ -4134,8 +4135,50 @@ def _get_has_radar():
   except Exception:
     return False
 
+def _get_offroad_vehicle_parked():
+  cp_bytes = _safe_params_get_live_raw("CarParamsPersistent")
+  fpcp_bytes = _safe_params_get_live_raw("StarPilotCarParamsPersistent")
+  if not cp_bytes or not fpcp_bytes:
+    return False
+
+  with car.CarParams.from_bytes(cp_bytes) as cp, custom.StarPilotCarParams.from_bytes(fpcp_bytes) as fpcp:
+    car_state = importlib.import_module(f"opendbc.car.{cp.brand}.carstate").CarState(cp, fpcp)
+    parsers = car_state.get_can_parsers(cp)
+    # CarState needs these options, but they don't affect gear.
+    toggles = SimpleNamespace(subaru_sng=False, cluster_offset=1.0)
+    car_state.update(parsers, toggles)  # The first update registers the messages CarState uses.
+    can_sock = messaging.sub_sock("can", timeout=100)
+    # Match pandad's clock (common/timing.h).
+    clock_id = getattr(time, "CLOCK_BOOTTIME", time.CLOCK_MONOTONIC)
+    started = time.clock_gettime_ns(clock_id)
+    deadline = started + 3_000_000_000
+    while time.clock_gettime_ns(clock_id) < deadline:
+      message_sizes = {(parser.bus, message.address): message.size
+                       for parser in parsers.values() for message in parser.message_states.values()}
+      packets = messaging.drain_sock(can_sock, wait_for_one=True)
+      now = time.clock_gettime_ns(clock_id)
+      frames = [
+        (packet.logMonoTime, [(c.address, c.dat, c.src) for c in packet.can if len(c.dat) == message_sizes.get((c.src, c.address))])
+        for packet in packets if packet.valid and started <= packet.logMonoTime <= now
+      ]
+      if not frames:
+        continue
+      for parser in parsers.values():
+        parser.update(frames)
+      state, _ = car_state.update(parsers, toggles)
+      car_state.out = state
+      # can_valid can stay true after messages stop arriving.
+      if all(
+        message.frequency > 0 and message.valid(now, parser.bus_timeout)
+        for parser in parsers.values() for message in parser.message_states.values() if not message.ignore_alive
+      ) and all(parser.can_valid for parser in parsers.values()):
+        return state.gearShifter == car.CarState.GearShifter.park
+  return False
+
 def _get_vehicle_parked():
   try:
+    if not params.get_bool("IsOnroad"):
+      return _get_offroad_vehicle_parked()
     sm = messaging.SubMaster(["carState"], poll="carState")
     sm.update(100)
     if not sm.seen["carState"] or not sm.alive["carState"] or not sm.valid["carState"]:


### PR DESCRIPTION
**Description**

Turning Force Offroad on in Galaxy causes card to stop. Because card is off, its no longer publishing carState. Galaxy then loses the carState.gearShifter reading it requires to confirm Park, so it refuses to turn Force Offroad back off even though the car is still in Park

**What happened**

Force Offroad could be enabled through Galaxy, but then could not be disabled. The device control still worked at the same time.

This doesn't affect toggling on the device, because the toggle on the Comma directly doesn’t have the carState.gearShifter check to switch back.

- Route: `9f7170b0e093c614/00000004--d4995663e3`
- Build: StarPilot `Dom`, `0.11.2`, commit `b91ea3e1da2a584123ce7129c73112ecd416648c`.
- Vehicle/device: `SUBARU_IMPREZA_2020` (Subaru Crosstrek 2020), fingerprint, stock longitudinal control; `mici`, OS `19.6.20`.

Parked, use Galaxy to force offroad using Galaxy. The accompanying tmux log shows `card` absent and `PUT /api/params` requests returning HTTP 403 (it doesn't show request body, but that is the force off-road toggle). This shows "Vehicle must be in park" notification even though the vehicle is in Park.

**What this fixes**

`_get_vehicle_parked()` now reads gear from live CAN while offroad. This works even after "card" stops. Galaxy already uses this function to decide whether to unlock the setting and whether to accept a toggle request. 
 
Turning Force Offroad on or off still requires Park. 

**Background**
 [c56f7d0](https://github.com/firestar5683/StarPilot/commit/c56f7d0c20711df0ca004177d609993125d29c2f) (August 11, 2026) added the Galaxy control and its `carState` requirement. 

Previously, the API accepted Force Offroad writes without checking gear. Offroad already stopped `card`; the new check created the dependency. 