### PR TITLE
Track driving statistics by running model

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -108,6 +108,8 @@ struct StarPilotDeviceState @0xda96579883444c35 {
 
 struct StarPilotModelDataV2 @0x80ae746ee2596b11 {
   turnDirection @0 :TurnDirection;
+  runtimeIdentity @1 :Text;  # loaded role identities; empty means unavailable
+  modelMonoTime @2 :UInt64;  # exact matching successful modelV2 Event timestamp
 
   enum TurnDirection {
     none @0;

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -70,6 +70,7 @@ from openpilot.starpilot.common.model_lab import (
   model_lab_manifest_eligible,
 )
 from openpilot.starpilot.common.model_versions import is_tinygrad_model_version
+from openpilot.starpilot.common.model_stats_identity import LoadedDigest, loaded_identity, publish_identity
 from openpilot.starpilot.common.starpilot_variables import get_starpilot_toggles, MODELS_PATH, params_memory
 
 
@@ -470,13 +471,22 @@ def _is_oob_artifact_header(header: bytes) -> bool:
   return 2 <= opcode_size <= MAX_OOB_OPCODE_SIZE and header[8] == 0x80 and header[9] <= pickle.HIGHEST_PROTOCOL
 
 
-def _load_model_artifact(path: Path):
+def _load_model_artifact(path: Path, stats_identity=None):
   """Load legacy pickle artifacts and the streaming OOB format used by large GPU models."""
   with open_file_chunked(path) as artifact_file:
     oob_artifact = _is_oob_artifact_header(artifact_file.peek(10)[:10])
 
   with open_file_chunked(path) as artifact_file:
-    return load_oob(artifact_file) if oob_artifact else pickle.load(artifact_file)
+    source = artifact_file
+    if stats_identity is not None:
+      try:
+        source = LoadedDigest(artifact_file)
+      except Exception:
+        pass
+    artifact = load_oob(source) if oob_artifact else pickle.load(source)
+    if isinstance(source, LoadedDigest):
+      source.apply(stats_identity)
+    return artifact
 
 
 def _normalize_model_artifact(artifact: dict) -> dict:
@@ -575,7 +585,11 @@ class ModelState:
 
     self.model_id = BUILTIN_MODEL_KEY if loaded_builtin else model_id
     self.uses_external_gpu = external_gpu_active and (requires_external_gpu or force_external_gpu) and not loaded_builtin
-    artifact = _normalize_model_artifact(_load_model_artifact(model_path))
+    try:
+      self.stats_identity = loaded_identity(self.model_id, self.uses_external_gpu)
+    except Exception:
+      self.stats_identity = None
+    artifact = _normalize_model_artifact(_load_model_artifact(model_path, self.stats_identity))
 
     self.model_type = artifact["model_type"]
     self.metadata = artifact["metadata"]
@@ -1509,6 +1523,7 @@ def main(demo=False):
 
       fill_pose_msg(posenet_send, model_output, meta_main.frame_id, vipc_dropped_frames, meta_main.timestamp_eof, live_calib_seen)
       pm.send('modelV2', modelv2_send)
+      publish_identity(starpilot_modelv2_send, modelv2_send, model, model_lab_longitudinal if model_lab_active else None)
       pm.send('starpilotModelV2', starpilot_modelv2_send)
       pm.send('drivingModelData', drivingdata_send)
       pm.send('cameraOdometry', posenet_send)

--- a/starpilot/common/model_stats.py
+++ b/starpilot/common/model_stats.py
@@ -1,0 +1,204 @@
+"""Passive, stdlib-only measurement policy v2. No Params or control writes.
+
+Total distance is assisted forward distance only. Rates are exposure / episode
+count, not averages of completed intervals. Unknown intervals are never bridged.
+"""
+from dataclasses import asdict, dataclass
+import json
+import math
+
+DEFINITION_VERSION = 2
+MAX_GAP = 0.25
+RELEASE_SECONDS = 2.0
+COUNTERS = ('assistedMeters', 'interventionMeters', 'disengagementMeters',
+            'interventions', 'disengagements', 'steering', 'brake', 'gas')
+
+
+def empty_stats(status='not_started'):
+  return dict.fromkeys(COUNTERS, 0) | {'available': status == 'ok', 'status': status,
+                                    'incomplete': False, 'milesPerIntervention': None, 'milesPerDisengagement': None}
+
+
+def measurement_policy(state):
+  """Untagged historical snapshots used v1; unknown policies stay unknown."""
+  version = state.get('definitionVersion', 1)
+  release = state.get('interventionReleaseSeconds', 0.5)
+  if type(version) is int and type(release) in (int, float) and (version, release) in ((1, 0.5), (2, 2.0)):
+    return (version, release)
+  return None
+
+
+def apply_definition_policy(stats, policies):
+  policies = set(policies)
+  known = policies - {None}
+  comparable = len(policies) == 1 and None not in policies
+  status = ('unknown' if not policies or None in policies else 'mixed' if len(policies) > 1
+            else 'current' if next(iter(policies))[0] == DEFINITION_VERSION else 'historical')
+  stats.update(definitionVersions=sorted(p[0] for p in known), definitionStatus=status,
+               definitionVersion=next(iter(policies))[0] if comparable else None,
+               interventionReleaseSeconds=next(iter(policies))[1] if comparable else None,
+               eventRatesComparable=comparable)
+  return stats
+
+
+def rates(stats):
+  for count, distance, field in [('interventions', 'interventionMeters', 'milesPerIntervention'),
+                                ('disengagements', 'disengagementMeters', 'milesPerDisengagement')]:
+    stats[field] = stats[distance] / 1609.344 / stats[count] if stats[count] and stats.get('eventRatesComparable', True) else None
+  return stats
+
+
+def parse_identity(text):
+  """Only accept output provenance, never model-selection Params."""
+  try:
+    if not isinstance(text, str) or len(text) > 4096:
+      return None
+    obj = json.loads(text)
+    roles = obj['roles']
+    if obj['version'] != 1 or not isinstance(roles, list) or not 1 <= len(roles) <= 2:
+      return None
+    for role in roles:
+      if not isinstance(role, dict):
+        return None
+      if not all(isinstance(role.get(k), str) and 0 < len(role[k]) <= 512
+                 for k in ('modelId', 'artifact', 'backend')):
+        return None
+    return json.dumps(obj, sort_keys=True, separators=(',', ':'))
+  except (ValueError, TypeError, KeyError):
+    return None
+
+
+@dataclass(frozen=True)
+class Sample:
+  t: float
+  owner: str | None
+  speed: float
+  enabled: bool = False
+  aol: bool = False
+  lat: bool = False
+  long: bool = False
+  steering: bool = False
+  brake: bool = False
+  gas: bool = False
+  valid: bool = True
+  reverse: bool = False
+  onroad: bool = True
+
+  @property
+  def inputs(self):
+    return {k for k in ('steering', 'brake', 'gas') if getattr(self, k)}
+
+  @property
+  def mode(self):
+    return 'full' if self.enabled else ('aol' if self.aol else 'manual')
+
+  @property
+  def session(self):
+    return self.enabled or self.aol
+
+  @property
+  def assisted(self):
+    return self.session and (self.lat or self.long)
+
+  @property
+  def usable(self):
+    return (self.valid and self.onroad and self.owner is not None and not self.reverse
+            and math.isfinite(self.t) and math.isfinite(self.speed) and 0 <= self.speed <= 100)
+
+
+class Reducer:
+  def __init__(self):
+    self.previous = None
+    self.metrics = {}
+    self.gaps = 0
+    self.episode = None
+    self.release_at = None
+    self.blocked = True
+    self.sequence = 0
+    self.last_t = None
+    self.in_gap = False
+
+  def row(self, owner, mode):
+    key = (owner, mode)
+    return self.metrics.setdefault(key, dict.fromkeys(COUNTERS, 0))
+
+  def break_stream(self):
+    if not self.in_gap:
+      self.gaps += 1
+      self.sequence += 1  # semantic revision, not telemetry freshness
+    self.in_gap = True
+    self.previous = None
+    self.episode = None
+    self.release_at = None
+    self.blocked = True
+
+  def update(self, sample):
+    p = self.previous
+    if not math.isfinite(sample.t) or (self.last_t is not None and sample.t <= self.last_t):
+      return  # duplicate/out-of-order samples must not reset edge detection
+    self.last_t = sample.t
+    self.sequence += 1
+    if not sample.usable:
+      self.break_stream()
+      return
+    if p is not None and sample.t - p.t > MAX_GAP:
+      self.break_stream()
+      p = None
+    if p is None:
+      self.previous = sample
+      self.blocked = bool(sample.inputs)
+      self.in_gap = False
+      return
+
+    same_owner = sample.owner == p.owner
+    # Never charge an ambiguous model switch interval or takeover to fallback.
+    if same_owner:
+      row = self.row(p.owner, p.mode)
+      distance = (sample.t - p.t) * (sample.speed + p.speed) / 2
+      if p.assisted:
+        row['assistedMeters'] += distance
+        if not self.episode and not p.inputs and not self.blocked:
+          row['interventionMeters'] += distance
+      if p.session:
+        row['disengagementMeters'] += distance
+      if p.enabled and not sample.enabled:
+        row['disengagements'] += 1
+      elif not p.enabled and p.aol and not sample.enabled and not sample.aol:
+        row['disengagements'] += 1
+    else:
+      self.gaps += 1
+      self.episode = None
+      self.release_at = None
+      self.blocked = bool(sample.inputs)
+
+    if sample.inputs:
+      self.release_at = None
+      rising = sample.inputs - p.inputs
+      if not self.episode and not self.blocked and rising and same_owner:
+        if p.session or sample.session:
+          owner_mode = (p.owner, p.mode) if p.session else (sample.owner, sample.mode)
+          self.episode = (owner_mode, set())
+          self.row(*owner_mode)['interventions'] += 1
+        else:
+          self.blocked = True  # input begun manually cannot become an intervention
+      if self.episode:
+        owner_mode, types = self.episode
+        for kind in sample.inputs - types:
+          self.row(*owner_mode)[kind] += 1
+        types.update(sample.inputs)
+    elif self.episode or self.blocked:
+      if self.release_at is None:
+        self.release_at = sample.t
+      if sample.t - self.release_at >= RELEASE_SECONDS:
+        self.episode = None
+        self.blocked = False
+        self.release_at = None
+    self.previous = sample
+
+  def snapshot(self):
+    return {'definitionVersion': DEFINITION_VERSION, 'interventionReleaseSeconds': RELEASE_SECONDS,
+            'sequence': self.sequence, 'gaps': self.gaps, 'lastTime': self.last_t,
+            'previous': asdict(self.previous) if self.previous else None,
+            'blocked': self.blocked, 'releaseAt': self.release_at,
+            'episode': [list(self.episode[0]), sorted(self.episode[1])] if self.episode else None,
+            'metrics': [{'owner': owner, 'mode': mode, **values} for (owner, mode), values in self.metrics.items()]}

--- a/starpilot/common/model_stats_identity.py
+++ b/starpilot/common/model_stats_identity.py
@@ -1,0 +1,73 @@
+"""Loaded-content identity only: no selected Params or inference-loop hashing.
+
+Without a loaded-content digest the revision is deliberately isolated
+by load UUID. All-time UI totals aggregate model IDs; raw configurations retain
+this uncertainty and never pretend that a filename identifies immutable weights.
+"""
+import hashlib
+import json
+import uuid
+
+
+class LoadedDigest:
+  """Hash bytes consumed by pickle/OOB loading, never reopen a mutable filename.
+
+  Only the load path uses this wrapper; there is no hashing during inference.
+  Instrumentation errors disable provenance rather than aborting model loading.
+  """
+  def __init__(self, source):
+    self.source = source
+    self.digest = hashlib.sha256()
+
+  def _record(self, data):
+    try:
+      if self.digest is not None:
+        self.digest.update(data)
+    except Exception:
+      self.digest = None
+
+  def read(self, size=-1):
+    data = self.source.read(size)
+    self._record(data)
+    return data
+
+  def readline(self, size=-1):
+    data = self.source.readline(size)
+    self._record(data)
+    return data
+
+  def readinto(self, buffer):
+    size = self.source.readinto(buffer)
+    if size:
+      self._record(memoryview(buffer)[:size])
+    return size
+
+  def apply(self, identity):
+    try:
+      if self.digest is not None and identity is not None:
+        identity.update(artifact='loaded-sha256:' + self.digest.hexdigest(), artifactVerified=True)
+    except Exception:
+      pass
+
+
+def loaded_identity(model_id, external):
+  return {'modelId': model_id, 'backend': 'chestnut' if external else 'comma',
+          'artifact': 'unverified-load:' + uuid.uuid4().hex, 'artifactVerified': False}
+
+
+def output_identity(model, longitudinal=None):
+  roles = [model.stats_identity]
+  if longitudinal is not None:
+    roles.append(longitudinal.stats_identity)
+  return json.dumps({'version': 1, 'roles': roles}, sort_keys=True, separators=(',', ':'))
+
+
+def publish_identity(message, model_message, model, longitudinal=None):
+  # Statistics must never prevent model/control publication, even with an old
+  # schema or instrumentation failure. The observer treats empty provenance as a gap.
+  try:
+    message.starpilotModelV2.runtimeIdentity = output_identity(model, longitudinal)
+    message.starpilotModelV2.modelMonoTime = model_message.logMonoTime
+    message.valid = model_message.valid
+  except Exception:
+    pass

--- a/starpilot/common/model_stats_recovery.py
+++ b/starpilot/common/model_stats_recovery.py
@@ -1,0 +1,110 @@
+"""Explicit off-road log recovery; never imported or run by the live observer.
+
+The caller reviews/reconstructs complete retained routes before applying them.
+Original rows remain for audit/backup; recovered rows declare supersession.
+"""
+import hashlib
+import json
+import math
+import sqlite3
+from pathlib import Path
+
+from openpilot.starpilot.common.model_stats import COUNTERS, parse_identity, measurement_policy
+from openpilot.starpilot.common.model_stats_store import Store, read_stats, ACTIVE_DRIVES
+
+
+def import_routes(path, routes, backup_path):
+  """Atomically add validated reconstructions; a second import adds nothing.
+
+  The process owner must establish off-road state and exclude concurrent live
+  collection/restore. This function is also usable with isolated test databases.
+  """
+  if not routes or len(routes) > 100:
+    raise ValueError('Expected 1..100 reviewed routes')
+  prepared = []
+  names = set()
+  for route in routes:
+    name, started, updated = route['routeName'], route['started'], route['updated']
+    if not isinstance(name, str) or not 0 < len(name) <= 128 or name in names:
+      raise ValueError('Duplicate/invalid route identity')
+    names.add(name)
+    if not all(type(v) in (float, int) and math.isfinite(v) for v in (started, updated)) or not 0 < started < updated:
+      raise ValueError('Invalid route interval')
+    snapshot = route['snapshot']
+    if measurement_policy(snapshot) is None:
+      raise ValueError('Unknown reconstruction measurement definition')
+    if not snapshot.get('metrics') or snapshot.get('sequence', 0) <= 0:
+      raise ValueError('No verified runtime coverage to recover')
+    if any(parse_identity(r['owner']) is None or r['mode'] not in ('manual','full','aol')
+           or any(type(r[k]) not in (int, float) or not math.isfinite(r[k]) or r[k] < 0
+                  or (not k.endswith('Meters') and int(r[k]) != r[k]) for k in COUNTERS)
+           for r in snapshot['metrics']):
+      raise ValueError('Invalid reconstruction counters/provenance')
+    digest = hashlib.sha256(json.dumps(route, sort_keys=True, allow_nan=False).encode()).hexdigest()
+    prepared.append((route, 'recovered:' + name, digest))
+  store = Store(path)
+  try:
+    existing = store.db.execute(ACTIVE_DRIVES + 'SELECT id, started, updated, state FROM active_drives').fetchall()
+    pending = []
+    for route, drive, digest in prepared:
+      prior = store.db.execute('SELECT state FROM drives WHERE id=?', (drive,)).fetchone()
+      if prior:
+        if json.loads(prior[0]).get('recovery', {}).get('digest') != digest:
+          raise ValueError('Different reconstruction already exists for this route')
+        continue
+      supersedes = []
+      for old, start, end, raw in existing:
+        state = json.loads(raw)
+        exact = state.get('routeName') == route['routeName']
+        overlap = start < route['updated'] and end > route['started']
+        if not exact and not overlap:
+          continue
+        # Never assign a fragment across routes, or guess around a clock jump.
+        matches = [r['routeName'] for r, _, _ in prepared if start < r['updated'] and end > r['started']]
+        if state.get('routeName') not in (None, route['routeName']) or (not exact and (
+            matches != [route['routeName']] or start < route['started'] - 2 or end > route['updated'] + 2)):
+          raise ValueError('Ambiguous statistics fragment; manual review required: ' + old)
+        if state.get('coverageLoss'):
+          raise ValueError('Do not hide a global coverage-loss marker')
+        if measurement_policy(state) != measurement_policy(route['snapshot']):
+          raise ValueError('Recovery measurement definition differs from accepted history: ' + old)
+        supersedes.append(old)
+      # Preserve at least every accepted per-configuration counter. A replay
+      # with missing segments/different definitions must not silently erase it.
+      old_totals = {}
+      for old in supersedes:
+        for owner, mode, *values in store.db.execute('SELECT owner, mode, ' + ','.join(COUNTERS) + ' FROM metrics WHERE drive=?', (old,)):
+          row = old_totals.setdefault((owner, mode), [0] * len(COUNTERS))
+          for i, value in enumerate(values): row[i] += value
+      new_totals = {(r['owner'], r['mode']): [r[k] for k in COUNTERS] for r in route['snapshot']['metrics']}
+      if any(key not in new_totals or any(new < old - 1e-5 for old, new in zip(values, new_totals[key]))
+             for key, values in old_totals.items()):
+        raise ValueError('Reconstruction would reduce an accepted counter')
+      snapshot = route['snapshot'] | {'routeName': route['routeName'], 'supersedes': supersedes,
+        'previous': None, 'recovery': {'version': 1, 'source': 'retained-rlog', 'digest': digest,
+                                     'files': route.get('files', [])}}
+      pending.append((route, drive, snapshot))
+    if not pending:
+      return {'added': 0, 'superseded': 0}
+    backup = Path(backup_path)
+    backup.parent.mkdir(parents=True, exist_ok=True)
+    if backup.exists():
+      raise ValueError('Recovery backup already exists; refusing to overwrite')
+    with sqlite3.connect(backup) as db:
+      store.db.backup(db)
+    # Use a temporary Store to build canonical rows, then insert them in ONE
+    # destination transaction. checkpoint's own transactions cannot split it.
+    staging = Store(':memory:')
+    try:
+      for route, drive, snapshot in pending:
+        staging.checkpoint(drive, route['started'], snapshot, complete=True,
+                           software=route.get('software',''), now=route['updated'])
+      with store.db:
+        for table in ('drives', 'metrics'):
+          for row in staging.db.execute('SELECT * FROM ' + table):
+            store.db.execute('INSERT INTO ' + table + ' VALUES (' + ','.join('?' for _ in row) + ')', row)
+    finally:
+      staging.close()
+    return {'added': len(pending), 'superseded': sum(len(s['supersedes']) for _, _, s in pending)}
+  finally:
+    store.close()

--- a/starpilot/common/model_stats_store.py
+++ b/starpilot/common/model_stats_store.py
@@ -1,0 +1,217 @@
+"""Single-writer cumulative checkpoints; Galaxy opens SQLite read-only.
+
+A restart creates a new drive fragment, never replays a retained sample. Prior
+unclosed fragments remain incomplete. History survives model/route deletion.
+"""
+import json
+import math
+from pathlib import Path
+import sqlite3
+import time
+
+from openpilot.starpilot.common.model_stats import COUNTERS, DEFINITION_VERSION, empty_stats, rates, measurement_policy, apply_definition_policy
+
+DEFAULT_PATH = Path('/data/starpilot/model_stats.sqlite')
+SCHEMA_VERSION = 1
+
+
+ACTIVE_DRIVES = """WITH superseded AS (
+  SELECT j.value AS id FROM drives, json_each(drives.state, '$.supersedes') AS j WHERE j.type='text' AND j.value != drives.id
+), active_drives AS (
+  SELECT * FROM drives WHERE id NOT IN (SELECT id FROM superseded)
+) """
+
+
+
+class Store:
+  def __init__(self, path=DEFAULT_PATH):
+    self.path = Path(path)
+    self.path.parent.mkdir(parents=True, exist_ok=True)
+    self.db = sqlite3.connect(self.path, timeout=0.1)
+    version = self.db.execute('PRAGMA user_version').fetchone()[0]
+    if version not in (0, SCHEMA_VERSION):
+      self.db.close()
+      raise ValueError('Unsupported model statistics schema; database not replaced')
+    if version == 0 and self.db.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchone():
+      self.db.close()
+      raise ValueError('Unversioned database; refusing to overwrite')
+    self.db.execute('PRAGMA journal_mode=WAL')
+    self.db.execute('PRAGMA synchronous=FULL')
+    with self.db:
+      self.db.execute('CREATE TABLE IF NOT EXISTS drives (id TEXT PRIMARY KEY, started REAL NOT NULL, '
+                      'updated REAL NOT NULL, complete INTEGER NOT NULL, sequence INTEGER NOT NULL, '
+                      'gaps INTEGER NOT NULL, state TEXT NOT NULL, software TEXT NOT NULL)')
+      columns = ', '.join(f'{key} REAL NOT NULL' for key in COUNTERS)
+      self.db.execute(f'CREATE TABLE IF NOT EXISTS metrics (drive TEXT NOT NULL, owner TEXT NOT NULL, '
+                      f'mode TEXT NOT NULL, {columns}, PRIMARY KEY(drive, owner, mode))')
+      self.db.execute(f'PRAGMA user_version={SCHEMA_VERSION}')
+
+  def checkpoint(self, drive, started, snapshot, complete=False, software='', now=None):
+    now = time.time() if now is None else now
+    with self.db:
+      prior = self.db.execute('SELECT sequence, complete, state, updated FROM drives WHERE id=?', (drive,)).fetchone()
+      if prior and (snapshot['sequence'] < prior[0] or prior[1]):
+        return
+      if prior and snapshot['sequence'] == prior[0]:
+        # A heartbeat is not evidence of a fresh carState. Still allow finalising
+        # a drive without a new sample, but keep its last telemetry write time.
+        if complete:
+          self.db.execute('UPDATE drives SET complete=1 WHERE id=?', (drive,))
+        return
+      # A stream-break revision persists metadata without refreshing telemetry.
+      if prior and snapshot.get('lastTime') == json.loads(prior[2]).get('lastTime'):
+        now = prior[3]
+      self.db.execute('INSERT INTO drives VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET '
+                      'updated=excluded.updated, complete=excluded.complete, sequence=excluded.sequence, '
+                      'gaps=excluded.gaps, state=excluded.state',
+                      (drive, started, now, int(complete), snapshot['sequence'], snapshot['gaps'],
+                       json.dumps(snapshot, allow_nan=False), software))
+      fields = ', '.join(COUNTERS)
+      assignments = ', '.join(f'{key}=excluded.{key}' for key in COUNTERS)
+      for row in snapshot['metrics']:
+        self.db.execute(f'INSERT INTO metrics (drive, owner, mode, {fields}) VALUES '
+                        f'({", ".join("?" for _ in range(3 + len(COUNTERS)))}) '
+                        f'ON CONFLICT(drive, owner, mode) DO UPDATE SET {assignments}',
+                        (drive, row['owner'], row['mode'], *(row[key] for key in COUNTERS)))
+
+  def close(self):
+    self.db.close()
+
+
+def read_stats(path=DEFAULT_PATH, *, model=None, mode='all', period='all', limit=50, offset=0, history=True):
+  if period not in ('all', '7', '30'):
+    raise ValueError('period must be all/7/30')
+  cutoff = 0 if period == 'all' else time.time() - int(period) * 86400
+  if mode not in ('all', 'full', 'aol') or not 1 <= limit <= 200 or not 0 <= offset <= 2**63 - 1:
+    raise ValueError('mode must be all/full/aol; limit 1..200; offset must be 0..9223372036854775807')
+  result = {'schemaVersion': SCHEMA_VERSION, 'definitionVersion': None, 'currentDefinitionVersion': DEFINITION_VERSION,
+            'available': False, 'status': 'not_started', 'models': {}, 'pairs': [],
+            'history': [], 'driveSummaries': [], 'driveSummariesHasMore': False, 'recordedSince': None, 'lastUpdated': None, 'gaps': 0,
+            'incompleteDrives': 0, 'trackingStatus': 'not_recorded', 'currentRuntime': None, 'coverageLoss': False,
+            'period': period, 'periodPolicy': 'drive_start', 'mode': mode, 'comparisons': [], 'historyTotal': 0, 'hasMore': False}
+  if not Path(path).exists():
+    return result
+  try:
+    db = sqlite3.connect(Path(path).resolve().as_uri() + '?mode=ro', uri=True, timeout=0.1)
+    try:
+      if db.execute('PRAGMA user_version').fetchone()[0] != SCHEMA_VERSION:
+        raise ValueError('Unsupported schema')
+      db.row_factory = sqlite3.Row
+      # A read transaction makes aggregate totals and history one coherent snapshot.
+      db.execute('BEGIN')
+      health = db.execute(ACTIVE_DRIVES + 'SELECT MIN(started), MAX(updated), COALESCE(SUM(gaps),0), '
+                          'COALESCE(SUM(NOT complete),0) FROM active_drives').fetchone()
+      result.update(available=True, status='ok', recordedSince=health[0], lastUpdated=health[1],
+                    gaps=health[2], incompleteDrives=health[3])
+      result['trackingStatus'] = 'recording' if health[1] and time.time() - health[1] < 30 else 'inactive'
+      latest = db.execute(ACTIVE_DRIVES + 'SELECT state, complete FROM active_drives ORDER BY updated DESC LIMIT 1').fetchone()
+      if latest and latest['complete']:
+        result['trackingStatus'] = 'inactive'
+      if latest and not latest['complete'] and result['trackingStatus'] == 'recording':
+        previous = json.loads(latest['state']).get('previous')
+        result['currentRuntime'] = json.loads(previous['owner']) if previous and previous.get('owner') else None
+        if result['currentRuntime'] is None:
+          result['trackingStatus'] = 'telemetry_unavailable'
+      result['coverageLoss'] = bool(db.execute(ACTIVE_DRIVES + "SELECT 1 FROM active_drives WHERE json_extract(state, '$.coverageLoss')=1 LIMIT 1").fetchone())
+      if result['coverageLoss']:
+        result['trackingStatus'] = 'resource_limited'
+        result['status'] = 'degraded'
+      where = ('WHERE mode != ?' if mode == 'all' else 'WHERE mode = ?') + ' AND started >= ?'
+      arg = 'manual' if mode == 'all' else mode
+      fields = ', '.join(f'SUM({key}) AS {key}' for key in COUNTERS)
+      # Extract policy metadata only, not retained sample states. Keep original
+      # counters intact; incompatible definition cohorts cannot produce a rate.
+      # JSON booleans become SQL integers under json_extract; gate types before
+      # rebuilding JSON so invalid policies cannot masquerade as historical v1.
+      policy_sql = (
+        "json_group_array(DISTINCT json_object('definitionVersion', "
+        "CASE WHEN json_type(state, '$.definitionVersion') IS NULL THEN 1 "
+        "WHEN json_type(state, '$.definitionVersion')='integer' THEN json_extract(state, '$.definitionVersion') "
+        "ELSE NULL END, 'interventionReleaseSeconds', "
+        "CASE WHEN json_type(state, '$.interventionReleaseSeconds') IS NULL THEN 0.5 "
+        "WHEN json_type(state, '$.interventionReleaseSeconds') IN ('integer','real') "
+        "THEN json_extract(state, '$.interventionReleaseSeconds') ELSE NULL END)) AS policies"
+      )
+      aggregates = db.execute(ACTIVE_DRIVES + f'SELECT owner, mode, {fields}, {policy_sql}, MAX(gaps > 0 OR (NOT complete AND updated < ?)) AS incomplete '
+                              f'FROM metrics JOIN active_drives AS drives ON drives.id=metrics.drive {where} GROUP BY owner, mode',
+                              (time.time() - 30, arg, cutoff)).fetchall()
+      pair_map = {}
+      all_policies = set()
+      for row in aggregates:
+        if any(not math.isfinite(row[key]) or row[key] < 0 for key in COUNTERS):
+          raise ValueError('Invalid stored counters')
+        identity = json.loads(row['owner'])
+        ids = [role['modelId'] for role in identity['roles']]
+        if not 1 <= len(ids) <= 2:
+          raise ValueError('Invalid stored identity')
+        if model is not None and model not in ids:
+          continue
+        policies = {measurement_policy(state) for state in json.loads(row['policies'])}
+        all_policies.update(policies)
+        comparison_stats = apply_definition_policy({key: row[key] for key in COUNTERS} |
+          {'available': True, 'status': 'ok', 'incomplete': bool(row['incomplete']) or result['coverageLoss']}, policies)
+        result['comparisons'].append({'identity': identity, 'mode': row['mode'], 'stats': rates(comparison_stats)})
+        if len(ids) == 2:
+          # A pair is a configuration, not two standalone model performances.
+          key = json.dumps(ids)
+          target = pair_map.setdefault(key, {'modelIds': ids, 'stats': empty_stats('ok'), 'configurations': []})
+        else:
+          target = result['models'].setdefault(ids[0], {'stats': empty_stats('ok'), 'configurations': []})
+        target.setdefault('_policies', set()).update(policies)
+        target['configurations'].append(identity)
+        target['stats']['incomplete'] = target['stats']['incomplete'] or bool(row['incomplete']) or result['coverageLoss']
+        for key in COUNTERS:
+          target['stats'][key] += row[key]
+      apply_definition_policy(result, all_policies)
+      result['pairs'] = list(pair_map.values())
+      for target in list(result['models'].values()) + result['pairs']:
+        apply_definition_policy(target['stats'], target.pop('_policies'))
+        rates(target['stats'])
+      if history:
+        # Bind JSON paths/values: no caller-controlled SQL or filesystem paths.
+        query = f'SELECT metrics.*, drives.started, drives.updated, drives.complete, drives.gaps, drives.software, drives.state '
+        query += f'FROM metrics JOIN active_drives AS drives ON drives.id=metrics.drive {where}'
+        args = [arg, cutoff]
+        if model is not None:
+          query += " AND (json_extract(owner, '$.roles[0].modelId')=? OR json_extract(owner, '$.roles[1].modelId')=?)"
+          args += [model, model]
+        result['historyTotal'] = db.execute(ACTIVE_DRIVES + 'SELECT COUNT(*) FROM (' + query + ')', args).fetchone()[0]
+        rows = db.execute(ACTIVE_DRIVES + query + ' ORDER BY started DESC, drive, owner, mode LIMIT ? OFFSET ?', (*args, limit, offset))
+        for row in rows:
+          entry = dict(row)
+          state = json.loads(entry.pop('state'))
+          entry['definitionVersion'] = state.get('definitionVersion', 1)
+          entry['interventionReleaseSeconds'] = state.get('interventionReleaseSeconds', 0.5)
+          entry['routeName'] = state.get('routeName')
+          entry['recovery'] = state.get('recovery')
+          entry['identity'] = json.loads(entry.pop('owner'))
+          entry['stats'] = rates(apply_definition_policy({key: entry.pop(key) for key in COUNTERS} |
+                                 {'available': True, 'status': 'ok',
+                                  'incomplete': not bool(entry['complete']) or bool(entry['gaps']) or result['coverageLoss']},
+                                 [measurement_policy(state)]))
+          result['history'].append(entry)
+        result['hasMore'] = offset + len(result['history']) < result['historyTotal']
+        # A separate bounded route-level view includes manual-only recordings.
+        # No coverage stays unknown; it must not turn into a fabricated zero.
+        if model is None and mode == 'all':
+          summaries = db.execute(ACTIVE_DRIVES +
+            'SELECT drives.*, COUNT(metrics.drive) AS covered, '
+            'COALESCE(SUM(interventions),0) AS interventions, COALESCE(SUM(disengagements),0) AS disengagements '
+            'FROM active_drives AS drives LEFT JOIN metrics ON metrics.drive=drives.id '
+            'WHERE started >= ? GROUP BY drives.id ORDER BY started DESC, drives.id LIMIT ?', (cutoff, limit + 1)).fetchall()
+          result['driveSummariesHasMore'] = len(summaries) > limit
+          for row in summaries[:limit]:
+            state = json.loads(row['state'])
+            result['driveSummaries'].append({
+              'drive': row['id'], 'started': row['started'], 'updated': row['updated'],
+              'complete': row['complete'], 'gaps': row['gaps'], 'routeName': state.get('routeName'),
+              'stats': {'available': bool(row['covered']), 'interventions': row['interventions'],
+                        'disengagements': row['disengagements'],
+                        'incomplete': not bool(row['complete']) or bool(row['gaps']) or result['coverageLoss']}})
+
+    finally:
+      db.close()
+  except (OSError, sqlite3.Error, ValueError, TypeError, KeyError, IndexError, AttributeError):
+    result.update(available=False, status='unavailable', models={}, pairs=[], comparisons=[], history=[], currentRuntime=None,
+                  trackingStatus='unavailable', historyTotal=0, hasMore=False, driveSummaries=[], driveSummariesHasMore=False)
+  return result

--- a/starpilot/common/tests/test_model_stats.py
+++ b/starpilot/common/tests/test_model_stats.py
@@ -1,0 +1,161 @@
+from dataclasses import replace
+import json
+import math
+
+import pytest
+
+from openpilot.starpilot.common.model_stats import Reducer, Sample, parse_identity, rates, RELEASE_SECONDS
+
+OWNER = json.dumps({'version': 1, 'roles': [{'modelId': 'rdf43', 'artifact': 'unverified-load:test', 'backend': 'comma'}]})
+OTHER = OWNER.replace('rdf43', 'gpu')
+
+
+def sample(t, **kwargs):
+  return replace(Sample(t, OWNER, 10, enabled=True, lat=True, long=True), **kwargs)
+
+
+def feed(reducer, start, stop, **kwargs):
+  for i in range(start, stop):
+    reducer.update(sample(i / 100, **kwargs))
+
+
+def totals(reducer):
+  return {key: sum(row[key] for row in reducer.metrics.values())
+          for key in ('assistedMeters', 'interventionMeters', 'disengagementMeters', 'interventions', 'disengagements', 'steering', 'brake', 'gas')}
+
+
+def test_manual_not_included_and_zero_event_rates():
+  r = Reducer()
+  feed(r, 0, 101, enabled=False, lat=False, long=False)
+  assert totals(r)['assistedMeters'] == 0
+  assert rates(totals(r))['milesPerIntervention'] is None
+  feed(r, 101, 202)
+  assert totals(r)['assistedMeters'] == pytest.approx(10)
+  assert totals(r)['interventions'] == 0
+
+
+@pytest.mark.parametrize('kind', ['steering', 'brake', 'gas'])
+def test_held_input_counts_once_and_rearms(kind):
+  r = Reducer()
+  feed(r, 0, 10)
+  feed(r, 10, 1010, **{kind: True})
+  assert totals(r)['interventions'] == 1
+  assert totals(r)[kind] == 1
+  assert totals(r)['assistedMeters'] > totals(r)['interventionMeters']
+  released = 1010 + int(RELEASE_SECONDS * 100) + 2
+  feed(r, 1010, released)
+  feed(r, released, released + 10, **{kind: True})
+  assert totals(r)['interventions'] == 2
+
+
+def test_overlap_chatter_counts_one_with_three_types():
+  r = Reducer()
+  feed(r, 0, 10)
+  feed(r, 10, 20, steering=True)
+  feed(r, 20, 30, steering=True, brake=True)
+  feed(r, 30, 40, gas=True)
+  feed(r, 40, 50)
+  feed(r, 50, 60, gas=True)
+  assert {k: totals(r)[k] for k in ('interventions', 'steering', 'brake', 'gas')} == dict(interventions=1, steering=1, brake=1, gas=1)
+
+
+def test_brake_disable_counts_both_and_stationary_counts():
+  r = Reducer()
+  feed(r, 0, 10, speed=0)
+  feed(r, 10, 20, speed=0, brake=True, enabled=False, lat=False, long=False)
+  assert totals(r)['interventions'] == totals(r)['disengagements'] == 1
+  assert totals(r)['assistedMeters'] == 0
+
+
+@pytest.mark.parametrize('initial_manual', [False, True])
+def test_initially_held_and_manual_input_do_not_create_engagement_edge(initial_manual):
+  r = Reducer()
+  feed(r, 0, 10, gas=True, enabled=not initial_manual)
+  feed(r, 10, 30, gas=True)
+  assert totals(r)['interventions'] == 0
+  released = 30 + int(RELEASE_SECONDS * 100) + 2
+  feed(r, 30, released)
+  feed(r, released, released + 10, gas=True)
+  assert totals(r)['interventions'] == 1
+
+
+def test_manual_rising_edge_stays_blocked_at_engagement():
+  r = Reducer()
+  feed(r, 0, 10, enabled=False)
+  feed(r, 10, 20, enabled=False, brake=True)
+  feed(r, 20, 40, brake=True)
+  assert totals(r)['interventions'] == 0
+
+
+def test_override_not_disengagement_and_aol_separate():
+  r = Reducer()
+  feed(r, 0, 10)
+  feed(r, 10, 20, lat=False, long=False)
+  assert totals(r)['disengagements'] == 0
+  feed(r, 20, 30, enabled=False, aol=True, long=False)
+  feed(r, 30, 40, enabled=False, aol=False, lat=False, long=False)
+  assert r.row(OWNER, 'full')['disengagements'] == 1
+  assert r.row(OWNER, 'aol')['disengagements'] == 1
+  assert r.row(OWNER, 'aol')['assistedMeters'] > 0
+
+
+@pytest.mark.parametrize('bad', [dict(valid=False), dict(reverse=True), dict(onroad=False), dict(owner=None),
+                               dict(speed=math.nan), dict(speed=math.inf), dict(speed=-1), dict(speed=101)])
+def test_invalid_sample_breaks_edges_and_distance(bad):
+  r = Reducer()
+  r.update(sample(0))
+  r.update(sample(.1, **bad))
+  r.update(sample(.2, enabled=False, brake=True))
+  assert totals(r)['assistedMeters'] == 0
+  assert totals(r)['interventions'] == totals(r)['disengagements'] == 0
+  assert r.gaps == 1
+
+
+def test_gap_duplicate_and_out_of_order():
+  r = Reducer()
+  r.update(sample(0))
+  r.update(sample(.1))
+  r.update(sample(.1, brake=True, enabled=False))
+  r.update(sample(.05, brake=True, enabled=False))
+  r.update(sample(1, enabled=False, brake=True))
+  assert totals(r)['assistedMeters'] == pytest.approx(1)
+  assert totals(r)['interventions'] == totals(r)['disengagements'] == 0
+  assert r.gaps == 1
+
+
+def test_switch_does_not_charge_ambiguous_takeover_to_fallback():
+  r = Reducer()
+  feed(r, 0, 10)
+  r.update(sample(.1, owner=OTHER, enabled=False, brake=True))
+  assert totals(r)['disengagements'] == totals(r)['interventions'] == 0
+  assert r.gaps == 1
+  assert r.row(OTHER, 'full')['assistedMeters'] == 0
+
+
+@pytest.mark.parametrize('bad', ['', '{}', '{', 'null', '[]', '{"version":1,"roles":[]}', '{"version":1,"roles":[null]}'])
+def test_unknown_identity_rejected(bad):
+  assert parse_identity(bad) is None
+
+
+def test_valid_pair_identity_preserved():
+  identity = json.loads(OWNER)
+  identity['roles'].append(json.loads(OTHER)['roles'][0])
+  assert len(json.loads(parse_identity(json.dumps(identity)))['roles']) == 2
+
+
+def test_two_second_grouping_merges_quick_corrections_and_restarts_timer():
+  r = Reducer()
+  feed(r,0,10)
+  feed(r,10,20,steering=True)
+  feed(r,20,170)  # 1.5 seconds fully released
+  feed(r,170,180,gas=True)
+  assert totals(r)['interventions'] == 1
+  assert totals(r)['steering'] == totals(r)['gas'] == 1
+  feed(r,180,330)  # another 1.5 seconds; timer starts from the latest release
+  feed(r,330,340,brake=True)
+  assert totals(r)['interventions'] == 1
+  feed(r,340,542)  # more than two seconds continuously clear
+  feed(r,542,550,steering=True)
+  assert totals(r)['interventions'] == 2
+  assert r.snapshot()['interventionReleaseSeconds'] == 2.0
+  assert r.snapshot()['definitionVersion'] == 2

--- a/starpilot/common/tests/test_model_stats_comparison.py
+++ b/starpilot/common/tests/test_model_stats_comparison.py
@@ -1,0 +1,70 @@
+"""Synthetic deterministic comparisons and loaded-stream provenance."""
+import hashlib
+import io
+import json
+import pickle
+from unittest.mock import patch
+import pytest
+from openpilot.starpilot.common.model_stats import Reducer, Sample, parse_identity
+from openpilot.starpilot.common.model_stats_identity import LoadedDigest, loaded_identity
+from openpilot.starpilot.common.model_stats_store import Store, read_stats
+
+
+def test_loaded_digest_is_consumed_content_not_filename():
+  for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+    content = pickle.dumps({'weights': b'a' * 10000}, protocol=protocol)
+    source = LoadedDigest(io.BytesIO(content))
+    assert pickle.load(source) == {'weights': b'a' * 10000}
+    identity = loaded_identity('builtin', False)
+    source.apply(identity)
+    assert identity['artifact'] == 'loaded-sha256:' + hashlib.sha256(content).hexdigest()
+    assert identity['artifactVerified'] is True
+  broken = LoadedDigest(io.BytesIO(b'abc'))
+  broken.digest = None
+  assert broken.read() == b'abc'
+  identity = loaded_identity('builtin', False)
+  broken.apply(identity)
+  assert not identity['artifactVerified']
+
+
+def test_oob_readinto_is_part_of_digest():
+  source = LoadedDigest(io.BytesIO(b'header-weights'))
+  assert source.read(7) == b'header-'
+  weights = bytearray(7)
+  assert source.readinto(weights) == 7
+  identity = loaded_identity('gpu', True)
+  source.apply(identity)
+  assert identity['artifact'] == 'loaded-sha256:' + hashlib.sha256(b'header-weights').hexdigest()
+
+
+def test_period_revision_mode_and_pair_separation(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  store = Store(path)
+  now = 100 * 86400
+  for i, (days, revision, mode, pair) in enumerate([(1, 'a', 'full', False), (10, 'b', 'full', False), (40, 'a', 'full', False), (1, 'a', 'aol', False), (1, 'a', 'full', True)]):
+    roles = [{'modelId': 'model', 'backend': 'comma', 'artifact': revision, 'artifactVerified': True}]
+    if pair:
+      roles.append({'modelId': 'long', 'backend': 'chestnut', 'artifact': 'c', 'artifactVerified': True})
+    owner = parse_identity(json.dumps({'version': 1, 'roles': roles}))
+    reducer = Reducer()
+    for t in [1, 1.1]:
+      reducer.update(Sample(t, owner, 10, enabled=mode == 'full', aol=mode == 'aol', lat=True))
+    store.checkpoint(str(i), now-days*86400, reducer.snapshot(), complete=True, now=now-days*86400)
+  store.close()
+  with patch('openpilot.starpilot.common.model_stats_store.time.time', return_value=now):
+    week = read_stats(path, period='7')
+    month = read_stats(path, period='30')
+    alltime = read_stats(path)
+    lateral = read_stats(path, period='7', mode='aol')
+  assert week['historyTotal'] == 3
+  assert month['historyTotal'] == 4
+  assert alltime['historyTotal'] == 5
+  assert len(week['comparisons']) == 3
+  assert len(alltime['comparisons']) == 4
+  assert len(lateral['comparisons']) == 1
+  assert all(row['mode'] == 'aol' for row in lateral['history'])
+  assert week['models']['model']['stats']['assistedMeters'] == pytest.approx(2)
+  assert week['pairs'][0]['stats']['assistedMeters'] == pytest.approx(1)
+  assert read_stats(path, period='7', offset=2, limit=1)['hasMore'] is False
+  with pytest.raises(ValueError):
+    read_stats(path, period='bad')

--- a/starpilot/common/tests/test_model_stats_definitions.py
+++ b/starpilot/common/tests/test_model_stats_definitions.py
@@ -1,0 +1,120 @@
+import json
+import sqlite3
+import pytest
+from openpilot.starpilot.common.model_stats_store import Store, read_stats
+from openpilot.starpilot.common.tests.test_model_stats_store import recorded
+from openpilot.starpilot.common.tests.test_model_stats_log_recovery import fixture
+from openpilot.starpilot.common.model_stats_recovery import import_routes
+from openpilot.starpilot.common.tests.test_model_stats_log_recovery import database_rows
+
+
+def set_policy(path, drive, version, release=None):
+  with sqlite3.connect(path) as db:
+    state=json.loads(db.execute('SELECT state FROM drives WHERE id=?',(drive,)).fetchone()[0])
+    state.pop('definitionVersion',None)
+    state.pop('interventionReleaseSeconds',None)
+    if version is not None: state['definitionVersion']=version
+    if release is not None: state['interventionReleaseSeconds']=release
+    db.execute('UPDATE drives SET state=? WHERE id=?',(json.dumps(state),drive))
+
+
+def test_mixed_definitions_keep_counters_and_distance_but_have_no_event_rates(tmp_path):
+  path=tmp_path/'stats.sqlite'
+  recorded(path,'v1',complete=True)
+  set_policy(path,'v1',None)
+  recorded(path,'v2',complete=True)
+  before=database_rows(path)
+  result=read_stats(path)
+  stats=result['models']['rdf43']['stats']
+  assert stats['assistedMeters']==pytest.approx(20.2)
+  assert stats['interventions']==stats['disengagements']==2
+  assert stats['eventRatesComparable'] is False
+  assert stats['definitionStatus']=='mixed'
+  assert stats['milesPerIntervention'] is None
+  assert stats['milesPerDisengagement'] is None
+  assert result['definitionVersion'] is None
+  assert result['currentDefinitionVersion']==2
+  assert all(row['stats']['milesPerIntervention'] is None for row in result['comparisons'])
+  assert {h['definitionVersion'] for h in result['history']}=={1,2}
+  assert all(h['stats']['eventRatesComparable'] for h in result['history'])
+  assert database_rows(path)==before
+
+
+@pytest.mark.parametrize('version,release,status,comparable',[(None,None,'historical',True),(2,2,'current',True),(7,2,'unknown',False),(2,.5,'unknown',False)])
+def test_single_definition_provenance(tmp_path,version,release,status,comparable):
+  path=tmp_path/'stats.sqlite'
+  recorded(path,complete=True)
+  set_policy(path,'drive1',version,release)
+  result=read_stats(path)
+  stats=result['models']['rdf43']['stats']
+  assert stats['definitionStatus']==status
+  assert stats['eventRatesComparable'] is comparable
+  assert (stats['milesPerIntervention'] is not None)==comparable
+  assert result['history'][0]['stats']['eventRatesComparable'] is comparable
+
+
+def test_cross_definition_recovery_refused_without_changes(tmp_path):
+  path=tmp_path/'stats.sqlite'
+  _,route=fixture(path)
+  set_policy(path,'original',None)
+  before=database_rows(path)
+  with pytest.raises(ValueError,match='definition'):
+    import_routes(path,[route],tmp_path/'backup.sqlite')
+  assert database_rows(path)==before
+  assert not (tmp_path/'backup.sqlite').exists()
+
+
+def test_same_historical_definition_recovery_preserves_policy(tmp_path):
+  path=tmp_path/'stats.sqlite'
+  _,route=fixture(path)
+  set_policy(path,'original',None)
+  route['snapshot'].pop('definitionVersion')
+  route['snapshot'].pop('interventionReleaseSeconds')
+  assert import_routes(path,[route],tmp_path/'backup.sqlite')['added']==1
+  result=read_stats(path)
+  assert result['history'][0]['definitionVersion']==1
+  assert result['models']['rdf43']['stats']['definitionStatus']=='historical'
+
+
+def test_different_revisions_still_mark_pooled_model_mixed(tmp_path):
+  from openpilot.starpilot.common.tests.test_model_stats import OWNER
+  path=tmp_path/'stats.sqlite'
+  recorded(path,'old',complete=True)
+  set_policy(path,'old',None)
+  identity=json.loads(OWNER)
+  identity['roles'][0]['artifact']='another-loaded-revision'
+  recorded(path,'new',owner=json.dumps(identity),complete=True)
+  result=read_stats(path)
+  assert len(result['comparisons'])==2
+  assert all(row['stats']['eventRatesComparable'] for row in result['comparisons'])
+  assert result['models']['rdf43']['stats']['eventRatesComparable'] is False
+  assert result['models']['rdf43']['stats']['assistedMeters']==pytest.approx(20.2)
+
+
+def test_explicit_null_policy_is_unknown_not_legacy(tmp_path):
+  path=tmp_path/'stats.sqlite'
+  recorded(path,complete=True)
+  with sqlite3.connect(path) as db:
+    state=json.loads(db.execute('SELECT state FROM drives').fetchone()[0])
+    state['definitionVersion']=None
+    state['interventionReleaseSeconds']=None
+    db.execute('UPDATE drives SET state=?',(json.dumps(state),))
+  result=read_stats(path)
+  assert result['models']['rdf43']['stats']['definitionStatus']=='unknown'
+  assert result['history'][0]['stats']['definitionStatus']=='unknown'
+
+
+@pytest.mark.parametrize('version,release', [(True, .5), (False, .5), (1.0, .5), ('1', .5), (2, True), (2, '2')])
+def test_invalid_policy_scalar_types_remain_unknown_in_aggregates(tmp_path, version, release):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  set_policy(path, 'drive1', version, release)
+  before = database_rows(path)
+  result = read_stats(path)
+  for stats in [result['models']['rdf43']['stats'], result['history'][0]['stats'], result['comparisons'][0]['stats']]:
+    assert stats['definitionStatus'] == 'unknown'
+    assert stats['eventRatesComparable'] is False
+    assert stats['milesPerIntervention'] is None
+    assert stats['assistedMeters'] == pytest.approx(10.1)
+    assert stats['interventions'] == 1
+  assert database_rows(path) == before

--- a/starpilot/common/tests/test_model_stats_log_recovery.py
+++ b/starpilot/common/tests/test_model_stats_log_recovery.py
@@ -1,0 +1,53 @@
+import json
+import sqlite3
+import pytest
+from openpilot.starpilot.common.model_stats import Reducer
+from openpilot.starpilot.common.model_stats_store import Store, read_stats
+from openpilot.starpilot.common.model_stats_recovery import import_routes
+from openpilot.starpilot.common.tests.test_model_stats import feed
+def database_rows(path):
+  with sqlite3.connect(path) as db:
+    return {table: db.execute('SELECT * FROM ' + table + ' ORDER BY 1, 2').fetchall()
+            for table in ('drives', 'metrics')}
+
+
+def fixture(path, manual=False):
+  reducer = Reducer()
+  feed(reducer, 0, 51, enabled=not manual)
+  store = Store(path)
+  store.checkpoint('original',100,reducer.snapshot(),complete=True,now=101)
+  store.close()
+  old = database_rows(path)
+  feed(reducer,51,101,enabled=not manual)
+  route = {'routeName':'route', 'started':100, 'updated':101.5, 'snapshot':reducer.snapshot()}
+  return old, route
+
+@pytest.mark.parametrize('manual',[True,False])
+def test_recovery_keeps_original_but_counts_only_replay_and_repeats_safely(tmp_path,manual):
+  path=tmp_path/'stats.sqlite'
+  old, route=fixture(path,manual)
+  report=import_routes(path,[route],tmp_path/'before.sqlite')
+  assert report == {'added':1,'superseded':1}
+  after=read_stats(path)
+  assert after['driveSummaries'][0]['routeName']=='route'
+  assert len(after['driveSummaries'])==1
+  assert after['driveSummaries'][0]['stats']['interventions']==0
+  if not manual:
+    assert after['models']['rdf43']['stats']['assistedMeters']==pytest.approx(10)
+  assert import_routes(path,[route],tmp_path/'never-created.sqlite')['added']==0
+  assert not (tmp_path/'never-created.sqlite').exists()
+  assert read_stats(path)==after
+  assert len(database_rows(path)['drives'])==2
+  assert database_rows(tmp_path/'before.sqlite')==old
+
+def test_partial_or_ambiguous_reconstruction_does_not_change_database(tmp_path):
+  path=tmp_path/'stats.sqlite'
+  old,route=fixture(path)
+  bad=json.loads(json.dumps(route));bad['snapshot']['metrics'][0]['assistedMeters']=0
+  with pytest.raises(ValueError,match='reduce'):
+    import_routes(path,[bad],tmp_path/'bad.sqlite')
+  other={**route,'routeName':'overlap'}
+  with pytest.raises(ValueError,match='Ambiguous'):
+    import_routes(path,[route,other],tmp_path/'bad.sqlite')
+  assert database_rows(path)==old
+  assert not (tmp_path/'bad.sqlite').exists()

--- a/starpilot/common/tests/test_model_stats_store.py
+++ b/starpilot/common/tests/test_model_stats_store.py
@@ -1,0 +1,145 @@
+import json
+import sqlite3
+
+import pytest
+
+from openpilot.starpilot.common.model_stats import Reducer
+from openpilot.starpilot.common.model_stats_store import Store, read_stats
+from openpilot.starpilot.common.tests.test_model_stats import OWNER, OTHER, feed, sample
+
+
+def recorded(path, drive='drive1', owner=OWNER, complete=False):
+  r = Reducer()
+  feed(r, 0, 101, owner=owner)
+  r.update(sample(1.01, owner=owner, brake=True, enabled=False))
+  store = Store(path)
+  store.checkpoint(drive, 1700000000, r.snapshot(), complete=complete, now=1700000010)
+  store.close()
+  return r
+
+
+def test_checkpoint_idempotent_atomic_cursor_and_restart(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  r = recorded(path)
+  before = read_stats(path)
+  store = Store(path)
+  store.checkpoint('drive1', 1700000000, r.snapshot(), now=1700000010)
+  store.checkpoint('drive1', 1700000000, {'sequence': 0}, now=1700000010)
+  state = json.loads(store.db.execute('SELECT state FROM drives').fetchone()[0])
+  assert state['sequence'] == r.sequence
+  assert state['previous']['brake']
+  assert read_stats(path) == before
+  store.close()
+  assert before['incompleteDrives'] == 1
+  assert before['models']['rdf43']['stats']['incomplete']
+  # Restart is a separate incomplete fragment; an input held at startup adds no edge.
+  restarted = Reducer()
+  feed(restarted, 0, 20, brake=True)
+  store = Store(path)
+  store.checkpoint('restart', 1700000020, restarted.snapshot(), complete=True)
+  store.close()
+  assert read_stats(path)['models']['rdf43']['stats']['interventions'] == 1
+
+
+def test_all_time_multiple_drives_no_average_of_ratios(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  r = Reducer()
+  feed(r, 0, 201)
+  store = Store(path)
+  store.checkpoint('drive2', 1700000040, r.snapshot(), complete=True)
+  store.close()
+  result = read_stats(path, model='rdf43', limit=1)
+  stats = result['models']['rdf43']['stats']
+  assert stats['assistedMeters'] == pytest.approx(30.1)
+  assert stats['interventions'] == stats['disengagements'] == 1
+  assert stats['milesPerDisengagement'] == pytest.approx(stats['disengagementMeters'] / 1609.344)
+  assert result['historyTotal'] == 2 and result['hasMore']
+  assert len(read_stats(path, offset=1)['history']) == 1
+
+
+def test_pair_never_duplicated_into_standalone(tmp_path):
+  identity = json.loads(OWNER)
+  identity['roles'].append(json.loads(OTHER)['roles'][0])
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, owner=json.dumps(identity), complete=True)
+  result = read_stats(path, model='rdf43')
+  assert result['models'] == {}
+  assert result['pairs'][0]['modelIds'] == ['rdf43', 'gpu']
+  assert result['pairs'][0]['stats']['assistedMeters'] == pytest.approx(10.1)
+  assert len(result['history']) == 1
+  assert read_stats(path, model='not-present')['historyTotal'] == 0
+
+
+def test_completed_snapshot_cannot_be_overwritten(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  r = recorded(path, complete=True)
+  before = read_stats(path)
+  feed(r, 102, 200)
+  store = Store(path)
+  store.checkpoint('drive1', 1700000000, r.snapshot())
+  store.close()
+  assert read_stats(path) == before
+
+
+def test_missing_corrupt_unknown_schema_never_reset(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  assert read_stats(path)['status'] == 'not_started'
+  assert not path.exists()
+  path.write_bytes(b'broken database')
+  assert read_stats(path)['status'] == 'unavailable'
+  with pytest.raises(sqlite3.Error):
+    Store(path)
+  assert path.read_bytes() == b'broken database'
+  path.unlink()
+  with sqlite3.connect(path) as db:
+    db.execute('PRAGMA user_version=99')
+  with pytest.raises(ValueError):
+    Store(path)
+  assert read_stats(path)['status'] == 'unavailable'
+  with sqlite3.connect(path) as db:
+    assert db.execute('PRAGMA user_version').fetchone()[0] == 99
+
+
+def test_failed_checkpoint_rolls_back_cursor_and_counters(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  r = recorded(path)
+  store = Store(path)
+  before = read_stats(path)
+  feed(r, 102, 120)
+  snapshot = r.snapshot()
+  snapshot['metrics'][0]['assistedMeters'] = None  # NOT NULL constraint fails after drive upsert
+  with pytest.raises(sqlite3.IntegrityError):
+    store.checkpoint('drive1', 1700000000, snapshot)
+  assert read_stats(path) == before
+  store.close()
+
+
+def test_read_only_api_cannot_change_database(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  before = path.read_bytes()
+  result = read_stats(path, model="' OR 1=1 --")
+  assert result['available'] and result['models'] == {}
+  assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize('kwargs', [{'mode': 'invalid'}, {'limit': 0}, {'limit': 201}, {'offset': -1}])
+def test_invalid_query_rejected(tmp_path, kwargs):
+  with pytest.raises(ValueError):
+    read_stats(tmp_path / 'no-db', **kwargs)
+
+
+def test_history_preserves_legacy_and_two_second_grouping_without_recounting(tmp_path):
+  path=tmp_path/'stats.sqlite'
+  r=recorded(path,complete=True)
+  current=read_stats(path)['history'][0]
+  assert current['definitionVersion']==2 and current['interventionReleaseSeconds']==2.0
+  store=Store(path)
+  snapshot=r.snapshot()
+  snapshot.pop('definitionVersion');snapshot.pop('interventionReleaseSeconds')
+  store.checkpoint('legacy',1600000000,snapshot,complete=True,now=1600000001)
+  store.close()
+  legacy=next(row for row in read_stats(path)['history'] if row['drive']=='legacy')
+  assert legacy['definitionVersion']==1 and legacy['interventionReleaseSeconds']==0.5
+  assert legacy['stats']['interventions']==current['stats']['interventions']

--- a/starpilot/common/tests/test_vehicle_snapshot.py
+++ b/starpilot/common/tests/test_vehicle_snapshot.py
@@ -1,0 +1,40 @@
+import json
+from types import SimpleNamespace
+import pytest
+from starpilot.common.vehicle_snapshot import write_vehicle_snapshot, read_vehicle_snapshot, MAX_AGE_NS
+
+class Snapshot(dict):pass
+
+def snapshot():
+  sm=Snapshot(carState=SimpleNamespace(gearShifter='park',accFaulted=False,steerFaultTemporary=False,steerFaultPermanent=False,canValid=True,cruiseState=SimpleNamespace(available=True,enabled=False)))
+  sm.seen={'carState':True};sm.alive={'carState':True};sm.valid={'carState':True};sm.logMonoTime={'carState':1_000_000_000}
+  return sm
+
+def test_atomic_roundtrip_and_source_expiry(tmp_path):
+  path=tmp_path/'vehicle';sm=snapshot()
+  assert write_vehicle_snapshot(sm,path)
+  assert read_vehicle_snapshot(path,now_ns=1_050_000_000).gearShifter=='park'
+  # Rewriting a cached message must not give it a fresh timestamp.
+  assert write_vehicle_snapshot(sm,path)
+  assert read_vehicle_snapshot(path,now_ns=1_000_000_000+MAX_AGE_NS) is None
+  assert read_vehicle_snapshot(path,now_ns=999_999_999) is None
+  sm['carState'].gearShifter='drive';sm.logMonoTime['carState']+=MAX_AGE_NS
+  assert write_vehicle_snapshot(sm,path)
+  assert read_vehicle_snapshot(path,now_ns=1_100_000_001).gearShifter=='drive'
+
+@pytest.mark.parametrize('field',['valid','alive','seen'])
+def test_invalid_producer_overwrites_previous_park(tmp_path,field):
+  path=tmp_path/'vehicle';sm=snapshot();write_vehicle_snapshot(sm,path)
+  getattr(sm,field)['carState']=False
+  assert write_vehicle_snapshot(sm,path)
+  assert read_vehicle_snapshot(path,now_ns=1_000_000_001) is None
+
+@pytest.mark.parametrize('content',['{}','[]','null','{','{"sourceMonoTime":true}', 'x'*5000])
+def test_corrupt_or_partial_payload_fails_closed(tmp_path,content):
+  path=tmp_path/'vehicle';path.write_text(content)
+  assert read_vehicle_snapshot(path,now_ns=1_000_000_001) is None
+
+def test_missing_path_and_write_failure_are_nonfatal(tmp_path):
+  path=tmp_path/'absent'/'vehicle'
+  assert read_vehicle_snapshot(path) is None
+  assert write_vehicle_snapshot(snapshot(),path) is False

--- a/starpilot/common/vehicle_snapshot.py
+++ b/starpilot/common/vehicle_snapshot.py
@@ -1,0 +1,54 @@
+"""Galaxy's vehicle status, mirrored by an existing reader into volatile RAM.
+
+Never subscribe here: carState's onroad reader budget is already full. Source
+timestamps expire at the same 100 ms budget as carState's normal alive check.
+"""
+import json
+import os
+from pathlib import Path
+import time
+from types import SimpleNamespace
+
+SNAPSHOT_PATH = Path('/dev/shm/starpilot_galaxy_vehicle.json')
+MAX_AGE_NS = 100_000_000
+BOOL_FIELDS = ('accFaulted', 'steerFaultTemporary', 'steerFaultPermanent', 'canValid')
+
+
+def write_vehicle_snapshot(sm, path=SNAPSHOT_PATH):
+  """Best-effort, atomic tmpfs write; optional Galaxy work must not stop driving."""
+  temporary = path.with_name(path.name + '.tmp')
+  try:
+    state = sm['carState']
+    payload = {
+      'sourceMonoTime': sm.logMonoTime['carState'],
+      'valid': bool(sm.seen['carState'] and sm.alive['carState'] and sm.valid['carState']),
+      'gearShifter': str(state.gearShifter),
+      **{key: bool(getattr(state, key)) for key in BOOL_FIELDS},
+      'cruiseAvailable': bool(state.cruiseState.available),
+      'cruiseEnabled': bool(state.cruiseState.enabled),
+    }
+    temporary.write_text(json.dumps(payload, allow_nan=False))
+    os.replace(temporary, path)
+    return True
+  except (OSError, AttributeError, KeyError, TypeError, ValueError):
+    return False
+
+
+def read_vehicle_snapshot(path=SNAPSHOT_PATH, *, now_ns=None):
+  """Fail closed on an absent producer, corrupt payload or old vehicle sample."""
+  try:
+    with path.open() as source:
+      payload = json.loads(source.read(4096))
+    stamp = payload['sourceMonoTime']
+    now_ns = time.monotonic_ns() if now_ns is None else now_ns
+    if type(stamp) is not int or stamp <= 0 or not 0 <= now_ns - stamp < MAX_AGE_NS:
+      return None
+    if payload['valid'] is not True or type(payload['gearShifter']) is not str:
+      return None
+    if any(type(payload[key]) is not bool for key in (*BOOL_FIELDS, 'cruiseAvailable', 'cruiseEnabled')):
+      return None
+    return SimpleNamespace(gearShifter=payload['gearShifter'],
+                           **{key: payload[key] for key in BOOL_FIELDS},
+                           cruiseState=SimpleNamespace(available=payload['cruiseAvailable'], enabled=payload['cruiseEnabled']))
+  except (OSError, KeyError, TypeError, ValueError):
+    return None

--- a/starpilot/docs/model_statistics_recorder.md
+++ b/starpilot/docs/model_statistics_recorder.md
@@ -1,0 +1,29 @@
+# Model statistics recorder
+
+The optional Galaxy-owned observer records assisted forward distance, interventions and disengagements against the model instance that produced successful output. Model identity includes ordered lateral/longitudinal roles, backend and a SHA-256 digest of bytes consumed by the existing loader. Instrumentation failure produces an unverified load UUID or unavailable coverage. No model hashing occurs during inference.
+
+Policy v2 combines held/overlapping steering, brake and gas inputs into an episode, then requires two continuous clear seconds before rearming. Intervention exposure excludes held/rearming inputs; disengagement exposure includes the assistance session, including temporarily inactive actuators. Rates are exposure divided by event count; zero events have no event rate. Distance excludes manual driving, reverse, missing CAN, stale services, ambiguous model switches and gaps over 250 ms. Full engagement and AOL remain distinct modes. Shutdown or missing telemetry cannot manufacture a disengagement.
+
+Historical records retain their definition version. Untagged records use historical policy v1 (0.5-second release). Mixed/unknown definitions retain counters and distance but cannot produce comparable pooled event rates. Standalone model totals and paired configurations remain separate.
+
+## Runtime and storage
+
+Galaxy starts a supervised low-priority observer only on device startup, never in response to a page request. It is absent from managerState and publishes no messages or Params. Seven non-conflated subscribers preserve intervention edges. SQLite checkpoints run only in that child at `/data/starpilot/model_stats.sqlite`, with a single-writer lock, WAL and FULL synchronization. Galaxy's read-only API uses a coherent SQLite read transaction. Successful checkpoints persist across model and route deletion; sudden power loss can lose the most recent uncheckpointed interval.
+
+Each receive pass yields at 256 messages, 1 MiB or a cooperative 5 ms deadline. Raw events above 64 KiB are rejected before bounded Cap'n Proto decoding. Pending data is limited to 2048 events / 4 MiB estimated payload; reduction has its own 256-event/5 ms budget. Capacity loss creates explicit gaps; ordinary cooperative yields preserve data. Model caches hold at most 256 entries; a drive freezes before 128 metric rows. Failed checkpoints retain at most 16 snapshots / 4 MiB plus bounded active/loss state, then suspend recording and preserve coverage-loss metadata rather than silently discard accepted counters. Diagnostics record fixed loss/yield and timing counters.
+
+These are cooperative bounds, not hard RSS or wall-clock limits. Native receive allocation, a single decode, interpreter/SQLite overhead and storage latency remain outside the timing budget. Storage/power loss may erase unsaved data and an unpersisted coverage marker.
+
+## Vehicle snapshot
+
+StarPilot's existing carState reader writes an atomic JSON snapshot into tmpfs. Galaxy parked authorization and cruise/steering/CAN diagnostics use it without opening additional carState readers. The original source monotonic timestamp expires after 100 ms; missing, malformed, invalid, future or stale snapshots fail closed. Rewriting a cached message cannot renew freshness. Snapshot write failures return without terminating StarPilot.
+
+## Read API and recovery
+
+`GET /api/models/stats` supports `model`, `mode=all|full|aol`, `period=all|7|30`, `limit=1..200` and `offset=0..9223372036854775807`. Period selection uses drive start. Unknown filters are rejected. `ModelStatsAPI.summary()` caches a defensive copy for two seconds; `annotate(models)` attaches statistics to catalogue dictionaries containing `value`. Presentation and file sizes are separate features.
+
+Explicit offline `model_stats_recovery.import_routes` accepts reviewed reconstructed routes. The caller must establish off-road state and exclude concurrent collection/restore. Recovery checks provenance, policy and counters, refuses reductions or ambiguous fragment assignment, backs up the database consistently, then commits accepted routes atomically. Original rows remain; superseded fragments are excluded from all read totals and health queries. Repeated identical imports add nothing. Recovery is never a background or driving-time job.
+
+## Validation boundary
+
+Focused tests cover reducer behavior, identity loaders, schema serialization, storage/restart integrity, recovery, measurement cohorts, bounded overload, API filtering and snapshot freshness/faults. Host-native synthetic probes validate isolated transport and measure local overhead only. Matching target schema/native builds, actual onroad reader occupancy, drive-time capture continuity, target resource soak, power-loss behavior and hardware/fallback integration remain unverified for this split.

--- a/starpilot/starpilot_process.py
+++ b/starpilot/starpilot_process.py
@@ -8,6 +8,7 @@ import requests
 import time
 
 from cereal import messaging
+from openpilot.starpilot.common.vehicle_snapshot import write_vehicle_snapshot
 from openpilot.common.api import Api, api_get
 from openpilot.common.gps import get_gps_location_service
 from openpilot.common.params import Params
@@ -327,6 +328,7 @@ def starpilot_thread():
 
   while True:
     sm.update()
+    write_vehicle_snapshot(sm)
 
     now = datetime.datetime.now(datetime.timezone.utc)
     monotonic_now = time.monotonic()

--- a/starpilot/system/model_statsd.py
+++ b/starpilot/system/model_statsd.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Optional passive observer. No publishers, Params writes, control hooks or replay.
+
+Non-conflated sockets preserve short pedal/steering edges. A bounded 100ms
+reorder buffer aligns service timestamps. Gaps are excluded, not interpolated.
+SQLite runs only here, never in modeld/controlsd. Shutdown is not a disengagement.
+"""
+import heapq
+import logging
+import os
+import signal
+import sys
+import time
+import uuid
+from pathlib import Path
+from collections import Counter
+from types import SimpleNamespace
+
+from openpilot.starpilot.common.model_stats import Reducer, Sample, parse_identity
+from openpilot.starpilot.common.model_stats_store import Store
+
+SERVICES = ('carState', 'carControl', 'selfdriveState', 'starpilotCarState', 'deviceState', 'modelV2', 'starpilotModelV2')
+FRESHNESS = {'carControl': .25, 'selfdriveState': .25, 'starpilotCarState': .25, 'deviceState': 2.5}
+
+
+# Observer-local budgets, not control/transport configuration. Native receive
+# allocates ONE raw message before its size is knowable; never bulk-drain.
+MAX_TICK_MESSAGES = 256
+MAX_EVENT_BYTES = 64 * 1024
+MAX_TICK_BYTES = 1024 * 1024
+MAX_TICK_SECONDS = .005
+MAX_PENDING_EVENTS = 2048
+MAX_PENDING_BYTES = 4 * 1024 * 1024
+MAX_CHECKPOINTS = 16
+MAX_CHECKPOINT_BYTES = 4 * 1024 * 1024
+MAX_METRIC_ROWS = 128
+MAX_MODEL_CACHE = 256
+
+
+def decode_event(raw):
+  # Do not use messaging.log_from_bytes: that disables traversal limits. Copy
+  # only scalar observation fields, then release the native reader/raw buffer.
+  from cereal import log
+  fields = {
+    'carState': ('vEgo', 'canValid', 'gearShifter', 'steeringPressed', 'brakePressed', 'gasPressed'),
+    'carControl': ('latActive', 'longActive'), 'selfdriveState': ('enabled',),
+    'starpilotCarState': ('alwaysOnLateralEnabled',), 'deviceState': ('started',),
+    'modelV2': (), 'starpilotModelV2': ('modelMonoTime', 'runtimeIdentity'),
+  }
+  with log.Event.from_bytes(raw, traversal_limit_in_words=MAX_EVENT_BYTES // 8, nesting_limit=16) as event:
+    name = event.which()
+    data = getattr(event, name)
+    values = {key: str(getattr(data, key)) if key == 'gearShifter' else getattr(data, key) for key in fields[name]}
+    return SimpleNamespace(logMonoTime=event.logMonoTime, valid=event.valid, **{name: SimpleNamespace(**values)})
+
+
+class BoundedEvents:
+  def __init__(self):
+    self.pending = []
+    self.bytes = 0
+    self.serial = 0
+    self.cursor = 0
+    self.loss_reason = self.yield_reason = None
+    self.high_water_events = self.high_water_bytes = 0
+
+  def clear(self):
+    self.pending.clear()
+    self.bytes = 0
+
+  def receive(self, sockets, decode, clock=time.monotonic):
+    """Yield without losing events on cooperative budgets; True is actual loss.
+
+    Reserve one maximum-size event before receiving: no raw message is consumed
+    merely to discover that the remaining per-pass byte budget is too small.
+    Native calls are nonblocking; a single decode cannot be preempted.
+    """
+    self.loss_reason = None
+    self.yield_reason = None
+    active = list(sockets)
+    if not active:
+      return False
+    indexes = {sock: index for index, sock in enumerate(active)}
+    first = self.cursor % len(active)
+    active = active[first:] + active[:first]
+    deadline = clock() + MAX_TICK_SECONDS
+    count = used = 0
+    while active:
+      if count >= MAX_TICK_MESSAGES:
+        self.yield_reason = 'message_budget'
+        return False
+      if used + MAX_EVENT_BYTES > MAX_TICK_BYTES:
+        self.yield_reason = 'byte_budget'
+        return False
+      if clock() >= deadline:
+        self.yield_reason = 'time_budget'
+        return False
+      if len(self.pending) >= MAX_PENDING_EVENTS or self.bytes >= MAX_PENDING_BYTES:
+        return self.lose('pending_capacity')
+      sock = active.pop(0)
+      self.cursor = (indexes[sock] + 1) % len(sockets)
+      raw = sock.receive(non_blocking=True)
+      if raw is None:
+        continue
+      count += 1
+      size = len(raw)
+      if size > MAX_EVENT_BYTES:
+        return self.lose('oversize_raw')
+      try:
+        event = decode(raw)
+        stamp = event.logMonoTime
+        size = max(size, snapshot_size((stamp, self.serial + 1, sockets[sock], event, 0)) + 8)
+      except Exception:
+        return self.lose('decode_error')
+      if size > MAX_EVENT_BYTES:
+        return self.lose('oversize_decoded')
+      if size > MAX_PENDING_BYTES - self.bytes:
+        return self.lose('pending_capacity')
+      # Keep the event even when decode/preemption crossed the cooperative
+      # deadline. The next iteration yields before receiving anything else.
+      self.serial += 1
+      heapq.heappush(self.pending, (stamp, self.serial, sockets[sock], event, size))
+      self.bytes += size
+      used += size
+      self.high_water_events = max(self.high_water_events, len(self.pending))
+      self.high_water_bytes = max(self.high_water_bytes, self.bytes)
+      active.append(sock)
+    return False
+
+  def lose(self, reason):
+    self.loss_reason = reason
+    self.clear()
+    return True
+
+  def pop(self):
+    stamp, serial, name, event, size = heapq.heappop(self.pending)
+    self.bytes -= size
+    return stamp, serial, name, event
+
+
+def snapshot_size(value):
+  """Conservative Python retention estimate (shared objects counted repeatedly)."""
+  size = sys.getsizeof(value)
+  if isinstance(value, SimpleNamespace):
+    return size + snapshot_size(vars(value))
+  if isinstance(value, dict):
+    for key, item in value.items():
+      size += snapshot_size(key) + snapshot_size(item)
+      if size > MAX_CHECKPOINT_BYTES:
+        break
+  elif isinstance(value, (list, tuple)):
+    for item in value:
+      size += snapshot_size(item)
+      if size > MAX_CHECKPOINT_BYTES:
+        break
+  return size
+
+
+class Telemetry:
+  def __init__(self):
+    self.latest = {}
+    self.models = {}
+    self.identities = {}
+    self.runtime = None
+
+  def feed(self, service, timestamp, valid, data):
+    t = timestamp / 1e9
+    # Reorder buffering cannot recover messages arriving after its deadline.
+    # Never let those messages rewrite already-observed edges or road state.
+    if service in self.latest and t <= self.latest[service][0]:
+      return None
+    if service == 'modelV2':
+      self.models[timestamp] = valid
+    elif service == 'starpilotModelV2':
+      self.identities[getattr(data, 'modelMonoTime', 0)] = parse_identity(getattr(data, 'runtimeIdentity', '')) if valid else None
+    else:
+      self.latest[service] = (t, valid, data)
+    for stamp in sorted(self.models.keys() & self.identities.keys()):
+      if self.runtime is None or stamp > self.runtime[0]:
+        self.runtime = (stamp, self.identities[stamp] if self.models[stamp] else None)
+    for cache in (self.models, self.identities):
+      for stamp in list(cache):
+        if timestamp - stamp > 1e9:
+          del cache[stamp]
+      while len(cache) > MAX_MODEL_CACHE:
+        del cache[next(iter(cache))]  # unmatched provenance is unavailable, never guessed
+    if service != 'carState':
+      return None
+    fresh = valid and all(name in self.latest and self.latest[name][1]
+                          and 0 <= t - self.latest[name][0] <= age for name, age in FRESHNESS.items())
+    runtime_fresh = self.runtime and 0 <= timestamp - self.runtime[0] <= 250_000_000
+    if not fresh or not runtime_fresh or self.runtime is None:
+      return Sample(t, None, 0, valid=False)
+    cc, sd, sp, device = (self.latest[name][2] for name in FRESHNESS)
+    return Sample(t, self.runtime[1], data.vEgo, enabled=sd.enabled,
+                  aol=sp.alwaysOnLateralEnabled, lat=cc.latActive, long=cc.longActive,
+                  steering=data.steeringPressed, brake=data.brakePressed, gas=data.gasPressed,
+                  reverse=str(data.gearShifter) == 'reverse', onroad=device.started,
+                  valid=bool(data.canValid))
+
+
+class Checkpoints:
+  """Bounded failed cumulative snapshots; never evict counters silently.
+
+  Saturation latches collection off for this process. A constant-size loss marker
+  is retried alongside retained counters, including after storage recovers. It
+  deliberately remains visible in history across restart (excluded coverage is
+  not repaired by restarting). Power loss before any write can still lose RAM.
+  """
+  def __init__(self, factory=Store):
+    self.factory = factory
+    self.store = None
+    self.pending = {}
+    self.sizes = {}
+    self.pending_bytes = 0
+    self.retry_at = 0
+    self.suspended = False
+    self.loss_marker = None
+    self.blocked_drive = None
+
+  def suspend(self):
+    if not self.suspended:
+      self.suspended = True
+      marker = Reducer()
+      marker.break_stream()
+      self.loss_marker = (uuid.uuid4().hex, time.time(), marker.snapshot() | {'coverageLoss': True})
+      logging.error('Model statistics resource limit: collection suspended; coverage lost; retained counters retrying')
+
+  def submit(self, drive, started, snapshot, complete=False):
+    size = snapshot_size((drive, started, snapshot, complete))
+    total = self.pending_bytes - self.sizes.get(drive, 0) + size
+    if ((drive not in self.pending and ((self.suspended and drive != self.blocked_drive) or len(self.pending) >= MAX_CHECKPOINTS))
+        or total > MAX_CHECKPOINT_BYTES):
+      if not self.suspended:
+        self.blocked_drive = drive
+      self.suspend()
+      return False
+    self.pending[drive] = (started, snapshot, complete)
+    self.sizes[drive] = size
+    self.pending_bytes = total
+    return True
+
+  def flush(self, now):
+    if not self.pending and self.loss_marker is None:
+      return True
+    if now < self.retry_at:
+      return False
+    try:
+      if self.store is None:
+        self.store = self.factory()
+      if self.loss_marker is not None:
+        drive, started, snapshot = self.loss_marker
+        self.store.checkpoint(drive, started, snapshot, complete=False)
+        self.loss_marker = None
+      # Count is hard bounded; one flush cannot grow with outage duration.
+      for drive, (started, snapshot, complete) in list(self.pending.items()):
+        self.store.checkpoint(drive, started, snapshot, complete=complete)
+        del self.pending[drive]
+        self.pending_bytes -= self.sizes.pop(drive)
+      return True
+    except Exception:
+      logging.exception('Model statistics checkpoint failed; retained for retry; driving is unaffected')
+      if self.store is not None:
+        try:
+          self.store.close()
+        except Exception:
+          logging.exception('Model statistics store close failed')
+      self.store = None
+      self.retry_at = now + 30
+      return False
+
+
+class Diagnostics:
+  """Constant-size counters/maxima, no per-message log or retained samples."""
+  def __init__(self):
+    self.counts = Counter()
+    self.maxima = {}
+
+  def timing(self, name, wall, cpu):
+    for key, value in ((name + 'WallMs', wall * 1000), (name + 'CpuMs', cpu * 1000),
+                       (name + 'WaitingMs', max(0, wall - cpu) * 1000)):
+      self.maxima[key] = max(self.maxima.get(key, 0), round(value, 3))
+
+  def snapshot(self, events):
+    return {'counts': dict(self.counts), **self.maxima,
+            'pendingHighWaterEvents': events.high_water_events,
+            'pendingHighWaterBytes': events.high_water_bytes}
+
+
+def current_route(path=Path('/data/params/d/CurrentRoute')):
+  # Logger clears this on each onroad transition, then publishes its new ID.
+  # Read only at start/checkpoint, never from a control process or per sample.
+  import re
+  try:
+    with path.open('rb') as handle:
+      value = handle.read(129).decode('ascii').strip()
+    return value if re.fullmatch(r'(?:[0-9a-f]{8}--[0-9a-f]{10}|\d{4}-\d{2}-\d{2}--\d{2}-\d{2}-\d{2})', value) else None
+  except (OSError, UnicodeError):
+    return None
+
+
+def main():
+  import fcntl
+  from openpilot.starpilot.common.model_stats_store import DEFAULT_PATH
+  logging.basicConfig(level=logging.INFO)
+  os.nice(19)
+  DEFAULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+  lock = (DEFAULT_PATH.parent / 'model_statsd.lock').open('a')
+  try:
+    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+  except BlockingIOError:
+    lock.close()
+    return
+  parent_pid = os.getppid()
+  import cereal.messaging as messaging
+  # Imported only by the process, so reducer/adapter tests need no native cereal.
+  poller = messaging.Poller()
+  sockets = {messaging.sub_sock(name, poller=poller, conflate=False): name for name in SERVICES}
+  telemetry = Telemetry()
+  reducer = None
+  writer = Checkpoints()
+  drive = None
+  started = 0
+  last_write = 0
+  events = BoundedEvents()
+  diagnostics = Diagnostics()
+  route = None
+  last_diagnostic_log = 0
+  discard_before = 0
+  unassigned_gap = False
+  stopping = False
+
+  def stop(*_):
+    nonlocal stopping
+    stopping = True
+
+  signal.signal(signal.SIGTERM, stop)
+  signal.signal(signal.SIGINT, stop)
+
+  def checkpoint(complete=False):
+    nonlocal last_write, route
+    if reducer is not None:
+      route = route or current_route()
+      writer.submit(drive, started, reducer.snapshot() | {
+        'routeName': route, 'diagnostics': diagnostics.snapshot(events)}, complete)
+    last_write = time.monotonic()
+    cpu = time.process_time()
+    result = writer.flush(last_write)
+    diagnostics.timing('storage', time.monotonic() - last_write, time.process_time() - cpu)
+    if not result:
+      diagnostics.counts['storage_retry'] += 1
+    return result
+
+  try:
+    while not stopping and os.getppid() == parent_pid:
+      if writer.suspended:
+        # No more drive/reducer/socket growth. Preserve this bounded reducer for
+        # retry if its final cumulative snapshot could not enter the queue.
+        if reducer is not None:
+          reducer.break_stream()
+        if time.monotonic() - last_write >= 10:
+          checkpoint()
+        time.sleep(.02)
+        continue
+      poller.poll(20)
+      receive_wall, receive_cpu = time.monotonic(), time.process_time()
+      lost = events.receive(sockets, decode_event)
+      diagnostics.timing('receive', time.monotonic() - receive_wall, time.process_time() - receive_cpu)
+      if events.yield_reason:
+        diagnostics.counts[events.yield_reason] += 1
+      if lost:
+        diagnostics.counts[events.loss_reason or 'input_loss'] += 1
+        discard_before = int(time.monotonic() * 1e9)
+        telemetry = Telemetry()
+        if reducer:
+          reducer.break_stream()
+        else:
+          unassigned_gap = True
+      cutoff = int((time.monotonic() - .1) * 1e9)
+      processing_wall, processing_cpu = time.monotonic(), time.process_time()
+      processing_deadline = processing_wall + MAX_TICK_SECONDS
+      processed = 0
+      while events.pending and events.pending[0][0] <= cutoff:
+        if processed >= MAX_TICK_MESSAGES or time.monotonic() >= processing_deadline:
+          break
+        stamp, _, name, event = events.pop()
+        processed += 1
+        if stamp < discard_before or stamp < cutoff - 250_000_000:
+          diagnostics.counts['pre_break_backlog' if stamp < discard_before else 'stale_event'] += 1
+          telemetry = Telemetry()
+          if reducer:
+            reducer.break_stream()
+          else:
+            unassigned_gap = True
+          continue
+        data = getattr(event, name)
+        if name in telemetry.latest and stamp / 1e9 <= telemetry.latest[name][0]:
+          continue
+        if name == 'deviceState' and event.valid:
+          if data.started and reducer is None:
+            reducer, drive = Reducer(), uuid.uuid4().hex
+            started = time.time() - (time.monotonic() - stamp / 1e9)
+            route = current_route()
+            if unassigned_gap:
+              reducer.break_stream()
+              unassigned_gap = False
+          elif not data.started and reducer is not None:
+            checkpoint(complete=True)
+            if writer.suspended:
+              reducer.break_stream()
+              events.clear()
+              break
+            reducer, drive = None, None
+        sample = telemetry.feed(name, stamp, event.valid, data)
+        if reducer is not None and sample is not None:
+          # An update can introduce at most two owner/mode rows. Stop rather
+          # than evict attribution/counters through pathological identity churn.
+          if len(reducer.metrics) >= MAX_METRIC_ROWS - 2:
+            reducer.break_stream()
+            writer.blocked_drive = drive
+            writer.suspend()
+            events.clear()
+            break
+          if not sample.usable:
+            diagnostics.counts['unusable_sample'] += 1
+            if not sample.owner:
+              diagnostics.counts['identity_or_service_unavailable'] += 1
+            elif sample.reverse:
+              diagnostics.counts['reverse_sample'] += 1
+            elif not 0 <= sample.speed <= 100:
+              diagnostics.counts['invalid_speed'] += 1
+            elif not sample.valid:
+              diagnostics.counts['invalid_can'] += 1
+          reducer.update(sample)
+      diagnostics.timing('reduction', time.monotonic() - processing_wall, time.process_time() - processing_cpu)
+      if processed >= MAX_TICK_MESSAGES or time.monotonic() >= processing_deadline:
+        diagnostics.counts['reduction_budget'] += 1
+      if reducer is not None and reducer.last_t is not None and cutoff / 1e9 - reducer.last_t > .25:
+        reducer.break_stream()
+      if time.monotonic() - last_write >= 10:
+        checkpoint()
+      if time.monotonic() - last_diagnostic_log >= 60:
+        logging.info('Model statistics diagnostics: %s', diagnostics.snapshot(events))
+        last_diagnostic_log = time.monotonic()
+      if events.yield_reason or processed >= MAX_TICK_MESSAGES:
+        time.sleep(.001)  # explicitly yield CPU while catching up; no busy drain loop
+  finally:
+    # A process stop mid-drive leaves an incomplete fragment, not a false event.
+    checkpoint()
+    if writer.store is not None:
+      writer.store.close()
+    lock.close()
+
+
+def start_observer():
+  """Galaxy-owned optional subprocess, deliberately absent from managerState.
+
+  Started at server startup, not by a page/HTTP request. Failure cannot trigger
+  processNotRunning. Parent death is observed by the child; retries are bounded.
+  """
+  import subprocess
+  import sys
+  import threading
+
+  def supervise():
+    while True:
+      try:
+        child = subprocess.Popen([sys.executable, '-m', 'openpilot.starpilot.system.model_statsd'],
+                                 stdin=subprocess.DEVNULL)
+        child.wait()
+      except Exception:
+        logging.exception('Optional model statistics observer failed')
+      time.sleep(30)
+
+  threading.Thread(target=supervise, name='model-statistics-supervisor', daemon=True).start()
+
+
+if __name__ == '__main__':
+  main()

--- a/starpilot/system/tests/test_model_stats_bounds.py
+++ b/starpilot/system/tests/test_model_stats_bounds.py
@@ -1,0 +1,289 @@
+"""Finite synthetic review regressions; no native daemon/device required."""
+import json
+from types import SimpleNamespace as NS
+from unittest.mock import patch
+
+import pytest
+from openpilot.starpilot.common.model_stats import Reducer, Sample, parse_identity
+from openpilot.starpilot.common.model_stats_store import Store, read_stats
+from openpilot.starpilot.system import model_statsd as observer
+
+OWNER = parse_identity(json.dumps({'version': 1, 'roles': [{'modelId': 'test', 'artifact': 'test', 'backend': 'comma'}]}))
+
+@pytest.mark.parametrize('complete', [False, True])
+def test_gap_finalizes_without_sample(tmp_path, complete):
+  r = Reducer()
+  r.update(Sample(1, OWNER, 10, enabled=True, lat=True))
+  r.update(Sample(1.1, OWNER, 10, enabled=True, lat=True))
+  store = Store(tmp_path / 'stats.sqlite')
+  store.checkpoint('drive', 100, r.snapshot(), now=101)
+  revision, freshness = r.sequence, r.last_t
+  r.break_stream()
+  r.break_stream()
+  assert r.sequence == revision + 1
+  assert r.last_t == freshness
+  store.checkpoint('drive', 100, r.snapshot(), complete=complete, now=102)
+  row = store.db.execute('SELECT gaps, state, updated FROM drives').fetchone()
+  assert row[0] == 1 and json.loads(row[1])['previous'] is None
+  assert row[2] == 101  # a state revision is not fresh telemetry
+  assert read_stats(store.path)['models']['test']['stats']['incomplete']
+  store.close()
+
+@pytest.mark.parametrize('before,after,count', [
+  ((False, True), (True, False), 0), ((False, True), (True, True), 0),
+  ((False, True), (False, False), 1), ((True, False), (False, True), 1),
+  ((True, True), (False, True), 1), ((True, False), (False, False), 1),
+])
+def test_assistance_transition_matrix(before, after, count):
+  r = Reducer()
+  for t, (enabled, aol) in zip((1, 1.1), (before, after)):
+    r.update(Sample(t, OWNER, 10, enabled=enabled, aol=aol, lat=True))
+  assert sum(row['disengagements'] for row in r.metrics.values()) == count
+
+
+@pytest.mark.parametrize('flags,expected', [
+  ([(False, True), (True, True), (True, False)], 0),
+  # If services actually expose an off sample before full engagement, policy
+  # counts that observed off transition; do not invent handover smoothing.
+  ([(False, True), (False, False), (True, False)], 1),
+])
+def test_asynchronously_observed_handover(flags, expected):
+  r = Reducer()
+  for i, (enabled, aol) in enumerate(flags):
+    r.update(Sample(1 + i * .1, OWNER, 10, enabled=enabled, aol=aol, lat=True))
+  assert sum(row['disengagements'] for row in r.metrics.values()) == expected
+
+
+class Socket:
+  def __init__(self, count=None, size=64):
+    self.remaining, self.size, self.calls = count, size, 0
+  def receive(self, non_blocking):
+    assert non_blocking
+    self.calls += 1
+    if self.remaining == 0:
+      return None
+    if self.remaining is not None:
+      self.remaining -= 1
+    return b'x' * self.size
+
+@pytest.mark.parametrize('count', [12001, None])
+def test_transport_bounded_and_fair(count):
+  buffer = observer.BoundedEvents()
+  sockets = {Socket(count): name for name in observer.SERVICES}
+  decoded = []
+  def decode(raw):
+    decoded.append(len(raw))
+    return NS(logMonoTime=10**18)
+  assert not buffer.receive(sockets, decode, clock=lambda: 1)
+  assert buffer.yield_reason == "message_budget"
+  assert sum(s.calls for s in sockets) <= observer.MAX_TICK_MESSAGES
+  assert max(s.calls for s in sockets) - min(s.calls for s in sockets) <= 1
+  assert len(decoded) <= observer.MAX_TICK_MESSAGES
+  assert len(buffer.pending) <= observer.MAX_PENDING_EVENTS
+  assert buffer.bytes <= observer.MAX_PENDING_BYTES
+
+
+def test_oversize_is_rejected_before_decode():
+  buffer = observer.BoundedEvents()
+  sock = Socket(1, observer.MAX_EVENT_BYTES + 1)
+  assert buffer.receive({sock: 'carState'}, lambda _: pytest.fail('oversize decoded'))
+  assert not buffer.pending and buffer.bytes == 0
+
+
+def test_deadline_returns_and_rotates_first_socket():
+  buffer = observer.BoundedEvents()
+  sockets = {Socket(): name for name in observer.SERVICES}
+  for _ in range(len(sockets)):
+    times = iter([0, 0, 1])
+    assert not buffer.receive(sockets, lambda _: NS(logMonoTime=1), clock=lambda: next(times))
+    assert buffer.yield_reason == "time_budget"
+  assert all(s.calls == 1 for s in sockets)
+
+
+def test_many_drive_outage_is_bounded_and_reported(tmp_path):
+  def fail():
+    raise OSError('synthetic outage')
+  q = observer.Checkpoints(fail)
+  r = Reducer()
+  with patch('logging.exception'):
+    for i in range(300):
+      q.submit(str(i), i, r.snapshot(), complete=True)
+      q.flush(i * 31)
+  assert len(q.pending) <= observer.MAX_CHECKPOINTS
+  assert q.pending_bytes <= observer.MAX_CHECKPOINT_BYTES
+  assert q.suspended
+  q.factory = lambda: Store(tmp_path / 'stats.sqlite')
+  assert q.flush(10000)
+  summary = read_stats(tmp_path / 'stats.sqlite')
+  assert summary['coverageLoss']
+  assert summary['trackingStatus'] == 'resource_limited'
+  q.store.close()
+
+
+def test_checkpoint_byte_cap_and_coalescing():
+  q = observer.Checkpoints()
+  r = Reducer()
+  assert q.submit('drive', 1, r.snapshot())
+  assert q.submit('drive', 1, r.snapshot())
+  assert len(q.pending) == 1
+  huge = r.snapshot() | {'extra': 'x' * observer.MAX_CHECKPOINT_BYTES}
+  assert not q.submit('drive', 1, huge)
+  assert q.pending_bytes <= observer.MAX_CHECKPOINT_BYTES
+  assert q.suspended and len(q.pending) == 1
+
+
+def test_heap_high_water_and_byte_budget_before_cleanup():
+  real_push = observer.heapq.heappush
+  maximum = [0, 0]
+  buffer = observer.BoundedEvents()
+  def push(heap, item):
+    real_push(heap, item)
+    maximum[0] = max(maximum[0], len(heap))
+    maximum[1] = max(maximum[1], sum(row[4] for row in heap))
+  sockets = {Socket(12001): 'carState'}
+  with patch.object(observer.heapq, 'heappush', push):
+    assert not buffer.receive(sockets, lambda _: NS(logMonoTime=1), clock=lambda: 1)
+  assert maximum[0] == observer.MAX_TICK_MESSAGES
+  assert maximum[1] <= observer.MAX_PENDING_BYTES
+  # Across ticks, future timestamps cannot evade the retained heap cap.
+  maximum[:] = [0, 0]
+  with patch.object(observer.heapq, 'heappush', push):
+    for _ in range(30):
+      buffer.receive({Socket(100): 'carState'}, lambda _: NS(logMonoTime=10**18), clock=lambda: 1)
+  assert maximum[0] <= observer.MAX_PENDING_EVENTS
+  assert maximum[1] <= observer.MAX_PENDING_BYTES
+  calls = []
+  buffer.clear()
+  assert not buffer.receive({Socket(size=observer.MAX_EVENT_BYTES): 'carState'},
+                        lambda raw: (calls.append(len(raw)), NS(logMonoTime=1))[1], clock=lambda: 1)
+  assert sum(calls) <= observer.MAX_TICK_BYTES
+
+
+def test_decoded_size_budget_before_heap_insertion():
+  buffer = observer.BoundedEvents()
+  assert buffer.receive({Socket(1): 'carState'}, lambda _: NS(logMonoTime=1, text='x' * observer.MAX_EVENT_BYTES))
+  assert not buffer.pending
+
+
+@pytest.mark.parametrize('offroad', [False, True])
+@pytest.mark.parametrize('outage', [False, True])
+def test_main_overflow_then_finalize_without_carstate(tmp_path, monkeypatch, offroad, outage):
+  import sys
+  import types
+  import openpilot.starpilot.common.model_stats_store as store_module
+  from collections import deque
+  queues, messages, handlers, writers = {}, {}, {}, []
+  clock = [100.0]
+  ticks = [0]
+  class QueuedSocket:
+    def __init__(self, name):
+      self.queue = queues[name] = deque()
+    def receive(self, non_blocking):
+      return self.queue.popleft() if self.queue else None
+  def put(name, data):
+    key = str(len(messages)).encode().ljust(64, b' ')
+    messages[key] = NS(logMonoTime=round((clock[0] - .15) * 1e9) + int(name == 'carState'), valid=True, **{name: data})
+    queues[name].append(key)
+  def frame():
+    for name, data in {
+      'deviceState': NS(started=True), 'carControl': NS(latActive=True, longActive=True),
+      'selfdriveState': NS(enabled=True), 'starpilotCarState': NS(alwaysOnLateralEnabled=False),
+      'modelV2': NS(), 'starpilotModelV2': NS(modelMonoTime=round((clock[0] - .15) * 1e9), runtimeIdentity=OWNER),
+      'carState': NS(vEgo=10, canValid=True, gearShifter='drive', steeringPressed=False, brakePressed=False, gasPressed=False),
+    }.items():
+      put(name, data)
+    if outage:
+      put('carState', NS(vEgo=10, canValid=True, gearShifter='drive', steeringPressed=False, brakePressed=False, gasPressed=False))
+      messages[queues['carState'][-1]].logMonoTime += 10_000_000
+  class Poller:
+    def poll(self, timeout):
+      ticks[0] += 1
+      clock[0] += .2
+      if ticks[0] <= 2:
+        frame()
+      elif ticks[0] == 3:
+        queues['carState'].append(b'x' * (observer.MAX_EVENT_BYTES + 1))
+      elif ticks[0] == 4 and offroad:
+        put('deviceState', NS(started=False))
+      else:
+        handlers[observer.signal.SIGTERM]()
+      assert ticks[0] <= 5
+      return list(queues)
+  fake = types.ModuleType('cereal.messaging')
+  fake.Poller = Poller
+  fake.sub_sock = lambda name, **kwargs: QueuedSocket(name)
+  cereal = types.ModuleType('cereal')
+  cereal.messaging = fake
+  monkeypatch.setitem(sys.modules, 'cereal', cereal)
+  monkeypatch.setitem(sys.modules, 'cereal.messaging', fake)
+  path = tmp_path / 'stats.sqlite'
+  monkeypatch.setattr(store_module, 'DEFAULT_PATH', path)
+  original = observer.Checkpoints
+  def writer():
+    result = original(lambda: Store(path))
+    if outage:
+      monkeypatch.setattr(observer, 'MAX_CHECKPOINTS', 1)
+      def unavailable():
+        raise OSError('synthetic storage outage')
+      result.factory = unavailable
+      result.submit('earlier', 1, Reducer().snapshot(), complete=True)
+    writers.append(result)
+    return result
+  sleeps = [0]
+  def sleep(_):
+    sleeps[0] += 1
+    assert sleeps[0] <= 3
+    clock[0] += 31
+    writers[0].factory = lambda: Store(path)
+    if sleeps[0] == 3:
+      handlers[observer.signal.SIGTERM]()
+  monkeypatch.setattr(observer.time, 'sleep', sleep)
+  monkeypatch.setattr(observer, 'Checkpoints', writer)
+  monkeypatch.setattr(observer, 'decode_event', lambda raw: messages[raw])
+  monkeypatch.setattr(observer.time, 'monotonic', lambda: clock[0])
+  # receive's default captured the real monotonic at import time. Keep this
+  # synthetic main-loop scenario on one clock, including its receive budget.
+  receive = observer.BoundedEvents.receive
+  monkeypatch.setattr(observer.BoundedEvents, 'receive',
+                      lambda self, sockets, decode: receive(self, sockets, decode, clock=lambda: clock[0]))
+  monkeypatch.setattr(observer.os, 'nice', lambda _: None)
+  monkeypatch.setattr(observer.signal, 'signal', lambda sig, handler: handlers.update({sig: handler}))
+  observer.main()
+  store = Store(path)
+  if outage:
+    assert ticks[0] == 1  # saturation stopped polling/new collection, but not stop/retry checks
+    assert writers[0].suspended and not writers[0].pending
+    rows = store.db.execute('SELECT id, gaps, state FROM drives').fetchall()
+    assert len(rows) == 3  # prior snapshot + explicit loss marker + frozen active drive
+    active = next(json.loads(state) for drive_id, _, state in rows
+                  if drive_id != 'earlier' and not json.loads(state).get('coverageLoss'))
+    assert active['sequence'] == 3 and active['lastTime'] is not None and active['previous'] is None
+    assert read_stats(path)['coverageLoss']
+    assert read_stats(path)['models']['test']['stats']['assistedMeters'] == pytest.approx(.1)
+    store.close()
+    return
+  complete, gaps, state = store.db.execute('SELECT complete, gaps, state FROM drives').fetchone()
+  assert bool(complete) == offroad
+  assert gaps == 1 and json.loads(state)['previous'] is None
+  assert json.loads(state)['sequence'] == 3
+  assert read_stats(path)['models']['test']['stats']['incomplete']
+  store.close()
+
+
+def test_bounded_decoder_real_event_roundtrip():
+  from cereal import log
+  event = log.Event.new_message(logMonoTime=123, valid=True)
+  event.init('carState')
+  event.carState.vEgo = 10
+  event.carState.canValid = True
+  event.carState.gearShifter = 'drive'
+  decoded = observer.decode_event(event.to_bytes())
+  assert decoded.logMonoTime == 123 and decoded.valid
+  assert decoded.carState.vEgo == 10 and decoded.carState.gearShifter == 'drive'
+  event = log.Event.new_message(logMonoTime=456, valid=True)
+  event.init('starpilotModelV2')
+  event.starpilotModelV2.runtimeIdentity = OWNER
+  event.starpilotModelV2.modelMonoTime = 123
+  decoded = observer.decode_event(event.to_bytes())
+  assert decoded.starpilotModelV2.runtimeIdentity == OWNER
+  assert decoded.starpilotModelV2.modelMonoTime == 123

--- a/starpilot/system/tests/test_model_stats_loader.py
+++ b/starpilot/system/tests/test_model_stats_loader.py
@@ -1,0 +1,40 @@
+"""Exercise exact loader functions without starting modeld/hardware.
+Synthetic pickle and OOB artifacts only, with the real chunked reader.
+"""
+import ast
+import hashlib
+import io
+from pathlib import Path
+import pickle
+import shutil
+import struct
+import tempfile
+
+from openpilot.common.file_chunker import open_file_chunked
+from openpilot.starpilot.common.model_stats_identity import LoadedDigest, loaded_identity
+
+
+def test_actual_loader_legacy_and_oob_loaded_identity(tmp_path):
+  root = Path(__file__).resolve().parents[3]
+  namespace = dict(Path=Path, pickle=pickle, io=io, struct=struct, shutil=shutil, tempfile=tempfile,
+                   open_file_chunked=open_file_chunked, LoadedDigest=LoadedDigest, MAX_OOB_OPCODE_SIZE=1024**3)
+  for file, names in [('selfdrive/modeld/helpers.py', {'dump_oob', 'load_oob'}),
+                      ('selfdrive/modeld/modeld.py', {'_load_model_artifact', '_is_oob_artifact_header'})]:
+    tree = ast.parse((root / file).read_text())
+    selected = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in names]
+    assert len(selected) == len(names)
+    exec(compile(ast.Module(body=selected, type_ignores=[]), file, 'exec'), namespace)
+  for oob in [False, True]:
+    path = tmp_path / ('oob.pkl' if oob else 'legacy.pkl')
+    with path.open('wb') as stream:
+      if oob:
+        namespace['dump_oob']({'weights': pickle.PickleBuffer(b'synthetic weights')}, stream)
+      else:
+        pickle.dump({'weights': b'synthetic weights'}, stream)
+    identity = loaded_identity('actual-fallback', False)
+    loaded = namespace['_load_model_artifact'](path, identity)
+    assert bytes(loaded['weights']) == b'synthetic weights'
+    assert identity['modelId'] == 'actual-fallback'
+    assert identity['artifactVerified']
+    assert identity['artifact'] == 'loaded-sha256:' + hashlib.sha256(path.read_bytes()).hexdigest()
+    assert bytes(namespace['_load_model_artifact'](path)['weights']) == b'synthetic weights'

--- a/starpilot/system/tests/test_model_stats_recovery.py
+++ b/starpilot/system/tests/test_model_stats_recovery.py
@@ -1,0 +1,30 @@
+"""Synthetic storage faults; no daemon or real vehicle telemetry."""
+from openpilot.starpilot.common.model_stats import Reducer, Sample, parse_identity
+from openpilot.starpilot.system.model_statsd import Checkpoints
+import json
+
+
+def test_failed_final_checkpoint_retained_across_next_drive(tmp_path):
+  from openpilot.starpilot.common.model_stats_store import Store, read_stats
+  owner = parse_identity(json.dumps({'version': 1, 'roles': [{'modelId': 'test', 'artifact': 'test', 'backend': 'comma'}]}))
+  r = Reducer()
+  r.update(Sample(1, owner, 10, enabled=True, lat=True))
+  r.update(Sample(1.1, owner, 10, enabled=True, lat=True))
+  store = Store(tmp_path / 'stats.sqlite')
+  class Fault:
+    def checkpoint(self, *a, **kw):
+      raise OSError('synthetic full disk')
+    def close(self):
+      pass
+  writer = Checkpoints(lambda: store)
+  writer.store = Fault()
+  writer.submit('first', 100, r.snapshot(), complete=True)
+  assert not writer.flush(1)
+  assert 'first' in writer.pending
+  writer.submit('next', 200, Reducer().snapshot())
+  assert writer.flush(32)
+  assert not writer.pending
+  result = read_stats(tmp_path / 'stats.sqlite')
+  assert result['models']['test']['stats']['assistedMeters'] > .99
+  assert next(row for row in result['history'] if row['drive'] == 'first')['complete']
+  store.close()

--- a/starpilot/system/tests/test_model_stats_review.py
+++ b/starpilot/system/tests/test_model_stats_review.py
@@ -1,0 +1,83 @@
+"""SYNTHETIC fixtures, real candidate imports; no daemon, network or production DB.
+Tests assert desired behavior and intentionally fail when review defects reproduce.
+"""
+import importlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import types
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[3]
+OUT = Path(tempfile.mkdtemp(prefix='model-stats-review-'))
+import atexit, shutil
+atexit.register(shutil.rmtree, OUT)
+sys.dont_write_bytecode = True
+# Resolve openpilot namespace to this candidate without importing native conftest.
+pkg = types.ModuleType('openpilot')
+pkg.__path__ = [str(ROOT)]
+sys.modules['openpilot'] = pkg
+from openpilot.starpilot.system.model_statsd import Telemetry
+from openpilot.starpilot.common.model_stats import Reducer, parse_identity
+from openpilot.starpilot.common.model_stats_store import Store, read_stats
+from openpilot.starpilot.system.the_galaxy.model_stats_api import ModelStatsAPI
+from types import SimpleNamespace as NS
+
+OWNER = parse_identity(json.dumps({'version': 1, 'roles': [{'modelId': 'synthetic-a', 'artifact': 'synthetic.pkl', 'backend': 'synthetic'}]}))
+PAIR = parse_identity(json.dumps({'version': 1, 'roles': [{'modelId': m, 'artifact': 'synthetic.pkl', 'backend': 'synthetic'} for m in ['synthetic-a', 'synthetic-b']]}))
+
+def save(name, payload):
+    (OUT / (name + '.json')).write_text(json.dumps({'fixture': 'SYNTHETIC — not vehicle evidence', **payload}, indent=2) + '\n')
+
+def frame(tel, t, enabled=True, owner=OWNER, selfdrive=True, car=True):
+    stamp = round(t * 1e9)
+    fields = {'deviceState': NS(started=True), 'carControl': NS(latActive=enabled, longActive=enabled), 'starpilotCarState': NS(alwaysOnLateralEnabled=False), 'modelV2': NS(), 'starpilotModelV2': NS(modelMonoTime=stamp, runtimeIdentity=owner)}
+    if selfdrive:
+        fields['selfdriveState'] = NS(enabled=enabled)
+    for name, data in fields.items():
+        assert tel.feed(name, stamp, True, data) is None
+    if car:
+        return tel.feed('carState', stamp, True, NS(vEgo=10, canValid=True, gearShifter='drive', steeringPressed=False, brakePressed=False, gasPressed=False))
+
+def replay(delayed):
+    tel, reducer = Telemetry(), Reducer()
+    trace = []
+    for t, enabled, sd in [(1.0, True, True), (1.1, False, True), (1.15, False, False), (1.2, False, True)]:
+        if delayed and t == 1.15:
+            tel.feed('selfdriveState', 1_020_000_000, True, NS(enabled=True))
+        sample = frame(tel, t, enabled, selfdrive=sd)
+        reducer.update(sample)
+        trace.append({'carStateTime': t, 'cachedSelfdriveTime': tel.latest['selfdriveState'][0], 'sampleEnabled': sample.enabled, 'usable': sample.usable})
+    return {'trace': trace, 'snapshot': reducer.snapshot(), 'disengagements': sum(r['disengagements'] for r in reducer.metrics.values())}
+
+def test_delayed_selfdrive_does_not_duplicate_disengagement():
+    control, delayed = replay(False), replay(True)
+    save('delayed-selfdrive', {'control': control, 'delayed': delayed})
+    assert control['disengagements'] == 1
+    assert delayed['disengagements'] == 1
+
+def test_missing_carstate_does_not_keep_recording():
+    tel, reducer = Telemetry(), Reducer()
+    reducer.update(frame(tel, 1.0))
+    reducer.update(frame(tel, 1.1))
+    with tempfile.TemporaryDirectory(prefix='synthetic-heartbeat-', dir=OUT) as tmp:
+        db = Path(tmp) / 'stats.sqlite'
+        store = Store(db)
+        try:
+            store.checkpoint('synthetic-drive', 1000, reducer.snapshot(), now=1000)
+            with patch('openpilot.starpilot.common.model_stats_store.time.time', return_value=1031):
+                stale = read_stats(db)
+            # Main loop keeps checkpointing even with no new carState sample.
+            for t in (11.1, 21.1, 31.1):
+                assert frame(tel, t, car=False) is None
+                store.checkpoint('synthetic-drive', 1000, reducer.snapshot(), now=999 + t)
+            with patch('openpilot.starpilot.common.model_stats_store.time.time', return_value=1031):
+                heartbeat = read_stats(db)
+            save('missing-carstate', {'withoutHeartbeat': stale, 'withHeartbeat': heartbeat, 'lastSampleMonotonic': reducer.last_t, 'lastNonCarStateMonotonic': 31.1, 'sequence': reducer.sequence})
+        finally:
+            store.close()
+    assert stale['trackingStatus'] == 'inactive'
+    assert heartbeat['trackingStatus'] != 'recording'

--- a/starpilot/system/tests/test_model_stats_schema.py
+++ b/starpilot/system/tests/test_model_stats_schema.py
@@ -1,0 +1,13 @@
+"""Schema serialization only; not a native target build."""
+from pathlib import Path
+import capnp
+
+
+def test_runtime_provenance_schema_roundtrip():
+  schema = capnp.load(str(Path(__file__).resolve().parents[3] / 'cereal/custom.capnp'))
+  message = schema.StarPilotModelDataV2.new_message(runtimeIdentity='synthetic identity', modelMonoTime=123,
+                                                   turnDirection='none')
+  with schema.StarPilotModelDataV2.from_bytes(message.to_bytes()) as result:
+    assert result.runtimeIdentity == 'synthetic identity'
+    assert result.modelMonoTime == 123
+    assert str(result.turnDirection) == 'none'

--- a/starpilot/system/tests/test_model_stats_yield.py
+++ b/starpilot/system/tests/test_model_stats_yield.py
@@ -1,0 +1,71 @@
+"""Budget exhaustion must preserve brief pedal edges and bounded work."""
+from collections import deque
+from types import SimpleNamespace as NS
+from pathlib import Path
+import json
+import pytest
+from openpilot.starpilot.system import model_statsd as m
+from openpilot.starpilot.common.model_stats import Reducer
+from openpilot.starpilot.common.tests.test_model_stats import OWNER, sample
+
+class Socket:
+  def __init__(self, events):
+    self.events = deque(events)
+  def receive(self, non_blocking=True):
+    return self.events.popleft() if self.events else None
+
+def test_scheduling_pause_keeps_just_received_pedal_edge():
+  clock = [0.0]
+  events = {str(i).encode(): NS(logMonoTime=i, sample=sample(i / 100, brake=i == 2, enabled=i < 2)) for i in range(5)}
+  socket = Socket(events)
+  queue, reducer = m.BoundedEvents(), Reducer()
+  def decode(raw):
+    clock[0] += .03  # scheduling/decoding crossed the 5 ms cooperative deadline
+    return events[raw]
+  for _ in range(5):
+    assert not queue.receive({socket:'carState'}, decode, clock=lambda: clock[0])
+    assert len(queue.pending) == 1
+    reducer.update(queue.pop()[3].sample)
+  totals = {k:sum(r[k] for r in reducer.metrics.values()) for k in ('interventions','disengagements','brake')}
+  assert totals == {'interventions':1,'disengagements':1,'brake':1}
+  assert reducer.gaps == 0
+
+def test_many_ticks_resume_fairly_without_growth_or_loss():
+  total = 12000
+  socket = Socket(str(i).encode() for i in range(total))
+  queue = m.BoundedEvents()
+  seen = []
+  while socket.events:
+    assert not queue.receive({socket:'carState'}, lambda raw:NS(logMonoTime=int(raw)), clock=lambda:0)
+    assert len(queue.pending) <= m.MAX_TICK_MESSAGES
+    assert queue.bytes <= m.MAX_PENDING_BYTES
+    while queue.pending:
+      seen.append(queue.pop()[0])
+  assert seen == list(range(total))
+  assert queue.bytes == 0
+
+def test_byte_budget_yields_before_consuming_an_unretainable_event():
+  socket = Socket([b'x' * m.MAX_EVENT_BYTES] * 30)
+  queue = m.BoundedEvents()
+  assert not queue.receive({socket:'carState'},lambda raw:NS(logMonoTime=1),clock=lambda:0)
+  assert queue.yield_reason == 'byte_budget'
+  assert queue.bytes <= m.MAX_TICK_BYTES
+  assert len(socket.events) + len(queue.pending) == 30
+
+def test_route_read_is_bounded_validated_and_optional(tmp_path):
+  p = tmp_path/'CurrentRoute'
+  assert m.current_route(p) is None
+  p.write_text('0000013e--0520bd8368')
+  assert m.current_route(p) == '0000013e--0520bd8368'
+  for value in ('../wrong', 'x' * 10000, 'old route', ''):
+    p.write_text(value)
+    assert m.current_route(p) is None
+
+def test_diagnostics_separate_cpu_from_waiting():
+  d = m.Diagnostics()
+  d.timing('receive', .030, .001)
+  d.timing('receive', .002, .002)
+  state = d.snapshot(m.BoundedEvents())
+  assert state['receiveWallMs'] == 30
+  assert state['receiveCpuMs'] == 2
+  assert state['receiveWaitingMs'] == 29

--- a/starpilot/system/tests/test_model_statsd.py
+++ b/starpilot/system/tests/test_model_statsd.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace as NS
+
+from openpilot.starpilot.common.model_stats import Reducer
+from openpilot.starpilot.common.model_stats_identity import loaded_identity, output_identity, publish_identity
+from openpilot.starpilot.common.tests.test_model_stats import OWNER, totals
+from openpilot.starpilot.system.model_statsd import Telemetry
+
+
+def feed_state(telemetry, t=1, enabled=True, brake=False, accel_button=False, identity=OWNER):
+  ns = int(t * 1e9)
+  telemetry.feed('deviceState', ns, True, NS(started=True))
+  telemetry.feed('carControl', ns, True, NS(latActive=enabled, longActive=enabled))
+  telemetry.feed('selfdriveState', ns, True, NS(enabled=enabled))
+  telemetry.feed('starpilotCarState', ns, True, NS(alwaysOnLateralEnabled=False, accelPressed=accel_button))
+  telemetry.feed('modelV2', ns, True, NS())
+  telemetry.feed('starpilotModelV2', ns, True, NS(modelMonoTime=ns, runtimeIdentity=identity))
+  return telemetry.feed('carState', ns, True, NS(vEgo=10, canValid=True, gearShifter='drive',
+                                               steeringPressed=False, brakePressed=brake, gasPressed=False))
+
+
+def test_input_fixture_cruise_button_is_not_accelerator_and_brake_disables():
+  telemetry, reducer = Telemetry(), Reducer()
+  reducer.update(feed_state(telemetry))
+  reducer.update(feed_state(telemetry, 1.01, accel_button=True))
+  assert totals(reducer)['interventions'] == 0
+  reducer.update(feed_state(telemetry, 1.02, enabled=False, brake=True))
+  assert totals(reducer)['interventions'] == totals(reducer)['disengagements'] == 1
+  assert totals(reducer)['gas'] == 0
+
+
+def test_missing_delayed_mismatched_provenance_excluded():
+  t = Telemetry()
+  s = feed_state(t, identity='')
+  assert not s.usable
+  t.feed('starpilotModelV2', 1_010_000_000, True, NS(modelMonoTime=999_000_000, runtimeIdentity=OWNER))
+  assert not t.feed('carState', 1_010_000_000, True, NS(vEgo=10, canValid=True, gearShifter='drive',
+                    steeringPressed=False, brakePressed=False, gasPressed=False)).usable
+  assert feed_state(t, 1.02).usable
+  # Missing fresh carControl/selfdriveState must not become a disable.
+  assert not t.feed('carState', 2_000_000_000, True, NS()).usable
+
+
+def test_invalid_model_and_future_telemetry_rejected():
+  t = Telemetry()
+  feed_state(t)
+  t.feed('modelV2', 1_010_000_000, False, NS())
+  t.feed('starpilotModelV2', 1_010_000_000, True, NS(modelMonoTime=1_010_000_000, runtimeIdentity=OWNER))
+  assert not t.feed('carState', 1_020_000_000, True, NS(vEgo=10, canValid=True, gearShifter='drive',
+                    steeringPressed=False, brakePressed=False, gasPressed=False)).usable
+  t.feed('selfdriveState', 3_000_000_000, True, NS(enabled=False))
+  assert not t.feed('carState', 1_030_000_000, True, NS()).usable
+
+
+class Runner:
+  def __init__(self, model, external=False):
+    self.stats_identity = loaded_identity(model, external)
+
+
+def test_loaded_identity_fallback_pairs_restart_and_publication_failure():
+  fallback, external, long = Runner('rdf43'), Runner('selected-gpu', True), Runner('long', True)
+  assert json.loads(output_identity(fallback))['roles'][0]['modelId'] == 'rdf43'
+  assert json.loads(output_identity(external))['roles'][0]['backend'] == 'chestnut'
+  assert [r['modelId'] for r in json.loads(output_identity(external, long))['roles']] == ['selected-gpu', 'long']
+  assert output_identity(Runner('rdf43')) != output_identity(fallback)
+  target = NS(starpilotModelV2=NS())
+  publish_identity(target, NS(logMonoTime=123, valid=True), fallback)
+  assert target.valid
+  assert target.starpilotModelV2.modelMonoTime == 123
+  assert json.loads(target.starpilotModelV2.runtimeIdentity)['roles'][0]['modelId'] == 'rdf43'
+  publish_identity(object(), object(), fallback)  # old schema/instrumentation failure cannot raise
+
+
+def test_integration_is_optional_and_publication_only():
+  root = Path(__file__).resolve().parents[3]
+  manager = (root / 'system/manager/process_config.py').read_text()
+  controls = (root / 'selfdrive/selfdrived/selfdrived.py').read_text()
+  assert 'model_statsd' not in manager and 'model_statsd' not in controls
+  source = (root / 'selfdrive/modeld/modeld.py').read_text()
+  assert source.index("pm.send('modelV2', modelv2_send)") < source.index('publish_identity(starpilot_modelv2_send')
+  observer = (root / 'starpilot/system/model_statsd.py').read_text()
+  assert 'PubMaster(' not in observer and 'Params(' not in observer
+  assert 'conflate=False' in observer

--- a/starpilot/system/the_galaxy/model_stats_api.py
+++ b/starpilot/system/the_galaxy/model_stats_api.py
@@ -1,0 +1,63 @@
+"""Read-only Model Manager API. Failure leaves catalog/download controls usable."""
+import copy
+import threading
+import time
+
+from openpilot.starpilot.common.model_stats import empty_stats
+from openpilot.starpilot.common.model_stats_store import DEFAULT_PATH, read_stats
+
+
+class ModelStatsAPI:
+  def __init__(self, path=DEFAULT_PATH):
+    self.path = path
+    self.lock = threading.Lock()
+    self.cached = None
+    self.expires = 0
+
+  def summary(self):
+    with self.lock:
+      if self.cached is None or time.monotonic() >= self.expires:
+        self.cached = read_stats(self.path, history=False)
+        self.expires = time.monotonic() + 2
+      return copy.deepcopy(self.cached)
+
+  def annotate(self, models):
+    """Attach recorded statistics to catalogue dictionaries, without presentation or sizes."""
+    summary = self.summary()
+    for model in models:
+      key = model['value']
+      stored = summary['models'].get(key)
+      empty_status = 'ok' if summary['available'] else summary['status']
+      if summary['trackingStatus'] == 'telemetry_unavailable':
+        empty_status = 'telemetry_unavailable'
+      model['stats'] = stored['stats'] if stored else empty_stats(empty_status)
+      model['stats']['trackingStatus'] = summary['trackingStatus']
+      model['stats']['recordedSince'] = summary['recordedSince']
+      configurations = stored['configurations'] if stored else []
+      model['stats']['revisionStatus'] = ('verified_loaded_content' if configurations and
+                                         all(role.get('artifactVerified') for c in configurations for role in c['roles'])
+                                         else 'unverified_loaded_runs')
+      model['stats']['usedInPairs'] = any(key in pair['modelIds'] for pair in summary['pairs'])
+    return models
+
+
+def register_model_stats_api(app, path=DEFAULT_PATH):
+  from flask import jsonify, request
+  service = ModelStatsAPI(path)
+
+  @app.route('/api/models/stats', methods=['GET'])
+  def model_stats():
+    try:
+      if set(request.args) - {'model', 'mode', 'period', 'limit', 'offset'}:
+        raise ValueError('Unsupported statistics filter')
+      period = request.args.get('period', 'all')
+      model = request.args.get('model')
+      if model is not None and (not model or len(model) > 256):
+        raise ValueError('Invalid model ID')
+      payload = read_stats(service.path, model=model, mode=request.args.get('mode', 'all'), period=period,
+                           limit=int(request.args.get('limit', '50')), offset=int(request.args.get('offset', '0')))
+      return jsonify(payload)
+    except ValueError as error:
+      return jsonify({'error': str(error)}), 400
+
+  return service

--- a/starpilot/system/the_galaxy/tests/test_model_stats_api.py
+++ b/starpilot/system/the_galaxy/tests/test_model_stats_api.py
@@ -1,0 +1,78 @@
+import json
+
+from flask import Flask
+import pytest
+
+from openpilot.starpilot.common.tests.test_model_stats_store import recorded
+from openpilot.starpilot.system.the_galaxy.model_stats_api import ModelStatsAPI, register_model_stats_api
+
+
+def test_stats_endpoint_reads_persistent_totals_history_and_validation(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  app = Flask(__name__)
+  register_model_stats_api(app, path)
+  client = app.test_client()
+  response = client.get('/api/models/stats?model=rdf43&mode=full&limit=1')
+  assert response.status_code == 200
+  result = response.get_json()
+  assert result['available'] and result['definitionVersion'] == 2
+  assert result['models']['rdf43']['stats']['interventions'] == 1
+  assert len(result['history']) == 1
+  assert client.post('/api/models/stats').status_code == 405
+  for query in ['period=7d', 'mode=unknown', 'limit=201', 'offset=-1', 'limit=abc', 'reset=true', 'model=']:
+    assert client.get('/api/models/stats?' + query).status_code == 400
+
+
+def test_catalog_statistics_keep_unrecorded_models_available(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  models = [{'value': 'rdf43', 'builtin': True}, {'value': 'gpu', 'builtin': False}]
+  service = ModelStatsAPI(path)
+  result = service.annotate(models)
+  assert result[0]['stats']['assistedMeters'] == pytest.approx(10.1)
+  assert result[1]['stats']['available'] and result[1]['stats']['assistedMeters'] == 0
+  assert not result[1]['stats']['incomplete']
+  json.dumps(result, allow_nan=False)
+
+
+def test_missing_or_failed_store_does_not_break_catalog_or_create_history(tmp_path):
+  path = tmp_path / 'missing.sqlite'
+  service = ModelStatsAPI(path)
+  models = [{'value': 'rdf43', 'builtin': True}]
+  result = service.annotate(models)
+  assert not result[0]['stats']['available']
+  assert result[0]['stats']['status'] == 'not_started'
+  assert not path.exists()
+  path.write_bytes(b'bad sqlite')
+  service = ModelStatsAPI(path)
+  assert service.annotate(models)[0]['stats']['status'] == 'unavailable'
+
+
+def test_summary_cache_is_not_caller_mutable(tmp_path):
+  service = ModelStatsAPI(tmp_path / 'no-db')
+  summary = service.summary()
+  summary['models']['fake'] = {}
+  assert service.summary()['models'] == {}
+
+
+@pytest.mark.parametrize('offset', [2**63, 10**100])
+def test_oversized_history_offset_is_bad_request(tmp_path, offset):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  app = Flask(__name__)
+  app.config['TESTING'] = True
+  register_model_stats_api(app, path)
+  response = app.test_client().get(f'/api/models/stats?offset={offset}')
+  assert response.status_code == 400
+  assert 'offset' in response.get_json()['error']
+
+
+def test_largest_sqlite_history_offset_is_empty_page(tmp_path):
+  path = tmp_path / 'stats.sqlite'
+  recorded(path, complete=True)
+  app = Flask(__name__)
+  register_model_stats_api(app, path)
+  response = app.test_client().get(f'/api/models/stats?offset={2**63 - 1}')
+  assert response.status_code == 200
+  assert response.get_json()['history'] == []

--- a/starpilot/system/the_galaxy/tests/test_vehicle_snapshot_consumers.py
+++ b/starpilot/system/the_galaxy/tests/test_vehicle_snapshot_consumers.py
@@ -1,0 +1,38 @@
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+import pytest
+
+def helpers(snapshot):
+  source=Path('starpilot/system/the_galaxy/the_galaxy.py').read_text()
+  tree=ast.parse(source)
+  names={'_get_vehicle_parked','_build_vehicle_fault_status'}
+  nodes=[n for n in tree.body if isinstance(n,ast.FunctionDef) and n.name in names]
+  def forbidden(*args,**kwargs):
+    raise AssertionError('Galaxy must not allocate vehicle-data readers')
+  ns={'read_vehicle_snapshot':lambda:snapshot,'params':SimpleNamespace(get_bool=lambda k:True),
+      'messaging':SimpleNamespace(SubMaster=forbidden),'car':SimpleNamespace(CarState=SimpleNamespace(GearShifter=SimpleNamespace(park='park')))}
+  exec(compile(ast.fix_missing_locations(ast.Module(body=nodes,type_ignores=[])),'production_helpers','exec'),ns)
+  return ns
+
+def car_state(**changes):
+  return SimpleNamespace(gearShifter='park',accFaulted=False,steerFaultTemporary=False,
+                         steerFaultPermanent=False,canValid=True,cruiseState=SimpleNamespace(available=True,enabled=False),**changes)
+
+def test_repeated_settings_checks_use_snapshot_without_readers():
+  h=helpers(car_state())
+  for _ in range(100):assert h['_get_vehicle_parked']() is True
+
+def test_diagnostics_preserve_fault_details_without_readers():
+  state=car_state();state.accFaulted=True;state.steerFaultPermanent=True;state.canValid=False
+  result=helpers(state)['_build_vehicle_fault_status']()
+  assert result['available'] is True
+  assert result['summarySeverity']=='fault'
+  assert {x['label']:x['value'] for x in result['items']}=={'Cruise Fault':'Faulted','LKAS Fault':'Permanent','CAN Valid':'No','Cruise Available':'Yes','Cruise Engaged':'No'}
+
+@pytest.mark.parametrize('snapshot',[None,SimpleNamespace(gearShifter='drive')])
+def test_no_park_authorization_without_fresh_park(snapshot):
+  assert helpers(snapshot)['_get_vehicle_parked']() is False
+
+def test_missing_snapshot_keeps_diagnostics_unavailable():
+  assert helpers(None)['_build_vehicle_fault_status']()['available'] is False

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -41,6 +41,7 @@ from opendbc.car.gm.values import GMFlags
 from opendbc.car.toyota.carcontroller import LOCK_CMD, UNLOCK_CMD
 from opendbc.car.toyota.values import ToyotaStarPilotFlags
 from openpilot.common.constants import CV
+from openpilot.starpilot.common.vehicle_snapshot import read_vehicle_snapshot
 from openpilot.common.file_chunker import file_chunked_exists, get_chunk_name, get_manifest_path
 from openpilot.common.params import ParamKeyFlag, ParamKeyType, Params
 from openpilot.common.realtime import DT_HW
@@ -4178,6 +4179,7 @@ def _snapshot_bool_text(value):
     return "No"
   return "Unavailable"
 
+
 def _build_vehicle_fault_status():
   unavailable_items = [
     {"label": "Cruise Fault", "value": "Unavailable", "severity": "neutral"},
@@ -4195,10 +4197,8 @@ def _build_vehicle_fault_status():
     unavailable_severity = "warn"
 
   try:
-    sm = messaging.SubMaster(["carState"], poll="carState")
-    sm.update(100)
-    has_live_car_state = sm.seen["carState"] and sm.alive["carState"] and sm.valid["carState"]
-    if not has_live_car_state:
+    car_state = read_vehicle_snapshot()
+    if car_state is None:
       return {
         "available": False,
         "summary": unavailable_summary,
@@ -4206,7 +4206,6 @@ def _build_vehicle_fault_status():
         "items": unavailable_items,
       }
 
-    car_state = sm["carState"]
     cruise_state = getattr(car_state, "cruiseState", None)
 
     cruise_faulted = bool(getattr(car_state, "accFaulted", False))
@@ -4288,17 +4287,8 @@ def _get_has_radar():
     return False
 
 def _get_vehicle_parked():
-  try:
-    sm = messaging.SubMaster(["carState"], poll="carState")
-    sm.update(100)
-    if not sm.seen["carState"] or not sm.alive["carState"] or not sm.valid["carState"]:
-      return False
-
-    gear_shifter = getattr(getattr(car, "CarState", None), "GearShifter", None)
-    park_value = getattr(gear_shifter, "park", None)
-    return park_value is not None and getattr(sm["carState"], "gearShifter", None) == park_value
-  except Exception:
-    return False
+  state = read_vehicle_snapshot()
+  return state is not None and state.gearShifter == "park"
 
 def _get_longitudinal_mode_capable():
   # Do not authorize from a default or a stale toggle snapshot. Pending disable
@@ -5171,6 +5161,8 @@ class GalaxySlugMiddleware:
 
 
 def setup(app):
+  from openpilot.starpilot.system.the_galaxy.model_stats_api import register_model_stats_api
+  register_model_stats_api(app)
   if not isinstance(app.wsgi_app, GalaxySlugMiddleware):
     app.wsgi_app = GalaxySlugMiddleware(app.wsgi_app)
 
@@ -10404,6 +10396,12 @@ def main():
 
   # Desktop-only debug mode. On-device must stay on 8082 to match Galaxy FRP routing.
   on_device = _is_comma_device_runtime()
+  if on_device:
+    try:
+      from openpilot.starpilot.system.model_statsd import start_observer
+      start_observer()
+    except Exception as error:
+      print(f"Optional model statistics observer unavailable: {error}")
   debug = False if on_device else os.getenv("SP_GALAXY_DEBUG", "1").lower() in {"1", "true", "yes", "on"}
   port = 8082 if on_device else int(os.getenv("SP_GALAXY_PORT", "8083"))
   host = "0.0.0.0" if on_device else os.getenv("SP_GALAXY_HOST", "0.0.0.0")


### PR DESCRIPTION
Adds persistent recording of distance, engagement, interventions and disengagements, attributed to the loaded driving model, revision and backend. Runtime identity follows the model producing driving output.

Records retain their counting-policy version and coverage information across restarts. Retained-log recovery supports incomplete history while preserving original records and keeping incompatible measurement definitions separate.

The implementation uses a passive observer with bounded processing and recovery work, persistent storage and runtime-identity schema fields. Matching schema builds are required.

Galaxy's parked-status and vehicle-fault checks read an atomic RAM snapshot supplied by StarPilot's existing vehicle-data reader. Settings polling uses no additional carState subscribers, keeping those requests from exhausting the reader slots used by driving processes and the statistics observer.

The snapshot retains the source message timestamp and a 100 ms freshness limit. Missing, malformed, invalid or stale data cannot authorise parked-only settings. Cruise, steering and CAN fault details are retained, and snapshot write failures do not terminate the StarPilot process.

Validation: 123 focused tests and a native message/snapshot resource probe passed. Four broader regression failures were reproduced on unchanged Dom. Matching schema builds and full onroad resource/drive validation remain required; the local probe does not measure driving performance.