### PR TITLE
Add GPU telemetry to Galaxy and native performance metrics

### DIFF
--- a/cereal/log.capnp
+++ b/cereal/log.capnp
@@ -775,6 +775,13 @@ struct ChestnutState {
   supplyVoltage @8 :UInt16;  # mV
   supplyCurrent @9 :Int16;  # mA
   supplyFault @10 :Bool;
+  # Host monotonic time of the successful SMU temperature sample (not the
+  # faster cached-message publication). Zero means no external GPU sample.
+  tempSampleMonoTime @11 :UInt64;
+  # Physical VRAM unavailable to new allocations (allocated/cached + reserved).
+  memoryUsedBytes @12 :UInt64;
+  memoryTotalBytes @13 :UInt64;
+  memorySampleMonoTime @14 :UInt64;
 }
 
 struct RadarState @0x9a185389d6fdd05f {

--- a/selfdrive/modeld/modeld.py
+++ b/selfdrive/modeld/modeld.py
@@ -22,6 +22,7 @@ from cereal.messaging import PubMaster, SubMaster
 from cereal.services import SERVICE_LIST
 from msgq.visionipc import VisionIpcClient, VisionStreamType, VisionBuf
 from openpilot.common.swaglog import cloudlog
+from openpilot.starpilot.common.external_gpu_memory import allocated_vram
 from openpilot.common.params import Params
 from openpilot.common.filter_simple import FirstOrderFilter
 from openpilot.common.file_chunker import file_chunked_exists, open_file_chunked
@@ -272,6 +273,7 @@ class ChestnutState:
         metrics_buf = bytearray(smu.adev.vram.view(smu.driver_table_paddr, ctypes.sizeof(metrics_t))[:])
         metrics = metrics_t.from_buffer(metrics_buf).SmuMetrics
         self.metrics = {
+          "tempSampleMonoTime": time.monotonic_ns(),
           "tempC": metrics.AvgTemperature[smu.smu_mod.TEMP_HOTSPOT],
           "memoryTempC": metrics.AvgTemperature[smu.smu_mod.TEMP_MEM],
           "powerDrawW": metrics.AverageSocketPower,
@@ -286,6 +288,18 @@ class ChestnutState:
           cloudlog.exception("chestnut state read failed")
         self.valid = False
         self.metrics.clear()
+
+    # Optional accounting reads Python allocator state only; failure must not
+    # affect stock SMU/ASM diagnostics or their validity. Same 0.1 Hz cadence.
+    if self.big and "AMD" in Device._opened_devices and self.sends % 100 == 1:
+      self.memory_metrics = {}
+      memory = allocated_vram(Device["AMD"])
+      if memory is not None:
+        self.memory_metrics = {"memoryUsedBytes": memory[0], "memoryTotalBytes": memory[1],
+                               "memorySampleMonoTime": time.monotonic_ns()}
+    if self.big and "AMD" in Device._opened_devices:
+      for key, value in getattr(self, "memory_metrics", {}).items():
+        setattr(state, key, value)
 
     if self.big:
       for key, value in self.metrics.items():

--- a/selfdrive/ui/mici/onroad/augmented_road_view.py
+++ b/selfdrive/ui/mici/onroad/augmented_road_view.py
@@ -21,6 +21,7 @@ from openpilot.selfdrive.ui.mici.onroad.starpilot_status import (
 )
 from openpilot.selfdrive.ui.mici.onroad.cameraview import CameraView
 from openpilot.selfdrive.ui.onroad.starpilot.pip_sidecam import PipSideCamera
+from openpilot.selfdrive.ui.onroad.starpilot.developer_metrics import build_developer_metric_parts, external_gpu_temperature_metric, external_gpu_memory_metric, system_memory_total_gib
 from openpilot.selfdrive.ui.onroad.starpilot.pulse_glide import get_pulse_glide_border_color
 from openpilot.selfdrive.ui.onroad.starpilot.starpilot_border import get_traffic_border_colors
 from openpilot.selfdrive.ui.lib.starpilot_visuals import get_border_width
@@ -593,6 +594,8 @@ class AugmentedRoadView(CameraView):
     self._sidebar_widgets = MiciSidebarWidgets(self._confidence_ball)
     self._min_steer_speed_banner = MinSteerSpeedBanner()
     self._standstill_timer = StandstillTimerOverlay()
+    self._metrics_font = gui_app.font(FontWeight.MEDIUM)
+    self._memory_total_gib = system_memory_total_gib()
     self._favorite_slots = self._child(FavoriteSlotsOverlay())
     self._offroad_label = UnifiedLabel("start the car to\nuse openpilot", 54, FontWeight.DISPLAY,
                                        text_color=rl.Color(255, 255, 255, int(255 * 0.9)),
@@ -759,10 +762,14 @@ class AugmentedRoadView(CameraView):
 
     # Fade out bottom of overlays for looks
     rl.draw_texture_ex(self._fade_texture, rl.Vector2(self._content_rect.x, self._content_rect.y), 0.0, 1.0, rl.WHITE)
+    alert_to_render, not_animating_out = self._alert_renderer.will_render()
+
+    # Diagnostics are subordinate to alerts, navigation, HUD and previews.
+    # Keep them inside the camera scissor, never in the fixed sidebar/border.
+    if ui_state.started and draw_road_overlays and alert_to_render is None:
+      self._render_developer_metrics()
     if draw_hud_controls:
       self._hud_renderer.render_background()
-
-    alert_to_render, not_animating_out = self._alert_renderer.will_render()
 
     should_draw_dmoji = ui_state.is_onroad() and (
       is_driver_stream or camera_view_none or ((not in_reverse) and (not self._hud_renderer.drawing_top_icons()))
@@ -826,6 +833,72 @@ class AugmentedRoadView(CameraView):
     msg = messaging.new_message('uiDebug')
     msg.uiDebug.drawTimeMillis = (time.monotonic() - start_draw) * 1000
     self._pm.send('uiDebug', msg)
+
+  def _render_developer_metrics(self):
+    params = ui_state.ui_params
+    toggles = ui_state.starpilot_toggles
+    debug_mode = bool(toggles.get("debug_mode", params.get_bool("DebugMode")))
+    enabled = (bool(toggles.get("developer_ui", params.get_bool("DeveloperUI"))) and params.get_bool("DeveloperMetrics")) or debug_mode
+
+    def metric_enabled(toggle_key, param_key, debug_override=False):
+      if debug_mode and debug_override:
+        return True
+      return enabled and bool(toggles.get(toggle_key, params.get_bool(param_key)))
+
+    flags = dict(
+      show_cpu=metric_enabled("cpu_metrics", "ShowCPU", True),
+      show_gpu=metric_enabled("gpu_metrics", "ShowGPU"),
+      show_temp=metric_enabled("numerical_temp", "NumericalTemp", True),
+      show_memory=metric_enabled("memory_metrics", "ShowMemoryUsage", True),
+      show_fps=metric_enabled("show_fps", "FPSCounter", True),
+    )
+    if not any(flags.values()):
+      return
+
+    sm = ui_state.sm
+    # Do not present a missing/stale device message as a genuine 0% reading.
+    device = sm["deviceState"] if sm.valid.get("deviceState", False) and sm.alive.get("deviceState", False) else None
+    parts = build_developer_metric_parts(
+      **flags, fps=rl.get_fps(), min_fps=0, max_fps=0, avg_fps=0,
+      cpu_usage_percent=device.cpuUsagePercent if device else [],
+      cpu_temp_c=device.cpuTempC if device else [],
+      gpu_usage_percent=device.gpuUsagePercent if device else 0,
+      gpu_temp_c=device.gpuTempC if device else [],
+      max_temp_c=device.maxTempC if device else 0,
+      memory_usage_percent=device.memoryUsagePercent if device else 0,
+      memory_total_gib=self._memory_total_gib,
+    )
+    # MICI has a 536x240 canvas: show current FPS, not the big UI's history.
+    parts = [part for part in parts if not part.startswith(("Min:", "Max:", "Avg:"))]
+    if device is None:
+      parts = [part if part.startswith("FPS:") else part.split(":", 1)[0] + ": --" for part in parts]
+    if flags["show_gpu"]:
+      parts.append(external_gpu_temperature_metric(sm))
+      parts.append(external_gpu_memory_metric(sm))
+
+    # Leave room for the steering wheel/turn intent on the left and model
+    # source icon on the right. Fit whole metrics, never shrink to tiny text.
+    rect = self._content_rect
+    inset = max(14, self._get_border_width() + 6)
+    x = rect.x + max(96, inset)
+    width = rect.width - max(96, inset) - max(64, inset)
+    font_size, line_height, padding = 16, 20, 4
+    lines = []
+    for part in parts:
+      if measure_text_cached(self._metrics_font, part, font_size).x > width - 2 * padding:
+        return
+      candidate = f"{lines[-1]} | {part}" if lines else part
+      if lines and measure_text_cached(self._metrics_font, candidate, font_size).x <= width - 2 * padding:
+        lines[-1] = candidate
+      else:
+        lines.append(part)
+    height = len(lines) * line_height + 2 * padding
+    if not lines or height > min(108, rect.height - 2 * inset):
+      return
+    y = rect.y + rect.height - inset - height
+    rl.draw_rectangle_rec(rl.Rectangle(x, y, width, height), rl.Color(0, 0, 0, 185))
+    for index, line in enumerate(lines):
+      rl.draw_text_ex(self._metrics_font, line, rl.Vector2(x + padding, y + padding + index * line_height), font_size, 0, rl.WHITE)
 
   def _draw_border(self):
     border_size = self._get_border_width()

--- a/selfdrive/ui/onroad/starpilot/developer_metrics.py
+++ b/selfdrive/ui/onroad/starpilot/developer_metrics.py
@@ -1,0 +1,125 @@
+import math
+import os
+from starpilot.common.external_gpu_temperature import external_gpu_temperature
+from starpilot.common.external_gpu_memory import external_gpu_memory
+from collections.abc import Iterable
+from typing import Any
+
+
+def external_gpu_temperature_metric(sm, now_ns: int | None = None) -> str:
+  """Read only published Chestnut hotspot telemetry; never open the GPU.
+
+  SMU samples normally refresh every 10s; tolerate 5s scheduling margin.
+  Check sample age separately from the 10Hz cached envelope. Old publishers
+  without the sample timestamp deliberately display unavailable.
+  """
+  temperature, _ = external_gpu_temperature(sm, now_ns)
+  return "eGPU: --" if temperature is None else f"eGPU: {round(temperature)}°C"
+
+
+def external_gpu_memory_metric(sm, now_ns: int | None = None) -> str:
+  memory, _ = external_gpu_memory(sm, now_ns)
+  if memory is None:
+    return "eGPU RAM: --"
+  used, total = memory
+  return f"eGPU RAM: {used / 2**30:.1f}/{total / 2**30:.1f} GiB ({round(100 * used / total)}%)"
+
+
+def _finite_temperatures(values: Iterable[Any]) -> list[float]:
+  temperatures = []
+  for value in values:
+    try:
+      temperature = float(value)
+    except (OverflowError, TypeError, ValueError):
+      continue
+    if math.isfinite(temperature) and temperature > 0.0:
+      temperatures.append(temperature)
+  return temperatures
+
+
+def _usage_percent(value: Any) -> int:
+  try:
+    return max(0, min(100, int(value)))
+  except (OverflowError, TypeError, ValueError):
+    return 0
+
+
+def _rounded_metric(value: Any) -> str:
+  try:
+    number = float(value)
+  except (OverflowError, TypeError, ValueError):
+    return "--"
+  return str(round(number)) if math.isfinite(number) else "--"
+
+
+def _usage_with_temperature(label: str, usage_percent: int, temperatures_c: Iterable[Any]) -> str:
+  metric = f"{label}: {usage_percent}%"
+  temperatures = _finite_temperatures(temperatures_c)
+  if temperatures:
+    metric += f" / {round(max(temperatures))}°C"
+  return metric
+
+
+def system_memory_total_gib() -> float:
+  try:
+    total_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+  except (OSError, TypeError, ValueError):
+    return 0.0
+  total_gib = float(total_bytes) / (1024.0 ** 3)
+  return total_gib if math.isfinite(total_gib) and total_gib > 0.0 else 0.0
+
+
+def build_developer_metric_parts(
+  *,
+  show_fps: bool,
+  show_cpu: bool,
+  show_gpu: bool,
+  show_temp: bool,
+  show_memory: bool,
+  fps: float,
+  min_fps: float,
+  max_fps: float,
+  avg_fps: float,
+  cpu_usage_percent: Iterable[Any],
+  cpu_temp_c: Iterable[Any],
+  gpu_usage_percent: Any,
+  gpu_temp_c: Iterable[Any],
+  max_temp_c: Any,
+  memory_usage_percent: Any,
+  memory_total_gib: Any,
+) -> list[str]:
+  parts = []
+
+  if show_cpu:
+    cpu_values = [_usage_percent(value) for value in cpu_usage_percent]
+    cpu_usage = int(sum(cpu_values) / len(cpu_values)) if cpu_values else 0
+    parts.append(_usage_with_temperature("CPU", cpu_usage, cpu_temp_c))
+
+  if show_gpu:
+    parts.append(_usage_with_temperature("GPU", _usage_percent(gpu_usage_percent), gpu_temp_c))
+
+  if show_temp:
+    temperatures = _finite_temperatures([max_temp_c])
+    parts.append(f"TEMP: {round(temperatures[0])}°C" if temperatures else "TEMP: --")
+
+  if show_memory:
+    memory_usage = _usage_percent(memory_usage_percent)
+    try:
+      total_gib = float(memory_total_gib)
+    except (OverflowError, TypeError, ValueError):
+      total_gib = 0.0
+    if math.isfinite(total_gib) and total_gib > 0.0:
+      memory_used_gib = total_gib * memory_usage / 100.0
+      parts.append(f"RAM: {memory_used_gib:.1f}/{total_gib:.1f} GiB ({memory_usage}%)")
+    else:
+      parts.append(f"RAM: {memory_usage}%")
+
+  if show_fps:
+    parts += [
+      f"FPS: {_rounded_metric(fps)}",
+      f"Min: {_rounded_metric(min_fps)}",
+      f"Max: {_rounded_metric(max_fps)}",
+      f"Avg: {_rounded_metric(avg_fps)}",
+    ]
+
+  return parts

--- a/selfdrive/ui/onroad/starpilot/starpilot_onroad_view.py
+++ b/selfdrive/ui/onroad/starpilot/starpilot_onroad_view.py
@@ -1,3 +1,5 @@
+import math
+
 import pyray as rl
 from msgq.visionipc import VisionStreamType
 from openpilot.selfdrive.ui.onroad.augmented_road_view import AugmentedRoadView
@@ -18,6 +20,7 @@ from openpilot.selfdrive.ui.onroad.starpilot.pulse_glide import get_pulse_glide_
 from openpilot.selfdrive.ui.onroad.starpilot.pip_sidecam import PipSideCamera
 from openpilot.selfdrive.ui.onroad.starpilot.favorite_radial_menu import FavoriteRadialMenu
 from openpilot.selfdrive.ui.onroad.starpilot.weather_icon import render_weather_icon
+from openpilot.selfdrive.ui.onroad.starpilot.developer_metrics import build_developer_metric_parts, external_gpu_temperature_metric, external_gpu_memory_metric, system_memory_total_gib
 from openpilot.selfdrive.ui.lib.starpilot_status import (
   get_screen_edge_color,
 )
@@ -47,6 +50,7 @@ class StarPilotOnroadView(AugmentedRoadView):
     self._min_fps = 99.9
     self._max_fps = 0.0
     self._avg_fps = 0.0
+    self._memory_total_gib = system_memory_total_gib()
 
     self._pip_sidecam = self._child(PipSideCamera())
     self._favorite_radial_menu = FavoriteRadialMenu(
@@ -280,7 +284,7 @@ class StarPilotOnroadView(AugmentedRoadView):
     # Track FPS
     fps = rl.get_fps()
 
-    if fps > 0:
+    if math.isfinite(fps) and fps > 0:
       self._min_fps = min(self._min_fps, fps)
       self._max_fps = max(self._max_fps, fps)
       alpha = 1.0 / (60.0 * 5.0)
@@ -290,19 +294,21 @@ class StarPilotOnroadView(AugmentedRoadView):
         self._avg_fps = alpha * fps + (1.0 - alpha) * self._avg_fps
 
     # Gather device stats
-    device_state = ui_state.sm["deviceState"] if ui_state.sm.valid.get("deviceState", False) else None
-    cpu_val = 0
-    gpu_val = 0
-    temp_val = 0
-    mem_val = 0
-    mem_gb = 0.0
+    sm = ui_state.sm
+    device_state = sm["deviceState"] if sm.valid.get("deviceState", False) and sm.alive.get("deviceState", False) else None
+    cpu_usage = []
+    cpu_temps = []
+    gpu_usage = 0
+    gpu_temps = []
+    max_temp = 0.0
+    memory_usage = 0
     if device_state:
-      cpu_list = list(device_state.cpuUsagePercent)
-      cpu_val = int(sum(cpu_list) / len(cpu_list)) if cpu_list else 0
-      gpu_val = int(device_state.gpuUsagePercent)
-      temp_val = int(device_state.maxTempC)
-      mem_val = int(device_state.memoryUsagePercent)
-      mem_gb = 8.0 * mem_val / 100.0
+      cpu_usage = list(device_state.cpuUsagePercent)
+      cpu_temps = list(device_state.cpuTempC)
+      gpu_usage = device_state.gpuUsagePercent
+      gpu_temps = list(device_state.gpuTempC)
+      max_temp = device_state.maxTempC
+      memory_usage = device_state.memoryUsagePercent
 
     font = self._font_medium
     font_size = 24
@@ -315,25 +321,47 @@ class StarPilotOnroadView(AugmentedRoadView):
       rl.draw_text_ex(font, text, rl.Vector2(pos.x + 1, pos.y + 1), font_size, 0, rl.BLACK)
       rl.draw_text_ex(font, text, pos, font_size, 0, color)
 
-    parts = []
-    if show_cpu:
-      parts.append(f"CPU: {cpu_val}%")
-    if show_gpu:
-      parts.append(f"GPU: {gpu_val}%")
-    if show_temp:
-      parts.append(f"TEMP: {temp_val}°C")
-    if show_memory:
-      parts.append(f"RAM: {mem_gb:.1f} GB ({mem_val}%)")
-    if show_fps:
-      parts += [f"FPS: {round(fps)}", f"Min: {round(self._min_fps)}",
-                f"Max: {round(self._max_fps)}", f"Avg: {round(self._avg_fps)}"]
+    parts = build_developer_metric_parts(
+      show_fps=show_fps,
+      show_cpu=show_cpu,
+      show_gpu=show_gpu,
+      show_temp=show_temp,
+      show_memory=show_memory,
+      fps=fps,
+      min_fps=self._min_fps,
+      max_fps=self._max_fps,
+      avg_fps=self._avg_fps,
+      cpu_usage_percent=cpu_usage,
+      cpu_temp_c=cpu_temps,
+      gpu_usage_percent=gpu_usage,
+      gpu_temp_c=gpu_temps,
+      max_temp_c=max_temp,
+      memory_usage_percent=memory_usage,
+      memory_total_gib=self._memory_total_gib,
+    )
 
-    line = " | ".join(parts)
-    sz = measure_text_cached(font, line, font_size)
-    bx = self._content_rect.x + (self._content_rect.width - sz.x) / 2
+    if device_state is None:
+      # FPS comes from the renderer; device metrics require a live sample.
+      parts = [part if part.startswith(("FPS:", "Min:", "Max:", "Avg:")) else part.split(":", 1)[0] + ": --" for part in parts]
+
+    if show_gpu:
+      parts.append(external_gpu_temperature_metric(ui_state.sm))
+      parts.append(external_gpu_memory_metric(ui_state.sm))
+    lines = []
+    available_width = self._content_rect.width - 24
+    for part in parts:
+      candidate = f"{lines[-1]} | {part}" if lines else part
+      if lines and measure_text_cached(font, candidate, font_size).x <= available_width:
+        lines[-1] = candidate
+      else:
+        lines.append(part)
     border_width = self._get_border_width()
-    by = self._content_rect.y + self._content_rect.height + (border_width - sz.y) // 2
-    draw_text_with_outline(line, bx, by, rl.WHITE)
+    for index, line in enumerate(lines):
+      sz = measure_text_cached(font, line, font_size)
+      bx = self._content_rect.x + (self._content_rect.width - sz.x) / 2
+      by = self._content_rect.y + self._content_rect.height + (border_width - sz.y) // 2
+      by -= (len(lines) - index - 1) * (font_size + 4)
+      draw_text_with_outline(line, bx, by, rl.WHITE)
 
 
   def _render_bottom_row_widgets(self):

--- a/selfdrive/ui/tests/test_developer_metrics.py
+++ b/selfdrive/ui/tests/test_developer_metrics.py
@@ -1,0 +1,337 @@
+import ast
+import math
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+
+from openpilot.selfdrive.ui.onroad.starpilot.developer_metrics import build_developer_metric_parts, external_gpu_temperature_metric, external_gpu_memory_metric
+
+
+ONROAD_VIEW = Path("selfdrive/ui/onroad/starpilot/starpilot_onroad_view.py")
+
+
+def test_comma4_developer_metrics_use_published_temperatures_and_real_memory_capacity():
+  parts = build_developer_metric_parts(
+    show_fps=True,
+    show_cpu=True,
+    show_gpu=True,
+    show_temp=True,
+    show_memory=True,
+    fps=20.4,
+    min_fps=18.2,
+    max_fps=21.1,
+    avg_fps=19.8,
+    cpu_usage_percent=[20, 24, 2, 44, 0, 0, 0, 0],
+    cpu_temp_c=[58.4, 58.4, 58.8, 59.4, 57.8, 58.1, 57.8, 58.1],
+    gpu_usage_percent=0,
+    gpu_temp_c=[57.1, 57.8],
+    max_temp_c=59.5,
+    memory_usage_percent=32,
+    memory_total_gib=3.52,
+  )
+
+  assert parts == [
+    "CPU: 11% / 59°C",
+    "GPU: 0% / 58°C",
+    "TEMP: 60°C",
+    "RAM: 1.1/3.5 GiB (32%)",
+    "FPS: 20",
+    "Min: 18",
+    "Max: 21",
+    "Avg: 20",
+  ]
+
+
+def test_onroad_view_uses_the_device_agnostic_metric_formatter():
+  source = ONROAD_VIEW.read_text()
+
+  assert "self._memory_total_gib = system_memory_total_gib()" in source
+  assert "cpu_temps = list(device_state.cpuTempC)" in source
+  assert "gpu_temps = list(device_state.gpuTempC)" in source
+  assert "parts = build_developer_metric_parts(" in source
+  assert "if math.isfinite(fps) and fps > 0:" in source
+  assert "int(device_state.gpuUsagePercent)" not in source
+  assert "int(device_state.memoryUsagePercent)" not in source
+  assert "float(device_state.maxTempC)" not in source
+  assert "mem_gb = 8.0 * mem_val / 100.0" not in source
+
+
+def test_nonfinite_usage_values_fall_back_without_crashing_the_ui():
+  parts = build_developer_metric_parts(
+    show_fps=True,
+    show_cpu=True,
+    show_gpu=True,
+    show_temp=True,
+    show_memory=True,
+    fps=math.inf,
+    min_fps=-math.inf,
+    max_fps=math.nan,
+    avg_fps=math.inf,
+    cpu_usage_percent=cast(list[int], [math.inf, -math.inf, math.nan]),
+    cpu_temp_c=[],
+    gpu_usage_percent=cast(int, math.inf),
+    gpu_temp_c=[],
+    max_temp_c=math.nan,
+    memory_usage_percent=cast(int, math.nan),
+    memory_total_gib=math.inf,
+  )
+
+  assert parts == [
+    "CPU: 0%",
+    "GPU: 0%",
+    "TEMP: --",
+    "RAM: 0%",
+    "FPS: --",
+    "Min: --",
+    "Max: --",
+    "Avg: --",
+  ]
+
+
+@pytest.fixture
+def mici_metrics_view():
+  """Exercise actual MICI render/metrics bodies without target-only native imports."""
+  source_path = Path("selfdrive/ui/mici/onroad/augmented_road_view.py")
+  source = ast.parse(source_path.read_text())
+  view_class = next(node for node in source.body if isinstance(node, ast.ClassDef) and node.name == "AugmentedRoadView")
+  methods: list[ast.stmt] = [node for node in view_class.body if isinstance(node, ast.FunctionDef) and node.name in {"_render", "_render_developer_metrics"}]
+
+  class CameraView:
+    def _render(self, _rect):
+      pass
+
+  def rectangle(x, y, width, height):
+    return SimpleNamespace(x=x, y=y, width=width, height=height)
+
+  draw_text = Mock()
+  raylib = Mock()
+  raylib.Rectangle = rectangle
+  raylib.Vector2 = lambda x, y: SimpleNamespace(x=x, y=y)
+  raylib.draw_text_ex = draw_text
+  raylib.get_fps.return_value = 20
+  enabled_params = {"DeveloperUI", "DeveloperMetrics", "ShowGPU"}
+  params = SimpleNamespace(get_bool=lambda key, **_kwargs: key in enabled_params)
+
+  class SubMaster(dict):
+    valid = {"deviceState": True}
+    alive = {"deviceState": True}
+
+  sm = SubMaster(deviceState=SimpleNamespace(
+    cpuUsagePercent=[20, 24, 2, 44, 0, 0, 0, 0], cpuTempC=[58.4, 59.4],
+    gpuUsagePercent=0, gpuTempC=[57.1, 57.8], maxTempC=59.5, memoryUsagePercent=32,
+  ))
+  state = SimpleNamespace(
+    started=True, is_onroad=lambda: True, sm=sm, ui_params=params,
+    starpilot_toggles={"developer_ui": True, "debug_mode": False, "gpu_metrics": True},
+  )
+  # Use shipped Inter glyph advances and MICI FONT_SCALE, not guessed widths.
+  font_lines = Path("selfdrive/assets/fonts/Inter-Medium.fnt").read_text().splitlines()
+  advances = {}
+  for line in font_lines:
+    if line.startswith("char id="):
+      fields = dict(re.findall(r"(\w+)=(-?\d+)", line))
+      advances[int(fields["id"])] = int(fields["xadvance"])
+
+  def measure_text(_font, text, size):
+    return SimpleNamespace(x=sum(advances.get(ord(char), advances[63]) for char in text) * size * 1.16 / 200)
+
+  namespace = {
+    "CameraView": CameraView, "rl": raylib, "ui_state": state,
+    "time": SimpleNamespace(monotonic=lambda: 1.0), "gui_app": Mock(),
+    "messaging": Mock(), "SIDE_PANEL_WIDTH": 60,
+    "CAMERA_VIEW_NONE": 4, "DRIVER_CAM": 2,
+    "build_developer_metric_parts": build_developer_metric_parts,
+    "external_gpu_temperature_metric": external_gpu_temperature_metric,
+    "external_gpu_memory_metric": external_gpu_memory_metric,
+    "measure_text_cached": measure_text,
+  }
+  # Compile the production methods unchanged. Mock only unrelated camera,
+  # widget and graphics boundaries, not the metrics dispatch under test.
+  isolated_class = ast.ClassDef(
+    name="AugmentedRoadView", bases=[ast.Name(id="CameraView", ctx=ast.Load())],
+    keywords=[], body=methods, decorator_list=[],
+  )
+  tree = ast.fix_missing_locations(ast.Module(body=[isolated_class], type_ignores=[]))
+  exec(compile(tree, str(source_path), "exec"), namespace)
+  view = namespace["AugmentedRoadView"]()
+  view.rect = view._rect = rectangle(0, 0, 536, 240)
+  view.stream_type = 0
+  view._camera_view = lambda: 2
+  view._controls_ready = lambda: True
+  view._is_in_reverse = lambda: False
+  view._get_border_width = lambda: 8
+  for name in (
+    "_switch_stream_if_needed", "_update_calibration", "_hud_renderer",
+    "_model_renderer", "_driver_state_renderer", "_standstill_timer",
+    "_min_steer_speed_banner", "_sidebar_widgets", "_confidence_ball",
+    "_favorite_slots", "_pip_sidecam", "_draw_border", "_bookmark_icon", "_pm",
+  ):
+    setattr(view, name, Mock())
+  view._alert_renderer = SimpleNamespace(will_render=lambda: (None, True), render=Mock())
+  view._fade_texture = object()
+  view._offroad_label = Mock()
+  view._metrics_font = object()
+  view._memory_total_gib = 3.52
+  return SimpleNamespace(view=view, state=state, raylib=raylib, params=enabled_params, measure_text=measure_text)
+
+
+def test_comma4_onroad_render_emits_enabled_gpu_metric(mici_metrics_view):
+  fixture = mici_metrics_view
+  fixture.view._render(fixture.view.rect)
+  texts = [call.args[1] for call in fixture.raylib.draw_text_ex.call_args_list]
+  assert " | ".join(texts) == "GPU: 0% / 58°C | eGPU: -- | eGPU RAM: --", "Enabled GPU metrics were never drawn by MICI on-road renderer"
+
+
+@pytest.mark.parametrize("gate", ["DeveloperUI", "DeveloperMetrics", "ShowGPU", "resolved_gpu", "resolved_ui"])
+def test_mici_metrics_respect_master_and_individual_toggles(mici_metrics_view, gate):
+  f = mici_metrics_view
+  if gate.startswith("resolved_"):
+    f.state.starpilot_toggles["gpu_metrics" if gate == "resolved_gpu" else "developer_ui"] = False
+  else:
+    f.state.starpilot_toggles.clear()
+    f.params.remove(gate)
+  f.view._render(f.view.rect)
+  f.raylib.draw_text_ex.assert_not_called()
+
+
+@pytest.mark.parametrize("mode", ["alert", "alert_fading", "offroad", "waiting", "reverse", "driver", "camera_none"])
+def test_mici_metrics_yield_to_alerts_and_nonroad_views(mici_metrics_view, mode):
+  f = mici_metrics_view
+  if mode in {"alert", "alert_fading"}:
+    f.view._alert_renderer.will_render = lambda: (SimpleNamespace(visual_alert=0), mode == "alert")
+    f.view._render.__globals__["car"] = Mock()
+  elif mode == "offroad":
+    f.state.started = False
+  elif mode == "waiting":
+    f.view._controls_ready = lambda: False
+  elif mode == "reverse":
+    f.view._is_in_reverse = lambda: True
+  elif mode == "driver":
+    f.view.stream_type = 2
+  else:
+    f.view._camera_view = lambda: 4
+  f.view._render(f.view.rect)
+  f.raylib.draw_text_ex.assert_not_called()
+
+
+@pytest.mark.parametrize("status", ["valid", "alive"])
+def test_mici_missing_or_stale_device_metrics_are_unavailable(mici_metrics_view, status):
+  f = mici_metrics_view
+  getattr(f.state.sm, status)["deviceState"] = False
+  f.view._render(f.view.rect)
+  assert " | ".join(call.args[1] for call in f.raylib.draw_text_ex.call_args_list) == "GPU: -- | eGPU: -- | eGPU RAM: --"
+
+
+@pytest.mark.parametrize("border", [0, 8, 24])
+def test_mici_all_metrics_fit_readably_inside_camera_bounds(mici_metrics_view, border):
+  f = mici_metrics_view
+  f.state.starpilot_toggles.clear()
+  f.params.update({"ShowCPU", "NumericalTemp", "ShowMemoryUsage", "FPSCounter"})
+  f.view._get_border_width = lambda: border
+  f.view.rect.x, f.view.rect.y = 30, 12
+  f.view._render(f.view.rect)
+  calls = f.raylib.draw_text_ex.call_args_list
+  text = " | ".join(call.args[1] for call in calls)
+  for metric in ["CPU: 11% / 59°C", "GPU: 0% / 58°C", "TEMP: 60°C", "RAM: 1.1/3.5 GiB (32%)", "FPS: 20"]:
+    assert metric in text
+  assert "Min:" not in text
+  panel = f.raylib.draw_rectangle_rec.call_args.args[0]
+  content = f.view._content_rect
+  assert panel.x >= content.x + max(border, 96)
+  assert panel.x + panel.width <= content.x + content.width - max(border, 64)
+  assert panel.y >= content.y + border
+  assert panel.y + panel.height <= content.y + content.height - border
+  for call in calls:
+    font, line, pos, size = call.args[:4]
+    assert size >= 16
+    assert panel.x <= pos.x < pos.x + f.measure_text(font, line, size).x <= panel.x + panel.width
+    assert panel.y <= pos.y < pos.y + size * 1.16 <= panel.y + panel.height
+
+
+def test_mici_debug_mode_preserves_existing_overrides(mici_metrics_view):
+  f = mici_metrics_view
+  f.params.clear()
+  f.state.starpilot_toggles = {"debug_mode": True, "gpu_metrics": False}
+  f.view._render(f.view.rect)
+  text = " | ".join(call.args[1] for call in f.raylib.draw_text_ex.call_args_list)
+  for metric in ["CPU:", "TEMP:", "RAM:", "FPS:"]:
+    assert metric in text
+  assert "GPU:" not in text
+
+
+def test_mici_metrics_are_drawn_below_safety_hud_and_previews(mici_metrics_view):
+  f = mici_metrics_view
+  order = Mock()
+  order.attach_mock(f.raylib.draw_text_ex, "metrics")
+  order.attach_mock(f.view._hud_renderer.render_background, "navigation")
+  order.attach_mock(f.view._hud_renderer.render_foreground, "hud")
+  order.attach_mock(f.view._pip_sidecam.render, "preview")
+  f.view._render(f.view.rect)
+  names = [call[0] for call in order.mock_calls]
+  assert names.index("metrics") < names.index("navigation") < names.index("hud") < names.index("preview")
+
+
+def test_comma4_selects_mici_metrics_renderer_and_initialises_resources():
+  app = ast.parse(Path("system/ui/lib/application.py").read_text())
+  cls = next(node for node in app.body if isinstance(node, ast.ClassDef) and node.name == "GuiApplication")
+  method = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "big_ui")
+  method.decorator_list = []
+  namespace = {"HARDWARE": SimpleNamespace(get_device_type=lambda: "mici"), "BIG_UI": False}
+  exec(compile(ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[])), "application.py", "exec"), namespace)
+  assert namespace["big_ui"]() is False
+  assert "from openpilot.selfdrive.ui.mici.layouts.main import MiciMainLayout" in Path("selfdrive/ui/ui.py").read_text()
+  main = Path("selfdrive/ui/mici/layouts/main.py").read_text()
+  assert "from openpilot.selfdrive.ui.mici.onroad.augmented_road_view import AugmentedRoadView" in main
+  assert "self._onroad_layout = AugmentedRoadView(" in main
+  view = ast.parse(Path("selfdrive/ui/mici/onroad/augmented_road_view.py").read_text())
+  cls = next(node for node in view.body if isinstance(node, ast.ClassDef) and node.name == "AugmentedRoadView")
+  init = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "__init__")
+  source = ast.unparse(init)
+  assert "self._memory_total_gib = system_memory_total_gib()" in source
+  assert "self._metrics_font = gui_app.font(FontWeight.MEDIUM)" in source
+
+
+@pytest.mark.parametrize("status", ["fresh", "invalid", "stale"])
+def test_large_native_view_expires_device_metrics_but_preserves_fps(status):
+  """Run the comma 3/3X rendering method with live, invalid and expired telemetry."""
+  cls = next(node for node in ast.parse(ONROAD_VIEW.read_text()).body
+             if isinstance(node, ast.ClassDef) and node.name == "StarPilotOnroadView")
+  method = next(node for node in cls.body if isinstance(node, ast.FunctionDef)
+                and node.name == "_render_developer_metrics")
+
+  class Snapshot(dict):
+    pass
+
+  sm = Snapshot(deviceState=SimpleNamespace(cpuUsagePercent=[20, 40], cpuTempC=[58, 60],
+                gpuUsagePercent=12, gpuTempC=[55], maxTempC=60, memoryUsagePercent=25))
+  sm.valid = {"deviceState": status != "invalid"}
+  sm.alive = {"deviceState": status != "stale"}
+  sm.logMonoTime = {}
+  raylib = Mock()
+  raylib.get_fps.return_value = 20
+  raylib.Vector2 = lambda x, y: SimpleNamespace(x=x, y=y)
+  scope = {"math": math, "rl": raylib,
+           "ui_state": SimpleNamespace(sm=sm, starpilot_toggles={}),
+           "build_developer_metric_parts": build_developer_metric_parts,
+           "external_gpu_temperature_metric": external_gpu_temperature_metric,
+           "external_gpu_memory_metric": external_gpu_memory_metric,
+           "measure_text_cached": lambda font, text, size: SimpleNamespace(x=len(text)*12, y=26)}
+  exec(compile(ast.Module(body=[method], type_ignores=[]), str(ONROAD_VIEW), "exec"), scope)
+  params = {"DeveloperUI", "DeveloperMetrics", "ShowCPU", "ShowGPU", "ShowMemoryUsage", "NumericalTemp", "FPSCounter"}
+  view = SimpleNamespace(_params=SimpleNamespace(get_bool=lambda key: key in params),
+                         _min_fps=18, _max_fps=22, _avg_fps=20, _memory_total_gib=8,
+                         _font_medium=object(), _content_rect=SimpleNamespace(x=0, y=0, width=2000, height=1000),
+                         _get_border_width=lambda: 32)
+  scope["_render_developer_metrics"](view)
+  text = " | ".join(call.args[1] for call in raylib.draw_text_ex.call_args_list if call.args[-1] is raylib.WHITE)
+  for metric in ("FPS: 20", "Min: 18", "Max: 22", "Avg: 20"):
+    assert metric in text
+  expected = ("CPU: 30% / 60°C", "GPU: 12% / 55°C", "TEMP: 60°C", "RAM: 2.0/8.0 GiB (25%)") if status == "fresh" else ("CPU: --", "GPU: --", "TEMP: --", "RAM: --")
+  for metric in expected:
+    assert metric in text
+  if status != "fresh":
+    assert "°C" not in text and "%" not in text and "GiB" not in text

--- a/selfdrive/ui/tests/test_external_gpu_memory.py
+++ b/selfdrive/ui/tests/test_external_gpu_memory.py
@@ -1,0 +1,154 @@
+"""VRAM accounting and additive telemetry regression tests, with no GPU access."""
+import ast
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace as NS
+
+import pytest
+from cereal import log
+from tinygrad.runtime.support.memory import TLSFAllocator
+from starpilot.common.external_gpu_memory import allocated_vram, external_gpu_memory
+from openpilot.selfdrive.ui.onroad.starpilot.developer_metrics import external_gpu_memory_metric
+from openpilot.selfdrive.ui.tests.test_external_gpu_temperature import snapshot, NOW, publisher  # noqa: F401
+
+
+def driver():
+  mm = NS(boot_allocator=TLSFAllocator(16 << 20), ptable_allocator=TLSFAllocator(0), pa_allocator=TLSFAllocator(960 << 20))
+  return NS(iface=NS(dev_impl=NS(vram_size=1024 << 20, mm=mm)))
+
+
+def test_physical_allocator_alloc_free_and_reserved():
+  d = driver()
+  before = allocated_vram(d)
+  assert before == (48 << 20, 1024 << 20)
+  pool = d.iface.dev_impl.mm.pa_allocator
+  a = pool.alloc(120 << 20)
+  assert allocated_vram(d) == (168 << 20, 1024 << 20)
+  pool.free(a)
+  assert allocated_vram(d) == before
+  boot = d.iface.dev_impl.mm.boot_allocator
+  boot.alloc(4096)
+  assert allocated_vram(d)[0] == before[0] + 4096
+
+
+@pytest.mark.parametrize('failure', ['missing', 'negative', 'inconsistent', 'overfull', 'race'])
+def test_bad_accounting_is_unavailable(failure):
+  d = driver()
+  if failure == 'missing':
+    del d.iface.dev_impl.mm
+  elif failure == 'negative':
+    d.iface.dev_impl.vram_size = -1
+  elif failure == 'inconsistent':
+    d.iface.dev_impl.mm.pa_allocator.blocks.clear()
+  elif failure == 'overfull':
+    d.iface.dev_impl.vram_size = 4
+  else:
+    class Bad:
+      def values(self): raise RuntimeError('concurrent modification')
+    d.iface.dev_impl.mm.pa_allocator.blocks = Bad()
+  assert allocated_vram(d) is None
+
+
+def memory_snapshot():
+  sm = snapshot()
+  sm['chestnutState'].memoryUsedBytes = 1 << 30
+  sm['chestnutState'].memoryTotalBytes = 4 << 30
+  sm['chestnutState'].memorySampleMonoTime = NOW
+  return sm
+
+
+@pytest.mark.parametrize('used,total', [(0, 4 << 30), (1 << 30, 4 << 30), (4 << 30, 4 << 30)])
+def test_memory_wire_and_format(used,total):
+  sm = memory_snapshot()
+  sm['chestnutState'].memoryUsedBytes = used
+  sm['chestnutState'].memoryTotalBytes = total
+  with log.ChestnutState.from_bytes(sm['chestnutState'].to_bytes()) as state:
+    sm['chestnutState'] = state
+    assert external_gpu_memory(sm, NOW) == ((used,total), 1000)
+    assert external_gpu_memory_metric(sm,NOW) == f'eGPU RAM: {used/2**30:.1f}/4.0 GiB ({round(100*used/total)}%)'
+
+
+@pytest.mark.parametrize('failure', ['old','future','zero_time','bad_total','over_total','disconnected','envelope','invalid','missing'])
+def test_memory_stale_invalid_legacy(failure):
+  sm = memory_snapshot()
+  state = sm['chestnutState']
+  if failure == 'old': state.memorySampleMonoTime = NOW - 15_000_000_001
+  elif failure == 'future': state.memorySampleMonoTime = NOW + 1
+  elif failure == 'zero_time': state.memorySampleMonoTime = 0
+  elif failure == 'bad_total': state.memoryTotalBytes = 0
+  elif failure == 'over_total': state.memoryUsedBytes = 8 << 30
+  elif failure == 'disconnected': sm['deviceState'].chestnutPresent = False
+  elif failure == 'envelope': sm.logMonoTime['chestnutState'] = NOW - 1_000_000_001
+  elif failure == 'invalid': sm.valid['chestnutState'] = False
+  else: del sm['chestnutState']
+  assert external_gpu_memory_metric(sm,NOW) == 'eGPU RAM: --'
+
+
+def test_memory_independent_of_temperature():
+  sm = memory_snapshot()
+  sm['chestnutState'].tempC = 0
+  sm['chestnutState'].tempSampleMonoTime = 0
+  assert external_gpu_memory(sm,NOW)[0] == (1 << 30,4 << 30)
+
+
+def test_publisher_memory_failure_preserves_stock_diagnostics(publisher):
+  p = publisher
+  d = driver().iface.dev_impl
+  p.devices['AMD'].iface.dev_impl.mm = d.mm
+  p.devices['AMD'].iface.dev_impl.vram_size = d.vram_size
+  p.obj.send()
+  first = p.messages[-1]
+  assert first['valid']
+  assert first['chestnutState']['memoryUsedBytes'] == 48 << 20
+  assert first['chestnutState']['memorySampleMonoTime'] == NOW
+  del p.devices['AMD'].iface.dev_impl.mm
+  p.obj.sends = 100
+  p.obj.send()
+  failed = p.messages[-1]
+  assert failed['valid']
+  assert failed['chestnutState']['tempC'] == 73
+  assert failed['chestnutState']['memorySampleMonoTime'] == 0
+  assert p.smu._send_msg.call_count == 2
+  p.obj.big = False
+  p.obj.send()
+  assert p.messages[-1]['chestnutState']['memoryTotalBytes'] == 0
+
+
+def test_all_stock_chestnut_fields_and_cadence_identical(publisher):
+  p = publisher
+  source = Path(os.environ['DOM_MODELD_SOURCE']).read_text() if os.environ.get('DOM_MODELD_SOURCE') else subprocess.check_output(['git','show','7f3bd6129:selfdrive/modeld/modeld.py'],text=True)
+  assert hashlib.sha256(source.encode()).hexdigest() == '3fe2d92e43509473aeb93d4e38a3ea2164644f4285b60b2ab827611e230309bf'
+  cls = next(n for n in ast.parse(source).body if isinstance(n,ast.ClassDef) and n.name == 'ChestnutState')
+  namespace = dict(p.namespace)
+  exec(compile(ast.fix_missing_locations(ast.Module(body=[cls],type_ignores=[])), '<stock Dom ChestnutState>', 'exec'), namespace)
+  stock_messages = []
+  stock = namespace['ChestnutState'](NS(send=lambda _,m:stock_messages.append(m.to_dict())),True)
+  stock.power_limit = p.obj.power_limit
+  stock._read_ina = p.obj._read_ina
+  added = {'tempSampleMonoTime','memoryUsedBytes','memoryTotalBytes','memorySampleMonoTime'}
+  for step in range(205):
+    if step == 100: p.smu._send_msg.side_effect = RuntimeError('SMU failed')
+    if step == 200: p.smu._send_msg.side_effect = None
+    p.obj.send()
+    stock.send()
+    actual, baseline = p.messages[-1], stock_messages[-1]
+    assert actual['valid'] == baseline['valid']
+    assert {k:v for k,v in actual['chestnutState'].items() if k not in added} == {k:v for k,v in baseline['chestnutState'].items() if k not in added}
+    p.clock.value += 100_000_000
+  assert p.smu._send_msg.call_count == 6
+
+
+def test_galaxy_transport_grace_does_not_extend_sample_lifetime():
+  from openpilot.selfdrive.ui.tests.test_external_gpu_temperature import snapshot, NOW
+  from openpilot.starpilot.common.external_gpu_temperature import external_gpu_temperature
+  sm = snapshot(sample_time=NOW-10_000_000_000)
+  sm.logMonoTime['deviceState'] = NOW-1_500_000_000
+  assert external_gpu_temperature(sm, NOW) == (None, 0)
+  value, ttl = external_gpu_temperature(sm, NOW, envelope_max_age_ns=3_000_000_000)
+  assert value is not None and ttl == 1500
+  assert external_gpu_temperature(sm, NOW+1_500_000_001, envelope_max_age_ns=3_000_000_000) == (None, 0)
+  sm.logMonoTime['deviceState'] = NOW
+  sm['chestnutState'].tempSampleMonoTime = NOW-15_000_000_001
+  assert external_gpu_temperature(sm, NOW, envelope_max_age_ns=3_000_000_000) == (None, 0)

--- a/selfdrive/ui/tests/test_external_gpu_temperature.py
+++ b/selfdrive/ui/tests/test_external_gpu_temperature.py
@@ -1,0 +1,236 @@
+"""Published-message and production-method tests; no GPU/native UI access."""
+import ast
+import ctypes
+import math
+import time
+from functools import cached_property
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from cereal import log
+from starpilot.common.external_gpu_memory import allocated_vram
+
+from openpilot.selfdrive.ui.onroad.starpilot.developer_metrics import (
+  build_developer_metric_parts, external_gpu_temperature_metric, external_gpu_memory_metric,
+)
+from openpilot.selfdrive.ui.tests.test_developer_metrics import mici_metrics_view  # noqa: F401
+
+NOW = 30_000_000_000
+
+
+def snapshot(sample_time=NOW - 10_000_000_000, temperature=73.4):
+  class SubMaster(dict):
+    pass
+
+  device = log.DeviceState.new_message(chestnutPresent=True, gpuTempC=[58.0])
+  external = log.ChestnutState.new_message(tempC=temperature, tempSampleMonoTime=sample_time)
+  sm = SubMaster(deviceState=device, chestnutState=external)
+  sm.valid = dict.fromkeys(sm, True)
+  sm.alive = dict.fromkeys(sm, True)
+  sm.logMonoTime = dict.fromkeys(sm, NOW)
+  return sm
+
+
+def test_real_schema_roundtrip_and_distinct_sensor():
+  sm = snapshot()
+  with log.ChestnutState.from_bytes(sm['chestnutState'].to_bytes()) as state:
+    sm['chestnutState'] = state
+    assert external_gpu_temperature_metric(sm, NOW) == 'eGPU: 73°C'
+    assert list(sm['deviceState'].gpuTempC) == [58.0]
+
+
+@pytest.mark.parametrize('sample_age,available', [(0, True), (10_000_000_000, True), (15_000_000_000, True),
+                                                (15_000_000_001, False), (-1, False), (NOW, False)])
+def test_sample_freshness_not_cached_envelope(sample_age, available):
+  sm = snapshot(NOW - sample_age)
+  assert external_gpu_temperature_metric(sm, NOW) == ('eGPU: 73°C' if available else 'eGPU: --')
+
+
+@pytest.mark.parametrize('service', ['deviceState', 'chestnutState'])
+@pytest.mark.parametrize('mode', ['invalid', 'dead', 'old', 'future', 'missing'])
+def test_missing_stale_or_invalid_messages(service, mode):
+  sm = snapshot()
+  if mode == 'invalid':
+    sm.valid[service] = False
+  elif mode == 'dead':
+    sm.alive[service] = False
+  elif mode == 'missing':
+    del sm[service]
+  else:
+    sm.logMonoTime[service] = NOW - 1_000_000_001 if mode == 'old' else NOW + 1
+  assert external_gpu_temperature_metric(sm, NOW) == 'eGPU: --'
+
+
+@pytest.mark.parametrize('temperature', [0, -1, math.nan, math.inf, -math.inf])
+def test_unusable_temperature_never_falls_back_to_onboard_or_zero(temperature):
+  assert external_gpu_temperature_metric(snapshot(temperature=temperature), NOW) == 'eGPU: --'
+
+
+def test_disconnection_and_legacy_publisher_are_unavailable():
+  sm = snapshot()
+  sm['deviceState'].chestnutPresent = False
+  assert external_gpu_temperature_metric(sm, NOW) == 'eGPU: --'
+  sm['deviceState'].chestnutPresent = True
+  sm['chestnutState'] = SimpleNamespace(tempC=73.4)
+  assert external_gpu_temperature_metric(sm, NOW) == 'eGPU: --'
+
+
+@pytest.fixture
+def publisher():
+  """Compile the actual Chestnut publisher, mocking only hardware boundaries."""
+  source = Path('selfdrive/modeld/modeld.py')
+  tree = ast.parse(source.read_text())
+  cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == 'ChestnutState')
+  clock = SimpleNamespace(value=NOW)
+  messages = []
+
+  def new_message(service):
+    msg = log.Event.new_message(logMonoTime=clock.value)
+    msg.init(service)
+    return msg
+
+  class Metrics(ctypes.Structure):
+    _fields_ = [('AvgTemperature', ctypes.c_uint16 * 2), ('AverageSocketPower', ctypes.c_uint16),
+               ('AverageGfxActivity', ctypes.c_uint16), ('AverageGfxclkFrequencyPostDs', ctypes.c_uint16),
+               ('AvgFanRpm', ctypes.c_uint16)]
+
+  class External(ctypes.Structure):
+    _fields_ = [('SmuMetrics', Metrics)]
+
+  raw = External(Metrics((73, 64), 30, 50, 1200, 2000))
+  smu = SimpleNamespace(
+    smu_mod=SimpleNamespace(SmuMetricsExternal_t=External, TEMP_HOTSPOT=0, TEMP_MEM=1,
+                            PPSMC_MSG_TransferTableSmu2Dram=1, TABLE_SMU_METRICS=2),
+    _send_msg=Mock(), adev=SimpleNamespace(vram=SimpleNamespace(view=lambda *_: bytes(raw))), driver_table_paddr=0,
+  )
+  gpu = SimpleNamespace(iface=SimpleNamespace(dev_impl=SimpleNamespace(smu=smu),
+                        pci_dev=SimpleNamespace(usb=SimpleNamespace(read=Mock(return_value=b'\x10')))))
+
+  class Devices(dict):
+    _opened_devices = ['AMD']
+
+  devices = Devices(AMD=gpu)
+  namespace = dict(PubMaster=object, Device=devices, messaging=SimpleNamespace(new_message=new_message),
+                   time=SimpleNamespace(monotonic_ns=lambda: clock.value), ctypes=ctypes,
+                   cached_property=cached_property, cloudlog=Mock(), allocated_vram=allocated_vram)
+  exec(compile(ast.fix_missing_locations(ast.Module(body=[cls], type_ignores=[])), str(source), 'exec'), namespace)
+  obj = namespace['ChestnutState'](SimpleNamespace(send=lambda _, m: messages.append(m.to_dict())), True)
+  obj.power_limit = 45
+  obj._read_ina = Mock(return_value=(12000, 1000, False))
+  return SimpleNamespace(obj=obj, messages=messages, clock=clock, smu=smu, devices=devices, namespace=namespace)
+
+
+def test_publisher_stamps_only_successful_samples_not_cached_sends(publisher):
+  p = publisher
+  p.obj.send()
+  assert p.messages[-1]['chestnutState']['tempSampleMonoTime'] == NOW
+  assert p.messages[-1]['chestnutState']['tempC'] == 73
+  for _ in range(99):
+    p.clock.value += 100_000_000
+    p.obj.send()
+    assert p.messages[-1]['chestnutState']['tempSampleMonoTime'] == NOW
+  assert p.smu._send_msg.call_count == 1
+  p.clock.value += 100_000_000
+  p.obj.send()
+  assert p.messages[-1]['chestnutState']['tempSampleMonoTime'] == p.clock.value
+  assert p.smu._send_msg.call_count == 2
+
+
+def test_failed_smu_read_clears_timestamp_and_fallback_does_not_publish_cache(publisher):
+  p = publisher
+  p.obj.send()
+  p.obj.sends = 100
+  p.smu._send_msg.side_effect = RuntimeError('simulated read failure')
+  p.obj.send()
+  assert not p.messages[-1]['valid']
+  assert p.messages[-1]['chestnutState']['tempSampleMonoTime'] == 0
+  assert p.messages[-1]['chestnutState']['tempC'] == 0
+  p.smu._send_msg.side_effect = None
+  p.obj.sends = 200
+  p.obj.send()
+  p.obj.big = False
+  p.obj.send()
+  assert p.messages[-1]['chestnutState']['tempSampleMonoTime'] == 0
+  assert p.messages[-1]['chestnutState']['tempC'] == 0
+
+
+def test_no_opened_gpu_does_not_initialize_hardware(publisher):
+  p = publisher
+  p.devices._opened_devices = []
+  p.obj.send()
+  p.smu._send_msg.assert_not_called()
+  assert p.messages[-1]['chestnutState']['tempSampleMonoTime'] == 0
+
+
+@pytest.mark.parametrize('all_metrics', [False, True])
+@pytest.mark.parametrize('temperature', [73.4, 125.0])
+@pytest.mark.parametrize('border', [0, 24])
+def test_actual_mici_renderer_draws_real_external_sample(mici_metrics_view, all_metrics, temperature, border):
+  f = mici_metrics_view
+  f.view._get_border_width = lambda: border
+  now = time.monotonic_ns()
+  sm = snapshot(now, temperature)
+  sm.logMonoTime = dict.fromkeys(sm, now)
+  sm['deviceState'] = f.state.sm['deviceState']
+  sm['deviceState'].chestnutPresent = True
+  sm['chestnutState'].memoryUsedBytes = 3 << 30
+  sm['chestnutState'].memoryTotalBytes = 4 << 30
+  sm['chestnutState'].memorySampleMonoTime = now
+  f.state.sm = sm
+  if all_metrics:
+    f.state.starpilot_toggles.clear()
+    f.params.update({'ShowCPU', 'NumericalTemp', 'ShowMemoryUsage', 'FPSCounter'})
+  f.view._render(f.view.rect)
+  text = ' | '.join(c.args[1] for c in f.raylib.draw_text_ex.call_args_list)
+  assert 'GPU: 0% / 58°C' in text
+  assert f'eGPU: {round(temperature)}°C' in text
+  assert 'eGPU RAM: 3.0/4.0 GiB (75%)' in text
+  panel = f.raylib.draw_rectangle_rec.call_args.args[0]
+  for call in f.raylib.draw_text_ex.call_args_list:
+    font, line, pos, size = call.args[:4]
+    assert size >= 16
+    assert panel.x <= pos.x < pos.x + f.measure_text(font, line, size).x <= panel.x + panel.width
+    assert panel.y <= pos.y < pos.y + size * 1.16 <= panel.y + panel.height
+  if all_metrics:
+    for label in ['CPU:', 'TEMP:', 'RAM:', 'FPS:']:
+      assert label in text
+
+
+def test_actual_big_renderer_uses_external_telemetry(mici_metrics_view):
+  f = mici_metrics_view
+  sm = snapshot()
+  sm['deviceState'] = f.state.sm['deviceState']
+  sm['deviceState'].chestnutPresent = True
+  f.state.sm = sm
+  path = Path('selfdrive/ui/onroad/starpilot/starpilot_onroad_view.py')
+  cls = next(n for n in ast.parse(path.read_text()).body if isinstance(n, ast.ClassDef) and n.name == 'StarPilotOnroadView')
+  method = next(n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == '_render_developer_metrics')
+  def measure_text(font, text, size):
+    return SimpleNamespace(x=f.measure_text(font, text, size).x, y=size * 1.16)
+
+  namespace = dict(ui_state=f.state, rl=f.raylib, math=math, measure_text_cached=measure_text,
+                   build_developer_metric_parts=build_developer_metric_parts,
+                   external_gpu_memory_metric=external_gpu_memory_metric, external_gpu_temperature_metric=lambda sm: external_gpu_temperature_metric(sm, NOW))
+  exec(compile(ast.fix_missing_locations(ast.Module(body=[method], type_ignores=[])), str(path), 'exec'), namespace)
+  f.view._params = f.state.ui_params
+  f.view._font_medium = f.view._metrics_font
+  f.view._min_fps, f.view._max_fps, f.view._avg_fps = 20, 20, 20
+  f.view._content_rect = f.view.rect
+  namespace['_render_developer_metrics'](f.view)
+  rendered = ' | '.join(c.args[1] for c in f.raylib.draw_text_ex.call_args_list)
+  assert 'GPU: 0% / 58°C' in rendered and 'eGPU: 73°C' in rendered
+  assert 'eGPU RAM: --' in rendered
+  for c in f.raylib.draw_text_ex.call_args_list:
+    _, text, pos, size = c.args[:4]
+    assert f.view._content_rect.x <= pos.x
+    assert pos.x + measure_text(None, text, size).x <= f.view._content_rect.x + f.view._content_rect.width
+
+
+def test_subscription_is_read_only_and_existing_hardware_read_schedule_unchanged():
+  assert '"chestnutState",' in Path('selfdrive/ui/ui_state.py').read_text()
+  source = Path('selfdrive/modeld/modeld.py').read_text()
+  assert 'self.sends % 100 == 1' in source
+  formatter = Path('selfdrive/ui/onroad/starpilot/developer_metrics.py').read_text()
+  assert 'tinygrad' not in formatter and 'Device[' not in formatter

