### PR TITLE
Galaxy: fix Force Offroad getting stuck enabled

### DIFF
--- a/starpilot/system/the_galaxy/assets/components/tools/device_settings.js
+++ b/starpilot/system/the_galaxy/assets/components/tools/device_settings.js
@@ -1292,7 +1292,7 @@ function getSettingLockReason(param) {
   if (param?.requires_offroad && state.values.IsOnroad) {
     return "This setting can only be changed while parked."
   }
-  if (param?.requires_parked && !state.values.VehicleParked) {
+  if (param?.requires_parked && !state.values.VehicleParked && !(param.key === "ForceOffroad" && state.values.ForceOffroad)) {
     return "This setting can only be changed while the vehicle is in Park."
   }
   if (param?.disabled_when_key_true && state.values[param.disabled_when_key_true]) {

--- a/starpilot/system/the_galaxy/assets/mobile/js/views/Settings.js
+++ b/starpilot/system/the_galaxy/assets/mobile/js/views/Settings.js
@@ -98,7 +98,7 @@ export const Settings = {
     },
     lockReason(param) {
       if (param?.requires_offroad && this.values.IsOnroad) return "This setting can only be changed while parked."
-      if (param?.requires_parked && !this.values.VehicleParked) return "This setting can only be changed while the vehicle is in Park."
+      if (param?.requires_parked && !this.values.VehicleParked && !(param.key === "ForceOffroad" && this.values.ForceOffroad)) return "This setting can only be changed while the vehicle is in Park."
       if (param?.disabled_when_key_true && this.values[param.disabled_when_key_true]) return param.disabled_reason || "Disabled by another setting."
       if (param?.requires_nonempty_key) {
         const val = this.values[param.requires_nonempty_key]

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -5802,10 +5802,10 @@ def setup(app):
         }), 200
 
       if key == "ForceOffroad":
-        if not _get_vehicle_parked():
+        enabled = str_val.strip() in ("1", "true", "True")
+        if enabled and not _get_vehicle_parked():
           return jsonify({"error": "Force Offroad is only available while the vehicle is in Park."}), 403
 
-        enabled = str_val.strip() in ("1", "true", "True")
         params.put_bool("ForceOffroad", enabled)
         params.put_bool("ForceOnroad", False)
         update_starpilot_toggles()


### PR DESCRIPTION
**Description**

Enabling Force Offroad in Galaxy stops `card`, which publishes `carState`. Galaxy then loses the `carState.gearShifter` reading, which is required by its Park check. It then  refuses to disable Force Offroad, even though the car is still in Park.

**What happened**

Force Offroad could be enabled through Galaxy, but could not then be disabled. The device control still worked because it does not use Galaxy's Park check.

- Route: `9f7170b0e093c614/00000004--d4995663e3`
- Build: StarPilot `Dom`, `0.11.2`, commit `b91ea3e1da2a584123ce7129c73112ecd416648c`.
- Vehicle: 2020 Subaru Crosstrek, fingerprint `SUBARU_IMPREZA_2020`, stock longitudinal control.
- Device: `mici`, OS `19.6.20`.

To reproduce: with the car in Park and the device onroad, enable Force Offroad through Galaxy, wait for the device to go offroad, then try to disable it through Galaxy.

**What this fixes**

Require Park only when enabling Force Offroad.

**Background**

[c56f7d0](https://github.com/firestar5683/StarPilot/commit/c56f7d0c20711df0ca004177d609993125d29c2f) (August 11, 2026) added the Galaxy control and its Park check.