### PR TITLE
manager: Fix ForceOnroad causing premature Panda safety configuration 

### DIFF
--- a/system/manager/manager.py
+++ b/system/manager/manager.py
@@ -1163,11 +1163,18 @@ def manager_thread() -> None:
 
     started = sm['deviceState'].started
 
-    if started and not started_prev and not starpilot_toggles.force_onroad:
-      params.clear_all(ParamKeyFlag.CLEAR_ON_ONROAD_TRANSITION)
+    if started and not started_prev:
+      # ForceOnroad skips the normal onroad parameter reset.
+      if starpilot_toggles.force_onroad:
+        # These flags stay set after card exits.
+        # Clear them so pandad doesn't think card finished init on restart.
+        params.remove("ControlsReady")
+        params.remove("FirmwareQueryDone")
+      else:
+        params.clear_all(ParamKeyFlag.CLEAR_ON_ONROAD_TRANSITION)
 
-      # StarPilot variables
-      params_memory.clear_all(ParamKeyFlag.CLEAR_ON_ONROAD_TRANSITION)
+        # StarPilot variables
+        params_memory.clear_all(ParamKeyFlag.CLEAR_ON_ONROAD_TRANSITION)
     elif not started and started_prev:
       params.clear_all(ParamKeyFlag.CLEAR_ON_OFFROAD_TRANSITION)
 


### PR DESCRIPTION
#### Description

With `ForceOnroad` enabled, manager can retain the previous `card` process’s initialization flags, letting `pandad` switch Panda’s safety mode before the restarted `card` finishes initializing.

#### Chain of events:

- At startup, card sets `FirmwareQueryDone`and `ControlsReady`.
- Going Offroad stops card but preserves these flags and the stored car parameters. Neither flag has CLEAR_ON_OFFROAD_TRANSITION.
- Without rebooting, enable ForceOnroad.

Manager normally would clear them on the next Offroad → Onroad transition. However, `ForceOnroad` [skips](https://github.com/firestar5683/StarPilot/blob/b91ea3e1da2a584123ce7129c73112ecd416648c/system/manager/manager.py#L1166-L1167) that. So the old flag values persist and are not reset.

- `pandad` sees the old flag values and falsely assumes the new card process has finished initializing.
- `pandad` tells Panda to apply the car's safety mode.
- Panda stops forwarding messages because `card` is expected to send replacements.
- If card hasn’t started sending replacements, the receiving ECUs miss those expected messages.
- A long enough gap can cause the affected ECUs to report a fault.

#### Validation

Routes `00000003--8d5bce7dbb` and `00000005--53f2d4636d`, segment 0:

- `ForceOnroad=1`, `FirmwareQueryDone=1`, and `ControlsReady=1` at startup.
- `pandad` requests Subaru safety mode before the restarted `card` reaches its CAN wait

- **Tmux excerpt**, shows safety-mode request before `card` prints “Waiting for CAN messages...”

  ```text
  Panda 0: setting safety model: 11, param: 8, alternative experience: 32
  (Several lines later...)
  Waiting for CAN messages...
  ```

- Panda reports Subaru safety while `selfdriveInitializing` remains set. This event prevents `card` from calling `CarInterface.init()`, so Panda has applied the safety mode before the new process completes initialization.
- The camera keeps sending `ES_LKAS` messages on bus 2, but they don’t appear on bus 0, where the steering ECU is connected.
- The steering ECU reports a fault (`Steer_Error_1: false → true`, `0x119`, bus 0) while those messages are missing.
- first replacement `ES_LKAS` transmit arrives after 7.4 seconds of observed silence

#### Proposed Fix

Clear `FirmwareQueryDone` and `ControlsReady` when starting Onroad with `ForceOnroad` enabled. 