--- a/selfdrive/ui/ui_state.py
+++ b/selfdrive/ui/ui_state.py
@@ -49,6 +49,7 @@ class UIState:
         "liveCalibration",
         "radarState",
         "deviceState",
+        "chestnutState",
         "pandaStates",
         "carParams",
         "driverMonitoringState",

--- a/starpilot/common/external_gpu_memory.py
+++ b/starpilot/common/external_gpu_memory.py
@@ -1,0 +1,62 @@
+"""Optional physical VRAM accounting; no hardware reads or allocation changes."""
+import time
+
+
+def allocated_vram(device):
+  """Return used/reserved and physical total bytes from the opened AMD driver.
+
+  Physical free pools exclude firmware reservations. Cached buffers and page
+  tables remain allocated, so they count as used. Never use process-wide tensor
+  counters (which also include onboard devices) as Chestnut usage.
+  """
+  try:
+    driver = device.iface.dev_impl
+    total = driver.vram_size
+    pools = (driver.mm.boot_allocator, driver.mm.ptable_allocator, driver.mm.pa_allocator)
+    if type(total) is not int or total <= 0:
+      return None
+    free = 0
+    capacity = 0
+    for pool in pools:
+      if type(pool.size) is not int or pool.size < 0:
+        return None
+      blocks = tuple(pool.blocks.values())
+      if any(type(b[0]) is not int or b[0] < 0 or type(b[3]) is not bool for b in blocks):
+        return None
+      if sum(b[0] for b in blocks) != pool.size:
+        return None
+      capacity += pool.size
+      free += sum(b[0] for b in blocks if b[3])
+    if not 0 <= free <= capacity <= total:
+      return None
+    return total - free, total
+  except Exception:
+    # Driver revisions/racing snapshots must not break model execution.
+    return None
+
+
+def external_gpu_memory(sm, now_ns=None, *, envelope_max_age_ns=1_000_000_000):
+  """Return ((used, total), remaining ms) or (None, 0), independently of temp."""
+  now_ns = time.monotonic_ns() if now_ns is None else now_ns
+  try:
+    remaining = []
+    for service in ("deviceState", "chestnutState"):
+      if not sm.valid.get(service, False) or not sm.alive.get(service, False):
+        return None, 0
+      age = now_ns - sm.logMonoTime[service]
+      if not 0 <= age <= envelope_max_age_ns:
+        return None, 0
+      remaining.append(envelope_max_age_ns - age)
+    if not sm["deviceState"].chestnutPresent:
+      return None, 0
+    state = sm["chestnutState"]
+    age = now_ns - state.memorySampleMonoTime
+    if state.memorySampleMonoTime <= 0 or not 0 <= age <= 15_000_000_000:
+      return None, 0
+    remaining.append(15_000_000_000 - age)
+    used, total = state.memoryUsedBytes, state.memoryTotalBytes
+    if not 0 <= used <= total or total <= 0:
+      return None, 0
+    return (used, total), min(remaining) // 1_000_000
+  except (AttributeError, KeyError, OverflowError, TypeError, ValueError):
+    return None, 0

--- a/starpilot/common/external_gpu_temperature.py
+++ b/starpilot/common/external_gpu_temperature.py
@@ -1,0 +1,35 @@
+"""Read-only Chestnut hotspot telemetry, shared by native UI and Galaxy."""
+import math
+import time
+
+
+def external_gpu_temperature(sm, now_ns=None, *, envelope_max_age_ns=1_000_000_000):
+  """Return (Celsius, remaining freshness ms), or (None, 0).
+
+  Cached envelopes are not new SMU samples. Legacy publishers have no sample
+  timestamp and deliberately remain unavailable. No hardware access here.
+  """
+  now_ns = time.monotonic_ns() if now_ns is None else now_ns
+  try:
+    remaining = []
+    for service in ("deviceState", "chestnutState"):
+      if not sm.valid.get(service, False) or not sm.alive.get(service, False):
+        return None, 0
+      age = now_ns - sm.logMonoTime[service]
+      if not 0 <= age <= envelope_max_age_ns:
+        return None, 0
+      remaining.append(envelope_max_age_ns - age)
+    if not sm["deviceState"].chestnutPresent:
+      return None, 0
+    state = sm["chestnutState"]
+    sample_time = state.tempSampleMonoTime
+    age = now_ns - sample_time
+    if sample_time <= 0 or not 0 <= age <= 15_000_000_000:
+      return None, 0
+    remaining.append(15_000_000_000 - age)
+    temperature = float(state.tempC)
+    if not math.isfinite(temperature) or temperature <= 0:
+      return None, 0
+    return temperature, min(remaining) // 1_000_000
+  except (AttributeError, KeyError, OverflowError, TypeError, ValueError):
+    return None, 0

--- a/starpilot/system/the_galaxy/assets/components/home/external_gpu_memory.js
+++ b/starpilot/system/the_galaxy/assets/components/home/external_gpu_memory.js
@@ -1,0 +1,27 @@
+// Reuses the temperature widget's request: no extra polling or hardware reads.
+export class ExternalGpuMemory extends HTMLElement {
+  connectedCallback() {
+    this.textContent = "--";
+    this.title = "Allocated/cached and driver-reserved VRAM, out of physical capacity";
+    this.listener = ({detail: {data, start}}) => {
+      if (!this.isConnected) return;
+      clearTimeout(this.expiry);
+      const remaining = Math.min(3000, data.memoryMaxAgeMs) - (performance.now() - start);
+      const used = data.memoryUsedBytes, total = data.memoryTotalBytes;
+      if (Number.isSafeInteger(used) && Number.isSafeInteger(total) && used >= 0 && total > 0 && used <= total
+          && typeof data.memoryMaxAgeMs === "number" && Number.isFinite(remaining) && remaining > 0) {
+        this.textContent = `${(used / 2**30).toFixed(1)}/${(total / 2**30).toFixed(1)} GiB (${Math.round(100 * used / total)}%)`;
+        this.expiry = setTimeout(() => { this.textContent = "--"; }, remaining);
+      } else {
+        this.textContent = "--";
+      }
+    };
+    window.addEventListener("egpu-vitals-sample", this.listener);
+  }
+  disconnectedCallback() {
+    window.removeEventListener("egpu-vitals-sample", this.listener);
+    clearTimeout(this.expiry);
+    this.textContent = "--";
+  }
+}
+if (!customElements.get("external-gpu-memory")) customElements.define("external-gpu-memory", ExternalGpuMemory);

--- a/starpilot/system/the_galaxy/assets/components/home/external_gpu_temperature.js
+++ b/starpilot/system/the_galaxy/assets/components/home/external_gpu_temperature.js
@@ -1,0 +1,48 @@
+// Shared by Arrow and Vue. Only consumes modeld's read-only telemetry API.
+export class ExternalGpuTemperature extends HTMLElement {
+  connectedCallback() {
+    this.textContent = "--";
+    const generation = this.generation = (this.generation || 0) + 1;
+    const poll = async () => {
+      const start = performance.now();
+      const controller = this.controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 1000);
+      try {
+        const response = await fetch("/api/vitals/external-gpu", { cache: "no-store", signal: controller.signal });
+        if (!response.ok) throw new Error("Telemetry unavailable");
+        const data = await response.json();
+        if (!this.isConnected || generation !== this.generation) return;
+        window.dispatchEvent(new CustomEvent("egpu-vitals-sample", {detail: {data, start}}));
+        // Deduct the entire request latency; never extend server sample life.
+        const remaining = Math.min(3000, data.maxAgeMs) - (performance.now() - start);
+        clearTimeout(this.expiry);
+        if (typeof data.tempC === "number" && Number.isFinite(data.tempC) && data.tempC > 0
+            && typeof data.maxAgeMs === "number" && Number.isFinite(remaining) && remaining > 0) {
+          this.textContent = `${Math.round(data.tempC)}°C`;
+          this.expiry = setTimeout(() => { this.textContent = "--"; }, remaining);
+        } else {
+          this.textContent = "--";
+        }
+      } catch (_) {
+        // Request failure does not invalidate a still-fresh sample.
+        // Its independent expiry still clears it at the original deadline.
+      } finally {
+        clearTimeout(timeout);
+        if (this.isConnected && generation === this.generation) this.pollTimer = setTimeout(poll, 250);
+      }
+    };
+    poll();
+  }
+
+  disconnectedCallback() {
+    ++this.generation;
+    clearTimeout(this.pollTimer);
+    clearTimeout(this.expiry);
+    this.controller?.abort();
+    this.textContent = "--";
+  }
+}
+
+if (!customElements.get("external-gpu-temperature")) {
+  customElements.define("external-gpu-temperature", ExternalGpuTemperature);
+}

--- a/starpilot/system/the_galaxy/assets/mobile/js/views/Home.js
+++ b/starpilot/system/the_galaxy/assets/mobile/js/views/Home.js
@@ -1,3 +1,5 @@
+import "/assets/components/home/external_gpu_temperature.js"
+import "/assets/components/home/external_gpu_memory.js"
 import { api, showSnackbar } from "../api.js"
 import { usePolling } from "../composables.js"
 import { GalaxyConfirm } from "../components/GalaxyModal.js"
@@ -548,6 +550,8 @@ export const Home = {
                 <span class="gx-row__label">{{ v.label }}</span>
                 <span class="gx-row__value">{{ v.value }}</span>
               </div>
+              <div class="gx-row"><span class="gx-row__label">eGPU</span><span class="gx-row__value"><component is="external-gpu-temperature">--</component></span></div>
+              <div class="gx-row"><span class="gx-row__label">eGPU RAM</span><span class="gx-row__value"><component is="external-gpu-memory">--</component></span></div>
             </div>
           </section>
 

--- a/starpilot/system/the_galaxy/external_gpu_vitals.py
+++ b/starpilot/system/the_galaxy/external_gpu_vitals.py
@@ -1,0 +1,50 @@
+"""Galaxy subscriber to modeld telemetry; no GPU collector or hardware reads."""
+import threading
+import math
+import time
+
+from starpilot.common.external_gpu_temperature import external_gpu_temperature
+from starpilot.common.external_gpu_memory import external_gpu_memory
+
+_lock = threading.Lock()
+_sm = None
+
+
+def external_gpu_vitals(*, include_onboard=False):
+  global _sm
+  # Flask requests may overlap; SubMaster is owned behind this lock.
+  with _lock:
+    onboard = {'cpuTempC': None, 'gpuTempC': None, 'onboardMaxAgeMs': 0,
+               'hotspotTempC': None, 'gpuEdgeTempC': None}
+    try:
+      if _sm is None:
+        from cereal import messaging
+        _sm = messaging.SubMaster(["deviceState", "chestnutState"])
+      _sm.update(0)
+      if include_onboard:
+        try:
+          age = time.monotonic_ns() - _sm.logMonoTime['deviceState']
+          if _sm.valid.get('deviceState', False) and _sm.alive.get('deviceState', False) and 0 <= age < 3_000_000_000:
+            for field in ('cpuTempC', 'gpuTempC'):
+              values = [float(value) for value in getattr(_sm['deviceState'], field, [])]
+              values = [value for value in values if math.isfinite(value) and 0 < value < 150]
+              onboard[field] = max(values) if values else None
+            onboard['onboardMaxAgeMs'] = (3_000_000_000 - age) // 1_000_000
+        except (AttributeError, KeyError, TypeError, ValueError):
+          pass
+      temperature, remaining_ms = external_gpu_temperature(_sm, envelope_max_age_ns=3_000_000_000)
+      memory, memory_ms = external_gpu_memory(_sm, envelope_max_age_ns=3_000_000_000)
+      result = {"tempC": temperature, "maxAgeMs": remaining_ms,
+              "memoryUsedBytes": memory[0] if memory else None,
+              "memoryTotalBytes": memory[1] if memory else None, "memoryMaxAgeMs": memory_ms}
+      if include_onboard:
+        # modeld publishes TEMP_HOTSPOT in tempC. No edge temperature is published.
+        onboard['hotspotTempC'] = temperature
+        result.update(onboard)
+      return result
+    except Exception:
+      # Optional telemetry must not break the dashboard on legacy bindings.
+      result = {"tempC": None, "maxAgeMs": 0, "memoryUsedBytes": None, "memoryTotalBytes": None, "memoryMaxAgeMs": 0}
+      if include_onboard:
+        result.update(onboard)
+      return result

--- a/starpilot/system/the_galaxy/tests/test_external_gpu_vitals.py
+++ b/starpilot/system/the_galaxy/tests/test_external_gpu_vitals.py
@@ -1,0 +1,87 @@
+"""Local read-only API/schema regressions using real Cap'n Proto messages."""
+import ast
+import time
+from pathlib import Path
+
+import capnp
+import pytest
+from flask import Flask, jsonify
+from cereal import log
+
+from openpilot.selfdrive.ui.tests.test_external_gpu_temperature import snapshot
+from openpilot.starpilot.system.the_galaxy import external_gpu_vitals as backend
+
+
+@pytest.fixture
+def client(monkeypatch):
+  sm = snapshot(time.monotonic_ns())
+  sm.logMonoTime = dict.fromkeys(sm, time.monotonic_ns())
+  sm.update = lambda timeout: None
+  monkeypatch.setattr(backend, '_sm', sm)
+  tree = ast.parse(Path('starpilot/system/the_galaxy/the_galaxy.py').read_text())
+  handler = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == 'get_external_gpu_vitals')
+  app = Flask(__name__)
+  exec(compile(ast.fix_missing_locations(ast.Module(body=[handler], type_ignores=[])), 'production_endpoint', 'exec'),
+       {'app': app, 'jsonify': jsonify})
+  client = app.test_client()
+  # Fixture construction may exceed the real 1s envelope budget on ARM.
+  # Stamp the synthetic message only after Flask/AST setup, as a new sample.
+  sm.logMonoTime = dict.fromkeys(sm, time.monotonic_ns())
+  sm["chestnutState"].tempSampleMonoTime = time.monotonic_ns()
+  return client, sm
+
+
+def test_api_real_schema_temperature_and_cache_control(client):
+  c, sm = client
+  response = c.get('/api/vitals/external-gpu')
+  assert response.status_code == 200
+  assert response.headers['Cache-Control'] == 'no-store'
+  assert response.json['tempC'] == pytest.approx(73.4)
+  assert 0 < response.json['maxAgeMs'] <= 3000
+  assert list(sm['deviceState'].gpuTempC) == [58.0]
+  assert c.post('/api/vitals/external-gpu').status_code == 405
+  sm['chestnutState'].memoryUsedBytes = 1 << 30
+  sm['chestnutState'].memoryTotalBytes = 4 << 30
+  sm['chestnutState'].memorySampleMonoTime = time.monotonic_ns()
+  value = c.get('/api/vitals/external-gpu').json
+  assert value['memoryUsedBytes'] == 1 << 30 and value['memoryTotalBytes'] == 4 << 30
+  assert 0 < value['memoryMaxAgeMs'] <= 3000
+  assert value['tempC'] == pytest.approx(73.4)
+
+
+@pytest.mark.parametrize('failure', ['offroad', 'sample_stale', 'envelope_stale', 'invalid', 'legacy', 'exception'])
+def test_api_unavailable_not_zero_or_onboard(client, failure):
+  c, sm = client
+  if failure == 'offroad':
+    sm.alive['chestnutState'] = False
+  elif failure == 'sample_stale':
+    sm['chestnutState'].tempSampleMonoTime = time.monotonic_ns() - 15_000_000_001
+  elif failure == 'envelope_stale':
+    sm.logMonoTime['chestnutState'] = time.monotonic_ns() - 3_000_000_001
+  elif failure == 'invalid':
+    sm.valid['chestnutState'] = False
+  elif failure == 'legacy':
+    sm['chestnutState'].tempSampleMonoTime = 0
+  else:
+    def fail(_):
+      raise RuntimeError('simulated subscriber failure')
+    sm.update = fail
+  assert c.get('/api/vitals/external-gpu').json == {'tempC': None, 'maxAgeMs': 0, 'memoryUsedBytes': None, 'memoryTotalBytes': None, 'memoryMaxAgeMs': 0}
+
+
+def test_old_new_native_capnp_wire_compatibility(tmp_path):
+  # Independent native schema parser: exact original struct layout, without
+  # the additive field. Verify both directions, not merely Python attributes.
+  source = Path('cereal/log.capnp').read_text()
+  struct = source.split('struct ChestnutState {', 1)[1].split('\n}', 1)[0]
+  struct = '\n'.join(line for line in struct.splitlines() if not any(field in line for field in ('tempSampleMonoTime @11', 'memoryUsedBytes @12', 'memoryTotalBytes @13', 'memorySampleMonoTime @14')))
+  schema = tmp_path / 'legacy.capnp'
+  schema.write_text('@0xdedfbee5cafea123;\nstruct ChestnutState {' + struct + '\n}\n')
+  old = capnp.SchemaParser().load(str(schema))
+  legacy = old.ChestnutState.new_message(tempC=73.0, supplyVoltage=12000)
+  with log.ChestnutState.from_bytes(legacy.to_bytes()) as new:
+    assert new.tempC == 73.0 and new.supplyVoltage == 12000
+    assert new.tempSampleMonoTime == 0
+  current = log.ChestnutState.new_message(tempC=74.0, supplyVoltage=12500, tempSampleMonoTime=30_000_000_000)
+  with old.ChestnutState.from_bytes(current.to_bytes()) as previous:
+    assert previous.tempC == 74.0 and previous.supplyVoltage == 12500

--- a/starpilot/system/the_galaxy/tests/test_gpu_api_subscriber.py
+++ b/starpilot/system/the_galaxy/tests/test_gpu_api_subscriber.py
@@ -1,0 +1,26 @@
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from flask import Flask, jsonify
+from openpilot.starpilot.system.the_galaxy import external_gpu_vitals as telemetry
+
+
+def test_home_route_uses_canonical_shared_subscriber(monkeypatch):
+  # Execute the actual route body without importing vehicle/hardware services.
+  source = Path(__file__).resolve().parents[1] / "the_galaxy.py"
+  setup = next(n for n in ast.parse(source.read_text()).body if isinstance(n, ast.FunctionDef) and n.name == "setup")
+  route = next(n for n in setup.body if isinstance(n, ast.FunctionDef) and n.name == "get_external_gpu_vitals")
+  route.decorator_list = []
+  app = Flask("shared_gpu_subscriber")
+  namespace = {"jsonify": jsonify}
+  exec(compile(ast.Module(body=[route], type_ignores=[]), str(source), "exec"), namespace)
+  calls = []
+  sentinel = SimpleNamespace()
+  monkeypatch.setattr(telemetry, "_sm", sentinel)
+  monkeypatch.setattr(telemetry, "external_gpu_vitals", lambda **kwargs: calls.append(telemetry._sm) or {"tempC": 50})
+  with app.test_request_context():
+    for _ in range(2):
+      result = namespace["get_external_gpu_vitals"]()
+      assert result.get_json() == {"tempC": 50}
+      assert result.headers["Cache-Control"] == "no-store"
+  assert calls == [sentinel, sentinel]

--- a/starpilot/system/the_galaxy/tests/test_monitor_vitals.py
+++ b/starpilot/system/the_galaxy/tests/test_monitor_vitals.py
@@ -1,0 +1,42 @@
+import time
+from types import SimpleNamespace
+import pytest
+from openpilot.starpilot.system.the_galaxy import external_gpu_vitals as backend
+
+class Snapshot(dict):
+  pass
+
+def snapshot():
+  now=time.monotonic_ns()
+  sm=Snapshot(deviceState=SimpleNamespace(cpuTempC=[51.,57.],gpuTempC=[49.],chestnutPresent=True),
+              chestnutState=SimpleNamespace(tempC=73.,tempSampleMonoTime=now,memoryUsedBytes=1073741824,memoryTotalBytes=4294967296,memorySampleMonoTime=now))
+  sm.valid=dict.fromkeys(sm,True);sm.alive=dict.fromkeys(sm,True);sm.logMonoTime=dict.fromkeys(sm,now);sm.update=lambda timeout:None
+  return sm
+
+def test_monitor_exposes_onboard_maxima_and_real_hotspot(monkeypatch):
+  sm=snapshot();monkeypatch.setattr(backend,'_sm',sm)
+  result=backend.external_gpu_vitals(include_onboard=True)
+  assert result['cpuTempC']==57 and result['gpuTempC']==49
+  assert result['hotspotTempC']==73 and result['gpuEdgeTempC'] is None
+  assert result['memoryUsedBytes']==1073741824 and result['memoryTotalBytes']==4294967296
+
+@pytest.mark.parametrize('fault',['stale','invalid','missing','nan'])
+def test_bad_onboard_readings_do_not_hide_valid_external_gpu(monkeypatch,fault):
+  sm=snapshot();monkeypatch.setattr(backend,'_sm',sm)
+  if fault=='stale':sm.logMonoTime['deviceState']=time.monotonic_ns()-4000000000
+  elif fault=='invalid':sm.valid['deviceState']=False
+  elif fault=='missing':sm['deviceState'].cpuTempC=[];sm['deviceState'].gpuTempC=[]
+  else:sm['deviceState'].cpuTempC=[float('nan')];sm['deviceState'].gpuTempC=[float('inf')]
+  result=backend.external_gpu_vitals(include_onboard=True)
+  assert result['cpuTempC'] is None and result['gpuTempC'] is None
+  if fault in ('missing','nan'):assert result['hotspotTempC']==73
+
+def test_disconnected_external_gpu_keeps_onboard_temperatures(monkeypatch):
+  sm=snapshot();sm['deviceState'].chestnutPresent=False;monkeypatch.setattr(backend,'_sm',sm)
+  result=backend.external_gpu_vitals(include_onboard=True)
+  assert result['cpuTempC']==57
+  assert result['hotspotTempC'] is None and result['memoryUsedBytes'] is None
+
+def test_legacy_home_response_stays_unchanged(monkeypatch):
+  monkeypatch.setattr(backend,'_sm',snapshot())
+  assert set(backend.external_gpu_vitals())=={'tempC','maxAgeMs','memoryUsedBytes','memoryTotalBytes','memoryMaxAgeMs'}

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -5271,6 +5271,13 @@ def setup(app):
   def mobile_index():
     return _serve_new_ui()
 
+  @app.route("/api/vitals/external-gpu", methods=["GET"])
+  def get_external_gpu_vitals():
+    from openpilot.starpilot.system.the_galaxy.external_gpu_vitals import external_gpu_vitals
+    response = jsonify(external_gpu_vitals())
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
   @app.route("/api/bluetooth/status", methods=["GET"])
   def bluetooth_status():
     try:


### PR DESCRIPTION
Displays distinct onboard and external-GPU readings in Galaxy and the native developer display, including Chestnut temperature and VRAM usage where available.

Telemetry carries actual sample timestamps and treats stale, invalid or unsupported values as unavailable. VRAM reporting uses allocation metadata while preserving the existing Chestnut diagnostics and hardware sampling cadence.

Validation: 101 telemetry, schema, native display and API tests passed, including stale-reading expiry and the shared subscriber regression. A matching Chestnut schema build is required; these tests do not replace a target build or live device validation.