### PR TITLE
Add complete Galaxy backups for settings and drive history

### DIFF
--- a/starpilot/system/the_galaxy/assets/mobile/js/api.js
+++ b/starpilot/system/the_galaxy/assets/mobile/js/api.js
@@ -191,14 +191,14 @@ export const api = {
   deleteNavigationKey(type) { return request(`/api/navigation_key?type=${encodeURIComponent(type)}`, { method: "DELETE" }) },
 
   async backupToggles() {
-    const res = await fetch("/api/toggles/backup", { method: "POST" })
+    const res = await fetch("/api/backup", { method: "POST" })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
-      throw new Error(data?.message || "Failed to create toggle backup.")
+      throw new Error(data?.message || "Failed to create backup.")
     }
     return res.blob()
   },
-  restoreToggles(data) { return request("/api/toggles/restore", { method: "POST", data }) },
+  restoreToggles(data) { return request("/api/restore", { method: "POST", data }) },
   resetTogglesDefault() { return request("/api/toggles/reset_default", { method: "POST" }) },
 
   getUpdateBranches() { return request("/api/update/branches") },

--- a/starpilot/system/the_galaxy/assets/mobile/js/views/SystemTools.js
+++ b/starpilot/system/the_galaxy/assets/mobile/js/views/SystemTools.js
@@ -90,10 +90,10 @@ export const SystemTools = {
         const url = URL.createObjectURL(blob)
         const a = document.createElement("a")
         a.href = url
-        a.download = "toggle-backup.json"
+        a.download = "starpilot-backup.json"
         a.click()
         setTimeout(() => URL.revokeObjectURL(url), 1000)
-        showSnackbar("Toggle backup downloaded.")
+        showSnackbar("Backup downloaded.")
       } catch (e) {
         showSnackbar(e?.message || "Backup failed.", "error")
       }
@@ -142,19 +142,22 @@ export const SystemTools = {
         this.profileBusy = ""
       }
     },
-    onRestoreFile(e) {
+    async onRestoreFile(e) {
+      if (this.isOnroad) { showSnackbar("Park the vehicle before restoring.", "error"); return }
       const file = e.target.files[0]
       e.target.value = ""
       if (!file) return
-      if (file.size > 5_000_000) { showSnackbar("That toggle backup file is too large.", "error"); return }
-      file.text().then((text) => {
+      if (file.size > 67_108_864) { showSnackbar("That backup file is too large.", "error"); return }
+      return file.text().then(async (text) => {
         let data
-        try { data = JSON.parse(text) } catch { showSnackbar("That file is not a valid toggle backup.", "error"); return }
-        if (!data || typeof data !== "object" || Array.isArray(data)) { showSnackbar("That file is not a valid toggle backup.", "error"); return }
-        api.restoreToggles(data).then((res) => {
-          showSnackbar(res?.message || "Toggles restored!")
-        }).catch((err) => showSnackbar(err?.message || "Failed to restore toggles.", "error"))
-      })
+        try { data = JSON.parse(text) } catch { showSnackbar("That file is not a valid backup.", "error"); return }
+        if (!data || typeof data !== "object" || Array.isArray(data)) { showSnackbar("That file is not a valid backup.", "error"); return }
+        if (!(await GalaxyConfirm({ title: "Restore backup?", message: "This applies saved settings and merges driving history. Existing drive records are kept, so importing the same backup again does not double-count them.", confirmLabel: "Restore" }))) return
+        if (this.isOnroad) { showSnackbar("Park the vehicle before restoring.", "error"); return }
+        return api.restoreToggles(data).then((res) => {
+          showSnackbar(res?.message || "Backup restored!")
+        }).catch((err) => showSnackbar(err?.message || "Failed to restore backup.", "error"))
+      }).catch((err) => showSnackbar(err?.message || "Failed to read backup file.", "error"))
     },
     async resetDefault() {
       if (!(await GalaxyConfirm({ title: "Reset toggles to default?", message: "This resets all toggles to their default values and reboots.", confirmLabel: "Reset", danger: true }))) return
@@ -387,13 +390,13 @@ export const SystemTools = {
           </div>
         </div>
         <div style="padding: var(--sp-3); display:flex; gap:8px; flex-wrap:wrap;">
-          <button type="button" class="gx-btn" @click="backupToggles"><i class="bi bi-download"></i> Backup Toggles</button>
-          <button type="button" class="gx-btn gx-btn--tonal" @click="$refs.restoreInput.click()"><i class="bi bi-upload"></i> Restore Toggles</button>
+          <button type="button" class="gx-btn" @click="backupToggles"><i class="bi bi-download"></i> Backup</button>
+          <button type="button" class="gx-btn gx-btn--tonal" :disabled="isOnroad" @click="$refs.restoreInput.click()"><i class="bi bi-upload"></i> Restore</button>
           <button type="button" class="gx-btn gx-btn--tonal" @click="resetDefault">Reset to Default</button>
           <button type="button" class="gx-btn gx-btn--danger" @click="deleteAllDrivingRoutes">Delete All Driving Routes</button>
           <input ref="restoreInput" type="file" accept=".json" style="display:none;" @change="onRestoreFile" />
         </div>
-        <p class="gx-note" style="padding: 0 var(--sp-4);">Backup downloads your toggle settings as a JSON file. Restore re-applies one, and Reset to Default clears them back to stock and reboots.</p>
+        <p class="gx-note" style="padding: 0 var(--sp-4);">Backup downloads settings and dashboard history, plus model mileage, interventions and disengagements when model statistics are available. Restore applies settings and merges history while parked. Older toggle backups are also supported. Personality profile documents and their master switch are excluded. Model files and driving videos are not included. Reset to Default clears settings and reboots.</p>
 
         <div v-if="factoryResetStatus" style="padding: var(--sp-3); border-top: 1px solid var(--border-color, rgba(255,255,255,.08));">
           <div class="gx-section__header">

--- a/starpilot/system/the_galaxy/backup.py
+++ b/starpilot/system/the_galaxy/backup.py
@@ -1,0 +1,337 @@
+"""Portable data-only backups. Imported SQL and file paths are never executed."""
+import copy
+import json
+import math
+import sqlite3
+from pathlib import Path
+
+def _statistics_support():
+  """Load the optional recorder schema only when statistics are requested."""
+  try:
+    from openpilot.starpilot.common.model_stats import COUNTERS, parse_identity, measurement_policy
+    from openpilot.starpilot.common.model_stats_store import SCHEMA_VERSION, Store
+  except ImportError as error:
+    raise ValueError("Model statistics support is unavailable. Install the compatible statistics recorder to export or restore model history.") from error
+  return COUNTERS, parse_identity, measurement_policy, SCHEMA_VERSION, Store
+
+
+def require_parked(params):
+  """Fail closed using current runtime flags; never create a carState reader."""
+  def boolean(key):
+    value = params.get(key)
+    if type(value) is bool:
+      return value
+    if type(value) in (str, bytes):
+      if value in ('1', b'1', 'True', b'True'):
+        return True
+      if value in ('0', b'0', 'False', b'False'):
+        return False
+    return None
+  try:
+    permitted = (boolean('IsOnroad') is False and boolean('IsOffroad') is True
+                 and boolean('SafeMode') is False and params.get('SafeModeBackup') is None)
+  except Exception:
+    permitted = False
+  if not permitted:
+    raise ValueError("Restore requires a confirmed parked device with Safe Mode off and no pending Safe Mode restoration.")
+
+FORMAT = 'starpilot-backup'
+VERSION = 1
+MAX_BYTES = 64 * 1024 * 1024
+HISTORY_KEYS = ('GalaxyDashboardStats', 'ModelDrivesAndScores', 'UserFavorites', 'ModelSortMode', 'StarPilotStats', 'ApiCache_DriveStats')
+DRIVE_FIELDS = ('id', 'started', 'updated', 'complete', 'sequence', 'gaps', 'state', 'software')
+
+
+def json_document(value):
+  if isinstance(value, (str, bytes)):
+    value = json.loads(value)
+  # Reject non-finite values anywhere, including nested history documents.
+  json.dumps(value, allow_nan=False)
+  return value
+
+
+def export_statistics(path):
+  try:
+    COUNTERS, _, _, SCHEMA_VERSION, _ = _statistics_support()
+  except ValueError:
+    if not Path(path).exists():
+      return None  # Explicitly mark a settings/history-only export.
+    raise
+  METRIC_FIELDS = ('drive', 'owner', 'mode', *COUNTERS)
+  result = {'schemaVersion': SCHEMA_VERSION, 'drives': [], 'metrics': []}
+  if not Path(path).exists():
+    return result
+  with sqlite3.connect(Path(path).resolve().as_uri() + '?mode=ro', uri=True, timeout=5) as db:
+    db.execute('BEGIN')
+    if db.execute('PRAGMA user_version').fetchone()[0] != SCHEMA_VERSION:
+      raise ValueError('Unsupported model statistics schema')
+    for name, fields in [('drives', DRIVE_FIELDS), ('metrics', METRIC_FIELDS)]:
+      result[name] = [dict(zip(fields, row)) for row in db.execute(f'SELECT {", ".join(fields)} FROM {name}')]
+  return validate_statistics(result)
+
+
+def _number(value, integer=False):
+  try:
+    return type(value) in (int, float) and math.isfinite(value) and value >= 0 and (not integer or int(value) == value)
+  except OverflowError:
+    return False
+
+
+def _metric_values(row):
+  COUNTERS, parse_identity, _, _, _ = _statistics_support()
+  if not isinstance(row, dict) or set(row) != {'owner', 'mode', *COUNTERS}:
+    raise ValueError('Invalid checkpoint metric')
+  owner = parse_identity(row['owner'])
+  if owner is None or row['mode'] not in ('full', 'aol', 'manual'):
+    raise ValueError('Invalid metric ownership')
+  if any(not _number(row[k], not k.endswith('Meters')) for k in COUNTERS):
+    raise ValueError('Invalid metric counters')
+  return (owner, row['mode']), tuple(row[k] for k in COUNTERS)
+
+
+def _validate_supersession(drives, states, checkpoints):
+  """Recovery references must describe a complete, non-decreasing replacement.
+
+  This validates internal consistency, not authenticity of imported history.
+  Original records remain present in every supported recovery export.
+  """
+  COUNTERS, _, measurement_policy, _, _ = _statistics_support()
+  replaced_by = {}
+  for drive, state in states.items():
+    refs = state.get('supersedes', [])
+    if not isinstance(refs, list) or any(not isinstance(ref, str) for ref in refs) or len(set(refs)) != len(refs):
+      raise ValueError('Invalid recovery references')
+    if not refs:
+      continue
+    recovery, route = state.get('recovery'), state.get('routeName')
+    if (not isinstance(recovery, dict) or type(recovery.get('version')) is not int or recovery['version'] != 1
+        or recovery.get('source') != 'retained-rlog' or not isinstance(route, str) or not 0 < len(route) <= 128
+        or drive != 'recovered:' + route or drives[drive]['complete'] != 1
+        or not isinstance(recovery.get('digest'), str) or len(recovery['digest']) != 64
+        or any(c not in '0123456789abcdef' for c in recovery['digest'])):
+      raise ValueError('Invalid recovery provenance')
+    totals = {}
+    policy = measurement_policy(state)
+    for ref in refs:
+      if ref == drive or ref not in states or ref in replaced_by:
+        raise ValueError('Recovery references must be unique and contained in this backup')
+      replaced_by[ref] = drive
+      old = states[ref]
+      if old.get('coverageLoss') or policy is None or measurement_policy(old) != policy:
+        raise ValueError('Recovery cannot hide coverage loss or change measurement definitions')
+      old_route = old.get('routeName')
+      if old_route not in (None, route) or (old_route is None and (
+          drives[ref]['started'] < drives[drive]['started'] - 2 or drives[ref]['updated'] > drives[drive]['updated'] + 2)):
+        raise ValueError('Recovery references an unrelated route')
+      for key, values in checkpoints[ref].items():
+        total = totals.setdefault(key, [0] * len(COUNTERS))
+        for i, value in enumerate(values):
+          total[i] += value
+    current = checkpoints[drive]
+    if any(key not in current or any(new < old - 1e-5 for old, new in zip(values, current[key])) for key, values in totals.items()):
+      raise ValueError('Recovery would reduce accepted counters')
+  # Iterative traversal keeps deeply nested imported graphs off the call stack.
+  complete = set()
+  for start in replaced_by:
+    path, node = set(), start
+    while node in replaced_by and node not in complete:
+      if node in path:
+        raise ValueError('Cyclic recovery references')
+      path.add(node)
+      node = replaced_by[node]
+    complete.update(path)
+
+
+def validate_statistics(data):
+  if data is None:
+    return None
+  COUNTERS, parse_identity, _, SCHEMA_VERSION, _ = _statistics_support()
+  METRIC_FIELDS = ('drive', 'owner', 'mode', *COUNTERS)
+  if not isinstance(data, dict) or type(data.get('schemaVersion')) is not int or data.get('schemaVersion') != SCHEMA_VERSION:
+    raise ValueError('Unsupported model statistics schema')
+  drives, metrics = data.get('drives'), data.get('metrics')
+  if not isinstance(drives, list) or not isinstance(metrics, list) or len(drives) > 100000 or len(metrics) > 500000:
+    raise ValueError('Invalid model history')
+  ids, checkpoints, states, drive_rows, stored = set(), {}, {}, {}, {}
+  for row in drives:
+    if not isinstance(row, dict) or set(row) != set(DRIVE_FIELDS):
+      raise ValueError('Invalid drive record')
+    if not isinstance(row['id'], str) or not 0 < len(row['id']) <= 512 or row['id'] in ids:
+      raise ValueError('Duplicate or invalid drive identity')
+    ids.add(row['id'])
+    if any(not _number(row[k], k in ('complete', 'sequence', 'gaps')) for k in ('started', 'updated', 'complete', 'sequence', 'gaps')) or row['complete'] not in (0, 1):
+      raise ValueError('Invalid drive counters')
+    if not isinstance(row['software'], str) or not isinstance(row['state'], str) or not isinstance(json_document(row['state']), dict):
+      raise ValueError('Invalid drive state')
+    state = json_document(row['state'])
+    if (any(type(state.get(k)) is not int or not 0 <= state[k] <= 2**63 - 1 for k in ('sequence', 'gaps'))
+        or state['sequence'] != row['sequence'] or state['gaps'] != row['gaps'] or not isinstance(state.get('metrics'), list)):
+      raise ValueError('Inconsistent drive checkpoint')
+    previous = state.get('previous')
+    if previous is not None and (not isinstance(previous, dict) or (previous.get('owner') is not None and parse_identity(previous['owner']) is None)):
+      raise ValueError('Invalid drive provenance')
+    checkpoint = {}
+    for metric in state['metrics']:
+      key, values = _metric_values(metric)
+      if key in checkpoint:
+        raise ValueError('Duplicate checkpoint metric')
+      checkpoint[key] = values
+    checkpoints[row['id']], states[row['id']], drive_rows[row['id']] = checkpoint, state, row
+  for row in metrics:
+    if not isinstance(row, dict) or set(row) != set(METRIC_FIELDS):
+      raise ValueError('Invalid model metric')
+    if not isinstance(row['drive'], str) or row['drive'] not in ids:
+      raise ValueError('Invalid metric ownership')
+    key, values = _metric_values({k: row[k] for k in METRIC_FIELDS if k != 'drive'})
+    current = stored.setdefault(row['drive'], {})
+    if key in current:
+      raise ValueError('Duplicate metric counters')
+    current[key] = values
+  if any(checkpoints[drive] != stored.get(drive, {}) for drive in ids):
+    raise ValueError('Checkpoint and stored metric counters disagree')
+  _validate_supersession(drive_rows, states, checkpoints)
+  return data
+
+
+def merge_statistics(db, data):
+  """Retain existing drive identities intact; repeated imports never add counts."""
+  validate_statistics(data)
+  COUNTERS, _, _, _, _ = _statistics_support()
+  METRIC_FIELDS = ('drive', 'owner', 'mode', *COUNTERS)
+  existing = {r[0] for r in db.execute('SELECT id FROM drives')}
+  added = {r['id'] for r in data['drives']} - existing
+  # Two independent recovery exports may agree on the original fragment but
+  # supply different replacements. Validate against retained edges as well as
+  # within the imported graph, otherwise both replacements would be counted.
+  retained_references = {row[0] for row in db.execute(
+    "SELECT j.value FROM drives, json_each(drives.state, '$.supersedes') AS j WHERE j.type='text' AND j.value != drives.id")}
+  incoming = {row['id']: row for row in data['drives']}
+  incoming_metrics = {}
+  for row in data['metrics']:
+    incoming_metrics.setdefault(row['drive'], set()).add(tuple(row[k] for k in METRIC_FIELDS))
+  for drive in added:
+    for ref in json_document(incoming[drive]['state']).get('supersedes', []):
+      if ref in retained_references:
+        raise ValueError('Recovery conflicts with a retained replacement for drive: ' + ref)
+      if ref in existing:
+        retained = dict(zip(DRIVE_FIELDS, db.execute('SELECT ' + ','.join(DRIVE_FIELDS) + ' FROM drives WHERE id=?', (ref,)).fetchone()))
+        if retained != incoming[ref]:
+          raise ValueError('Recovery conflicts with a different retained drive: ' + ref)
+        retained_metrics = {tuple(row) for row in db.execute('SELECT ' + ','.join(METRIC_FIELDS) + ' FROM metrics WHERE drive=?', (ref,))}
+        supplied_metrics = incoming_metrics.get(ref, set())
+        if retained_metrics != supplied_metrics:
+          raise ValueError('Recovery conflicts with retained metric counters: ' + ref)
+  for table, fields, rows in [('drives', DRIVE_FIELDS, data['drives']), ('metrics', METRIC_FIELDS, data['metrics'])]:
+    for row in rows:
+      if row['id' if table == 'drives' else 'drive'] in added:
+        db.execute(f'INSERT INTO {table} ({", ".join(fields)}) VALUES ({", ".join("?" for _ in fields)})', [row[k] for k in fields])
+  return len(added)
+
+
+def merge_history(saved, current):
+  """Union records by identity. Existing values win conflicts; never sum totals."""
+  if isinstance(saved, dict) and isinstance(current, dict):
+    result = copy.deepcopy(saved)
+    for key, value in current.items():
+      result[key] = merge_history(result[key], value) if key in result else copy.deepcopy(value)
+    return result
+  if isinstance(saved, list) and isinstance(current, list):
+    return copy.deepcopy(current + [v for v in saved if v not in current])
+  return copy.deepcopy(current)
+
+
+class RestoreError(OSError):
+  """An I/O failure, optionally with an incomplete settings rollback."""
+
+
+def _verify_setting(params, key, value):
+  expected = value
+  # Params serializes/coerces according to its compiled registry. Compare the
+  # corresponding typed readback, including its empty-value/absent convention.
+  if value is not None and hasattr(params, '_put_cast') and hasattr(params, 'cpp2python'):
+    encoded = params._put_cast(key, value)
+    expected = params.cpp2python(key, encoded) if encoded else None
+  actual = params.get(key)
+  if type(actual) is not type(expected) or actual != expected:
+    raise RestoreError('Setting write could not be verified: ' + key)
+
+
+def apply_restore(params, settings, history, statistics, db_path, backup_dir, parked):
+  """Validate before entry. Roll back params and the SQL transaction on failure."""
+  parked()
+  validate_statistics(statistics)
+  updates = dict(settings)
+  for key, value in history.items():
+    old = params.get(key)
+    if key in ('GalaxyDashboardStats', 'ModelDrivesAndScores', 'StarPilotStats', 'ApiCache_DriveStats'):
+      old = json_document(old) if old not in (None, '', b'') else {}
+      merged = merge_history(value, old)
+      if key == 'GalaxyDashboardStats':
+        merged['routes'] = {**value.get('routes', {}), **old.get('routes', {})}
+      if key == 'StarPilotStats':
+        def cumulative(saved, current):
+          if isinstance(saved, dict) and isinstance(current, dict):
+            return {k: cumulative(saved[k], current[k]) if k in saved and k in current else copy.deepcopy(current[k] if k in current else saved[k]) for k in saved.keys() | current.keys()}
+          if _number(saved) and _number(current):
+            return max(saved, current)
+          return copy.deepcopy(current)
+        merged = cumulative(value, old)
+        if 'Month' in old:
+          merged['Month'] = old['Month']
+          if value.get('Month') != old['Month']:
+            merged['CurrentMonthsMeters'] = old.get('CurrentMonthsMeters', 0)
+      value = merged
+    elif key == 'UserFavorites' and old not in (None, '', b''):
+      old = old.decode() if isinstance(old, bytes) else old
+      value = ','.join(dict.fromkeys(v.strip() for v in (str(old) + ',' + str(value)).split(',') if v.strip()))
+    updates[key] = value
+  old_values = {key: params.get(key) for key in updates}
+  backup_dir = Path(backup_dir)
+  backup_dir.mkdir(parents=True, exist_ok=False, mode=0o700)
+  # Raw values preserve exact types/bytes for an operator recovery after power loss.
+  import base64
+  raw = {k: {'bytes': base64.b64encode(v).decode()} if isinstance(v, bytes) else {'value': v} for k, v in old_values.items()}
+  recovery = backup_dir / 'settings-before.json'
+  recovery.write_text(json.dumps(raw, allow_nan=False))
+  recovery.chmod(0o600)
+  store = _statistics_support()[4](db_path) if statistics is not None else None
+  try:
+    added = 0
+    if store is not None:
+      with sqlite3.connect(backup_dir / 'model_stats-before.sqlite') as snapshot:
+        store.db.backup(snapshot)
+      store.db.execute('BEGIN IMMEDIATE')
+      added = merge_statistics(store.db, statistics)
+    try:
+      parked()
+      for key, value in updates.items():
+        parked()
+        params.put(key, value)
+        _verify_setting(params, key, value)
+      parked()
+      if store is not None:
+        store.db.commit()
+    except Exception as error:
+      failures = []
+      try:
+        if store is not None:
+          store.db.rollback()
+      except Exception:
+        failures.append('statistics transaction')
+      for key, value in old_values.items():
+        try:
+          if value is None:
+            params.remove(key)
+          else:
+            params.put(key, value)
+          _verify_setting(params, key, value)
+        except Exception:
+          failures.append(key)
+      if failures:
+        raise RestoreError('Restore failed; rollback incomplete for ' + ', '.join(failures) +
+                           '. A recovery copy is retained on the device.') from error
+      raise
+  finally:
+    if store is not None:
+      store.close()
+  return {'restoredCount': len(settings), 'addedDrives': added, 'existingDrives': len(statistics['drives']) - added if statistics is not None else 0}

--- a/starpilot/system/the_galaxy/tests/test_backup.py
+++ b/starpilot/system/the_galaxy/tests/test_backup.py
@@ -1,0 +1,93 @@
+import copy
+import json
+import pytest
+
+from openpilot.starpilot.system.the_galaxy import backup
+pytest.importorskip('openpilot.starpilot.common.model_stats_store', reason='Requires optional statistics recorder')
+from openpilot.starpilot.common.model_stats_store import read_stats
+from openpilot.starpilot.common.tests.test_model_stats_store import recorded
+
+
+class Params:
+  def __init__(self, values=None):
+    self.values = dict(values or {})
+    self.fail = None
+  def get(self, key):
+    return self.values.get(key)
+  def put(self, key, value):
+    if key == self.fail:
+      self.fail = None
+      raise OSError('Injected write failure')
+    self.values[key] = value
+  def remove(self, key):
+    self.values.pop(key, None)
+
+
+def test_roundtrip_and_repeat_keeps_all_metrics(tmp_path):
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  recorded(source, complete=True)
+  data = backup.export_statistics(source)
+  params = Params({'GalaxyDashboardStats': {'version': 1, 'routes': {'new': {'duration': 4}}}})
+  history = {'GalaxyDashboardStats': {'version': 1, 'routes': {'old': {'duration': 2}}}}
+  result = backup.apply_restore(params, {'GpuModelReadySound': False}, history, data, target, tmp_path/'recovery1', lambda: None)
+  assert result['addedDrives'] == 1
+  assert read_stats(source)['models'] == read_stats(target)['models']
+  assert read_stats(source)['history'] == read_stats(target)['history']
+  assert set(params.values['GalaxyDashboardStats']['routes']) == {'new', 'old'}
+  result = backup.apply_restore(params, {}, history, data, target, tmp_path/'recovery2', lambda: None)
+  assert result['addedDrives'] == 0
+  assert read_stats(source)['models'] == read_stats(target)['models']
+
+
+def test_existing_drive_is_never_overwritten(tmp_path):
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  recorded(source, complete=False)
+  recorded(target, complete=True)
+  before = backup.export_statistics(target)
+  backup.apply_restore(Params(), {}, {}, backup.export_statistics(source), target, tmp_path/'recovery', lambda: None)
+  assert backup.export_statistics(target) == before
+
+
+def test_failed_settings_write_rolls_back_both_stores(tmp_path):
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  recorded(source, complete=True)
+  params = Params({'a': b'original'})
+  params.fail = 'b'
+  with pytest.raises(OSError):
+    backup.apply_restore(params, {'a': 'changed', 'b': 'fail'}, {}, backup.export_statistics(source), target, tmp_path/'recovery', lambda: None)
+  assert params.values == {'a': b'original'}
+  assert backup.export_statistics(target)['drives'] == []
+  assert (tmp_path/'recovery/settings-before.json').exists()
+
+
+@pytest.mark.parametrize('change', ['schema', 'nan', 'negative', 'duplicate', 'orphan', 'identity', 'fractional'])
+def test_rejects_corrupt_statistics(tmp_path, change):
+  path = tmp_path/'source.sqlite'
+  recorded(path, complete=True)
+  data = backup.export_statistics(path)
+  if change == 'schema': data['schemaVersion'] = 99
+  elif change == 'nan': data['metrics'][0]['assistedMeters'] = float('nan')
+  elif change == 'negative': data['metrics'][0]['interventions'] = -1
+  elif change == 'duplicate': data['drives'].append(copy.deepcopy(data['drives'][0]))
+  elif change == 'orphan': data['metrics'][0]['drive'] = 'missing'
+  elif change == 'identity': data['metrics'][0]['owner'] = '{}'
+  elif change == 'fractional': data['metrics'][0]['interventions'] = .5
+  with pytest.raises(ValueError): backup.validate_statistics(data)
+
+
+def test_onroad_refusal_writes_nothing(tmp_path):
+  def parked(): raise ValueError('onroad')
+  with pytest.raises(ValueError):
+    backup.apply_restore(Params(), {}, {}, {}, tmp_path/'db', tmp_path/'recovery', parked)
+  assert list(tmp_path.iterdir()) == []
+
+
+def test_lifetime_totals_keep_larger_values_without_summing(tmp_path):
+  params = Params({'StarPilotStats': {'StarPilotMeters': 200, 'StarPilotSeconds': 10, 'Month': 9, 'CurrentMonthsMeters': 20, 'ModelTimes': {'a': 50}}})
+  history = {'StarPilotStats': {'StarPilotMeters': 100, 'StarPilotSeconds': 30, 'Month': 8, 'CurrentMonthsMeters': 100, 'ModelTimes': {'a': 60, 'b': 5}}}
+  empty = {'schemaVersion': 1, 'drives': [], 'metrics': []}
+  backup.apply_restore(params, {}, history, empty, tmp_path/'db', tmp_path/'r1', lambda: None)
+  expected = {'StarPilotMeters': 200, 'StarPilotSeconds': 30, 'Month': 9, 'CurrentMonthsMeters': 20, 'ModelTimes': {'a': 60, 'b': 5}}
+  assert params.values['StarPilotStats'] == expected
+  backup.apply_restore(params, {}, history, empty, tmp_path/'db', tmp_path/'r2', lambda: None)
+  assert params.values['StarPilotStats'] == expected

--- a/starpilot/system/the_galaxy/tests/test_backup_api.py
+++ b/starpilot/system/the_galaxy/tests/test_backup_api.py
@@ -1,0 +1,83 @@
+import json
+import pytest
+from test_navigation_params import _params_client, the_galaxy as server
+
+def setup(monkeypatch, state=None):
+  client,params=_params_client(monkeypatch,{'IsOnroad':False,'IsOffroad':True,'SafeMode':False,'ForceOffroad':False,**(state or {})},'tici')
+  monkeypatch.setattr(server,'_params_raw',params)
+  monkeypatch.setattr(server,'_params_live_raw',params)
+  monkeypatch.setattr(server,'_get_toggle_backup_keys',lambda:{'ForceOffroad','CustomPersonalities',server.PERSONALITY_PROFILES_PARAM})
+  monkeypatch.setattr(server,'_coerce_toggle_restore_value',lambda key,value:value)
+  monkeypatch.setattr(server.galaxy_backup,'export_statistics',lambda path:None)
+  monkeypatch.setattr(server.utilities,'stop_dashboard_background_analysis',lambda:None)
+  monkeypatch.setattr(server.utilities,'_invalidate_dashboard_cache',lambda:None)
+  monkeypatch.setattr(server,'update_starpilot_toggles',lambda:None)
+  calls=[]
+  monkeypatch.setattr(server.galaxy_backup,'apply_restore',lambda *args:calls.append(args) or {'restoredCount':len(args[1]),'addedDrives':0,'existingDrives':0})
+  return client,params,calls
+
+def test_standalone_export_restore_excludes_profile_documents(monkeypatch):
+  client,params,calls=setup(monkeypatch)
+  params.values[server.PERSONALITY_PROFILES_PARAM]={'unsupported':'profile document'}
+  response=client.post('/api/backup');assert response.status_code==200,response.data
+  data=json.loads(response.data)
+  assert data['format']=='starpilot-backup'
+  assert data['modelStatistics'] is None
+  assert 'personalityProfiles' not in data
+  assert data['omittedSettings']==[server.PERSONALITY_PROFILES_PARAM,'CustomPersonalities']
+  assert server.PERSONALITY_PROFILES_PARAM not in data['settings']
+  assert 'CustomPersonalities' not in data['settings']
+  assert client.post('/api/restore',json=data).status_code==200
+  assert calls[0][1]=={'ForceOffroad':False}
+
+@pytest.mark.parametrize('damage',['profile','version','missing_statistics','statistics','secret_history','negative_distance'])
+def test_invalid_backup_fails_before_apply(monkeypatch,damage):
+  client,params,calls=setup(monkeypatch)
+  data=json.loads(client.post('/api/backup').data)
+  if damage=='profile':data['personalityProfiles']={'profiles':{}}
+  elif damage=='version':data['version']=99
+  elif damage=='missing_statistics':del data['modelStatistics']
+  elif damage=='statistics':
+    data['modelStatistics']={'schemaVersion':1,'drives':[],'metrics':[]}
+    def unavailable():raise ValueError('Model statistics support is unavailable')
+    monkeypatch.setattr(server.galaxy_backup,'_statistics_support',unavailable)
+  elif damage=='secret_history':data['history']['GithubSshKeys']='secret'
+  else:data['history']['GalaxyDashboardStats']={'version':1,'routes':{'x':{'distanceMeters':-1}}}
+  response=client.post('/api/restore',json=data)
+  assert response.status_code==400,response.data
+  assert not calls
+
+@pytest.mark.parametrize('state',[{'IsOnroad':True},{'SafeMode':True},{'SafeModeBackup':{}},{'IsOffroad':None}])
+def test_restore_refuses_unconfirmed_parked_state(monkeypatch,state):
+  client,params,calls=setup(monkeypatch,state)
+  data=json.loads(client.post('/api/backup').data)
+  assert client.post('/api/restore',json=data).status_code==400
+  assert not calls
+
+def test_statistics_export_failure_is_explicit(monkeypatch):
+  client,params,calls=setup(monkeypatch)
+  def unavailable(path):raise ValueError('Model statistics support is unavailable')
+  monkeypatch.setattr(server.galaxy_backup,'export_statistics',unavailable)
+  response=client.post('/api/backup')
+  assert response.status_code==409
+  assert 'unavailable' in response.json['message']
+
+@pytest.mark.parametrize('onroad',[False,True])
+def test_legacy_file_on_new_route_uses_guarded_restore(monkeypatch,onroad):
+  client,params,calls=setup(monkeypatch,{'IsOnroad':onroad,'IsOffroad':not onroad})
+  monkeypatch.setattr(server.utilities,'decode_parameters',lambda _: {'ForceOffroad':False,'CustomPersonalities':True})
+  response=client.post('/api/restore',json={'format':server.TOGGLE_BACKUP_FORMAT,'version':1,'data':'encoded'})
+  assert response.status_code==(400 if onroad else 200),response.data
+  if onroad:assert not calls
+  else:assert calls[0][1]=={'ForceOffroad':False}
+
+
+def test_restore_rechecks_live_safe_mode_during_apply(monkeypatch):
+  client,params,calls=setup(monkeypatch)
+  data=json.loads(client.post('/api/backup').data)
+  def apply(*args):
+    params.values['SafeMode']=True
+    args[-1]()
+    raise AssertionError('Restore guard must reject new Safe Mode')
+  monkeypatch.setattr(server.galaxy_backup,'apply_restore',apply)
+  assert client.post('/api/restore',json=data).status_code==400

--- a/starpilot/system/the_galaxy/tests/test_backup_client.mjs
+++ b/starpilot/system/the_galaxy/tests/test_backup_client.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import vm from 'node:vm'
+import test from 'node:test'
+const source=fs.readFileSync(new URL('../assets/mobile/js/views/SystemTools.js',import.meta.url),'utf8')
+const method=source.slice(source.indexOf('    async onRestoreFile('),source.indexOf('    async resetDefault('))
+function setup(confirm=async()=>true) {
+  const calls=[],messages=[]
+  const context=vm.createContext({api:{restoreToggles:async data=>{calls.push(data);return {}}},GalaxyConfirm:confirm,showSnackbar:(...args)=>messages.push(args)})
+  vm.runInContext('globalThis.instance={isOnroad:false,'+method+'}',context)
+  return {instance:context.instance,calls,messages}
+}
+const event=(text=async()=>'{"format":"starpilot-backup"}')=>({target:{value:'chosen',files:[{size:100,text}]}})
+test('file read failure reports an error without dispatch',async()=>{
+  const {instance,calls,messages}=setup()
+  await instance.onRestoreFile(event(async()=>{throw Error('read failed')}))
+  assert.equal(calls.length,0)
+  assert.equal(messages[0][0],'read failed')
+})
+test('road state is rechecked after confirmation',async()=>{
+  const state=setup(async()=>{state.instance.isOnroad=true;return true})
+  await state.instance.onRestoreFile(event())
+  assert.equal(state.calls.length,0)
+  assert.match(state.messages[0][0],/Park/)
+})
+test('cancel leaves saved state alone and successful confirm dispatches once',async()=>{
+  const canceled=setup(async()=>false)
+  await canceled.instance.onRestoreFile(event())
+  assert.equal(canceled.calls.length,0)
+  const accepted=setup()
+  await accepted.instance.onRestoreFile(event())
+  assert.equal(accepted.calls.length,1)
+  assert.equal(accepted.calls[0].format,'starpilot-backup')
+})

--- a/starpilot/system/the_galaxy/tests/test_backup_integrity.py
+++ b/starpilot/system/the_galaxy/tests/test_backup_integrity.py
@@ -1,0 +1,176 @@
+import copy
+import json
+import sqlite3
+
+import pytest
+
+from openpilot.starpilot.system.the_galaxy import backup
+pytest.importorskip('openpilot.starpilot.common.model_stats_store', reason='Requires optional statistics recorder')
+from openpilot.starpilot.common.model_stats_store import read_stats
+from openpilot.starpilot.common.model_stats_recovery import import_routes
+from openpilot.starpilot.common.tests.test_model_stats_log_recovery import fixture
+from openpilot.starpilot.common.tests.test_model_stats_store import recorded
+from test_backup import Params
+
+
+def test_silent_setting_failure_rolls_back_statistics_and_prior_settings(tmp_path):
+  class SilentFailure(Params):
+    def put(self, key, value):
+      if key != 'GpuModelReadySound':
+        super().put(key, value)
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  recorded(source, complete=True)
+  params = SilentFailure({'GpuModelReadySound': True, 'a': 'before'})
+  with pytest.raises(OSError, match='GpuModelReadySound'):
+    backup.apply_restore(params, {'a': 'after', 'GpuModelReadySound': False}, {}, backup.export_statistics(source),
+                         target, tmp_path/'recovery', lambda: None)
+  assert params.values == {'GpuModelReadySound': True, 'a': 'before'}
+  assert backup.export_statistics(target)['drives'] == []
+
+
+def test_rollback_attempts_every_setting_and_reports_incomplete_recovery(tmp_path):
+  class BrokenRollback(Params):
+    def put(self, key, value):
+      if key == 'fail' or (key == 'a' and value == 'old-a'):
+        raise OSError('Injected write failure')
+      super().put(key, value)
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  recorded(source, complete=True)
+  params = BrokenRollback({'a': 'old-a', 'b': 'old-b'})
+  with pytest.raises(OSError, match='(?i)rollback incomplete.*a'):
+    backup.apply_restore(params, {'a': 'new-a', 'b': 'new-b', 'fail': 'x'}, {}, backup.export_statistics(source),
+                         target, tmp_path/'recovery', lambda: None)
+  assert params.get('b') == 'old-b'
+  assert params.get('fail') is None
+  assert backup.export_statistics(target)['drives'] == []
+
+
+@pytest.mark.parametrize('damage', ['count', 'checkpoint_count', 'checkpoint_bool', 'extra_metric', 'missing_metric', 'duplicate_checkpoint'])
+def test_checkpoint_and_table_must_agree(tmp_path, damage):
+  source = tmp_path/'source.sqlite'
+  recorded(source, complete=True)
+  data = backup.export_statistics(source)
+  state = json.loads(data['drives'][0]['state'])
+  if damage == 'count': data['metrics'][0]['interventions'] += 1000
+  elif damage == 'checkpoint_count': state['metrics'][0]['interventions'] += 1000
+  elif damage == 'checkpoint_bool': state['sequence'] = True; data['drives'][0]['sequence'] = 1
+  elif damage == 'extra_metric': data['metrics'].append({**data['metrics'][0], 'mode': 'manual'})
+  elif damage == 'missing_metric': data['metrics'] = []
+  elif damage == 'duplicate_checkpoint': state['metrics'].append(copy.deepcopy(state['metrics'][0]))
+  data['drives'][0]['state'] = json.dumps(state)
+  with pytest.raises(ValueError): backup.validate_statistics(data)
+
+
+def test_supersession_cannot_reference_history_outside_backup(tmp_path):
+  source = tmp_path/'source.sqlite'
+  recorded(source, drive='incoming', complete=True)
+  data = backup.export_statistics(source)
+  state = json.loads(data['drives'][0]['state'])
+  state['supersedes'] = ['unrelated-existing-drive']
+  data['drives'][0]['state'] = json.dumps(state)
+  with pytest.raises(ValueError): backup.validate_statistics(data)
+
+
+@pytest.mark.parametrize('damage', ['provenance', 'decreased', 'cycle', 'policy', 'coverage_loss'])
+def test_recovery_relationships_must_be_consistent(tmp_path, damage):
+  source = tmp_path/'source.sqlite'
+  _, route = fixture(source)
+  import_routes(source, [route], tmp_path/'before.sqlite')
+  data = backup.export_statistics(source)
+  old = next(row for row in data['drives'] if row['id'] == 'original')
+  replacement = next(row for row in data['drives'] if row['id'].startswith('recovered:'))
+  state = json.loads(replacement['state'])
+  if damage == 'provenance': state.pop('recovery')
+  elif damage == 'decreased':
+    state['metrics'][0]['assistedMeters'] = 0
+    next(row for row in data['metrics'] if row['drive'] == replacement['id'])['assistedMeters'] = 0
+  elif damage == 'cycle':
+    old_state = json.loads(old['state']); old_state['supersedes'] = [replacement['id']]; old['state'] = json.dumps(old_state)
+  elif damage == 'policy': state['definitionVersion'] = 1; state['interventionReleaseSeconds'] = 0.5
+  elif damage == 'coverage_loss':
+    old_state = json.loads(old['state']); old_state['coverageLoss'] = True; old['state'] = json.dumps(old_state)
+  replacement['state'] = json.dumps(state)
+  with pytest.raises(ValueError): backup.validate_statistics(data)
+
+
+def test_recovery_cannot_supersede_a_different_retained_collision(tmp_path):
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  _, route = fixture(source)
+  old = backup.export_statistics(source)
+  import_routes(source, [route], tmp_path/'before.sqlite')
+  incoming = backup.export_statistics(source)
+  backup.apply_restore(Params(), {}, {}, old, target, tmp_path/'first', lambda: None)
+  with sqlite3.connect(target) as db:
+    db.execute('UPDATE drives SET software=? WHERE id=?', ('different-retained-record', 'original'))
+  before = backup.export_statistics(target)
+  with pytest.raises(ValueError, match='(?i)retained|collision'):
+    backup.apply_restore(Params(), {}, {}, incoming, target, tmp_path/'second', lambda: None)
+  assert backup.export_statistics(target) == before
+
+
+def test_valid_recovered_backup_roundtrip_is_idempotent(tmp_path):
+  source, target = tmp_path/'source.sqlite', tmp_path/'target.sqlite'
+  _, route = fixture(source)
+  old = backup.export_statistics(source)
+  import_routes(source, [route], tmp_path/'before.sqlite')
+  recovered = backup.export_statistics(source)
+  for i, data in enumerate([old, recovered, recovered, old]):
+    backup.apply_restore(Params(), {}, {}, data, target, tmp_path/f'restore-{i}', lambda: None)
+  assert read_stats(target) == read_stats(source)
+
+
+def test_native_params_readback_uses_registered_types_and_empty_values(tmp_path):
+  from openpilot.common.params import Params as NativeParams
+  params = NativeParams(str(tmp_path/'params'))
+  empty = {'schemaVersion': 1, 'drives': [], 'metrics': []}
+  values = {'IsMetric': True, 'LongitudinalPersonality': 2, 'DrivingModelName': '',
+            'GalaxyDashboardStats': {'version': 1, 'routes': {}}}
+  report = backup.apply_restore(params, values, {}, empty, tmp_path/'stats.sqlite', tmp_path/'before', lambda: None)
+  assert report['restoredCount'] == 4
+  assert params.get('IsMetric') is True
+  assert params.get('LongitudinalPersonality') == 2
+  assert params.get('DrivingModelName') is None
+  assert params.get('GalaxyDashboardStats') == {'version': 1, 'routes': {}}
+
+
+def test_silent_removal_failure_is_reported_after_other_keys_rollback(tmp_path):
+  class FailedRemoval(Params):
+    def remove(self, key):
+      if key != 'new': super().remove(key)
+  params = FailedRemoval({'last': 'original'})
+  params.fail = 'fail'
+  empty = {'schemaVersion': 1, 'drives': [], 'metrics': []}
+  with pytest.raises(OSError, match='rollback incomplete for new'):
+    backup.apply_restore(params, {'new': 'value', 'last': 'changed', 'fail': 'x'}, {}, empty,
+                         tmp_path/'db', tmp_path/'before', lambda: None)
+  assert params.get('last') == 'original'
+  assert params.get('new') == 'value'
+
+
+def test_guard_transition_during_restore_rolls_back_each_setting(tmp_path):
+  params = Params({'a': 'original'})
+  def guard():
+    if params.get('a') == 'changed': raise ValueError('state changed')
+  with pytest.raises(ValueError, match='state changed'):
+    backup.apply_restore(params, {'a': 'changed', 'b': 'other'}, {}, {'schemaVersion': 1, 'drives': [], 'metrics': []},
+                         tmp_path/'db', tmp_path/'before', guard)
+  assert params.values == {'a': 'original'}
+
+
+def test_restore_rejects_second_replacement_of_retained_fragment(tmp_path):
+  first, second, target = tmp_path/'first.sqlite', tmp_path/'second.sqlite', tmp_path/'target.sqlite'
+  _, first_route = fixture(first)
+  _, second_route = fixture(second)
+  first_route['routeName'] = 'route-a'
+  second_route['routeName'] = 'route-b'
+  # Each reconstruction is valid in isolation and refers to the same original
+  # unnamed fragment. The retained replacement must win when histories merge.
+  import_routes(first, [first_route], tmp_path/'first-before.sqlite')
+  import_routes(second, [second_route], tmp_path/'second-before.sqlite')
+  initial, incoming = backup.export_statistics(first), backup.export_statistics(second)
+  backup.apply_restore(Params(), {}, {}, initial, target, tmp_path/'restore-first', lambda: None)
+  before = backup.export_statistics(target)
+  with pytest.raises(ValueError, match='(?i)supersed|replacement|retained'):
+    backup.apply_restore(Params(), {}, {}, incoming, target, tmp_path/'restore-second', lambda: None)
+  assert backup.export_statistics(target) == before
+  assert read_stats(target) == read_stats(first)

--- a/starpilot/system/the_galaxy/tests/test_backup_standalone.py
+++ b/starpilot/system/the_galaxy/tests/test_backup_standalone.py
@@ -1,0 +1,77 @@
+import copy
+import pytest
+from openpilot.starpilot.system.the_galaxy import backup
+
+class Params:
+  def __init__(self, values=None): self.values = copy.deepcopy(values or {})
+  def get(self, key): return self.values.get(key)
+  def put(self, key, value): self.values[key] = value
+  def remove(self, key): self.values.pop(key, None)
+
+PARKED = {'IsOnroad': False, 'IsOffroad': True, 'SafeMode': False}
+
+@pytest.mark.parametrize('change', [{'IsOnroad':True}, {'IsOffroad':False}, {'SafeMode':True}, {'SafeModeBackup':{}},
+  {'IsOnroad':None}, {'IsOffroad':None}, {'SafeMode':None}, {'SafeMode':0}, {'SafeMode':'invalid'}])
+def test_guard_fails_closed(change):
+  with pytest.raises(ValueError,match='confirmed parked'):
+    backup.require_parked(Params({**PARKED, **change}))
+
+def test_guard_accepts_explicit_live_flags_without_readers():
+  backup.require_parked(Params(PARKED))
+  backup.require_parked(Params({'IsOnroad':b'0','IsOffroad':b'1','SafeMode':b'0'}))
+
+def test_guard_rejects_read_failure():
+  class Broken:
+    def get(self,key): raise OSError('unavailable')
+  with pytest.raises(ValueError,match='confirmed parked'): backup.require_parked(Broken())
+
+def unavailable(): raise ValueError('Model statistics support is unavailable')
+
+def test_optional_provider_has_explicit_export_and_import_behavior(tmp_path,monkeypatch):
+  monkeypatch.setattr(backup,'_statistics_support',unavailable)
+  assert backup.export_statistics(tmp_path/'missing.sqlite') is None
+  assert backup.validate_statistics(None) is None
+  (tmp_path/'existing.sqlite').touch()
+  with pytest.raises(ValueError,match='unavailable'): backup.export_statistics(tmp_path/'existing.sqlite')
+  with pytest.raises(ValueError,match='unavailable'):
+    backup.validate_statistics({'schemaVersion':1,'drives':[],'metrics':[]})
+
+def test_settings_history_roundtrip_repeated_import_without_recorder(tmp_path,monkeypatch):
+  monkeypatch.setattr(backup,'_statistics_support',unavailable)
+  params=Params({'setting':False,'GalaxyDashboardStats':{'version':1,'routes':{'retained':{'duration':4}}}})
+  history={'GalaxyDashboardStats':{'version':1,'routes':{'imported':{'duration':2}}}}
+  for n in range(2):
+    result=backup.apply_restore(params,{'setting':True},history,None,tmp_path/'model.sqlite',tmp_path/f'r{n}',lambda:None)
+    assert result=={'restoredCount':1,'addedDrives':0,'existingDrives':0}
+    assert params.values['setting'] is True
+    assert set(params.values['GalaxyDashboardStats']['routes'])=={'retained','imported'}
+  assert not (tmp_path/'model.sqlite').exists()
+  assert (tmp_path/'r0/settings-before.json').exists()
+
+@pytest.mark.parametrize('stop_at',[1,2,3,4,5])
+def test_road_state_changes_abort_and_restore_previous_values(tmp_path,stop_at):
+  params=Params({'a':'before','b':12});calls=0
+  def parked():
+    nonlocal calls
+    calls+=1
+    if calls==stop_at: raise ValueError('moving')
+  with pytest.raises(ValueError,match='moving'):
+    backup.apply_restore(params,{'a':'after','b':99},{},None,tmp_path/'db',tmp_path/'recovery',parked)
+  assert params.values=={'a':'before','b':12}
+
+def test_silent_write_failure_rolls_back_all_settings(tmp_path):
+  class Silent(Params):
+    def put(self,key,value):
+      if key!='b':super().put(key,value)
+  params=Silent({'a':'before','b':12})
+  with pytest.raises(backup.RestoreError,match='verified'):
+    backup.apply_restore(params,{'a':'after','b':99},{},None,tmp_path/'db',tmp_path/'recovery',lambda:None)
+  assert params.values=={'a':'before','b':12}
+
+def test_statistics_import_without_provider_writes_nothing(tmp_path,monkeypatch):
+  monkeypatch.setattr(backup,'_statistics_support',unavailable)
+  params=Params({'a':'before'})
+  with pytest.raises(ValueError,match='unavailable'):
+    backup.apply_restore(params,{'a':'after'},{},{'schemaVersion':1,'drives':[],'metrics':[]},tmp_path/'db',tmp_path/'recovery',lambda:None)
+  assert params.values=={'a':'before'}
+  assert not list(tmp_path.iterdir())

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -1229,6 +1229,8 @@ def _dispatch_sentry_event(event: dict, *, bypass_rate_limit: bool = False) -> N
     except Exception:
       cloudlog.exception("Galaxy: ntfy notification failed")
 
+from openpilot.starpilot.system.the_galaxy import backup as galaxy_backup
+
 TOGGLE_BACKUP_FORMAT = "starpilot-toggle-backup"
 TOGGLE_BACKUP_VERSION = 1
 TOGGLE_BACKUP_MAX_ENCODED_BYTES = 2_000_000
@@ -10029,11 +10031,129 @@ def setup(app):
 
     return send_file(buffer, as_attachment=True, download_name="toggle_backup.json", mimetype="application/json")
 
+  @app.route("/api/backup", methods=["POST"])
+  def backup_complete_data():
+    toggle_values = {}
+    default_values = _get_static_default_param_values()
+    for key in sorted(_get_toggle_backup_keys() - set(galaxy_backup.HISTORY_KEYS) - {PERSONALITY_PROFILES_PARAM, "CustomPersonalities"}):
+      raw_value = _params_raw.get(key)
+      if raw_value is None:
+        raw_value = default_values.get(key)
+      if raw_value is None:
+        continue
+      value = _sanitize_json_value(raw_value)
+      if not isinstance(value, (str, int, float, bool, dict, list)):
+        value = str(value)
+
+      toggle_values[key] = value
+
+    with _PERSONALITY_PROFILES_WRITE_LOCK, _STATS_RESPONSE_LOCK:
+      history = {}
+      for key in galaxy_backup.HISTORY_KEYS:
+        value = _params_raw.get(key)
+        if value is not None:
+          history[key] = _coerce_toggle_restore_value(key, value)
+      try:
+        statistics = galaxy_backup.export_statistics("/data/starpilot/model_stats.sqlite")
+      except (ValueError, OSError) as error:
+        return jsonify({"message": str(error)}), 409
+      payload = {
+        "format": galaxy_backup.FORMAT, "version": galaxy_backup.VERSION,
+        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "settings": toggle_values,
+        "omittedSettings": [PERSONALITY_PROFILES_PARAM, "CustomPersonalities"],
+        "history": history,
+        "modelStatistics": statistics,
+      }
+      encoded = json.dumps(payload, allow_nan=False)
+      if len(encoded.encode()) > galaxy_backup.MAX_BYTES:
+        return jsonify({"message": "Backup exceeds the supported size; no incomplete backup was created."}), 413
+    return send_file(BytesIO(encoded.encode()), as_attachment=True,
+                     download_name="starpilot-backup.json", mimetype="application/json")
+
+  def _restore_complete_backup(data):
+    def parked():
+      galaxy_backup.require_parked(_params_live_raw)
+    try:
+      parked()
+      if type(data.get("version")) is not int or data["version"] != galaxy_backup.VERSION:
+        raise ValueError("This backup requires a compatible Galaxy version.")
+      galaxy_backup.json_document(data)
+      if len(json.dumps(data).encode()) > galaxy_backup.MAX_BYTES:
+        raise ValueError("Backup file is too large.")
+      if not isinstance(data.get("settings"), dict) or not isinstance(data.get("history"), dict):
+        raise ValueError("Backup settings or history are missing.")
+      allowed = _get_toggle_backup_keys() - set(galaxy_backup.HISTORY_KEYS) - {PERSONALITY_PROFILES_PARAM, "CustomPersonalities"}
+      settings = {}
+      skipped = 0
+      for saved_key, value in data["settings"].items():
+        key = LEGACY_STARPILOT_PARAM_RENAMES.get(saved_key, saved_key)
+        if key not in allowed:
+          skipped += 1
+          continue
+        value = _coerce_toggle_restore_value(key, value)
+        if key in PERSONALITY_ADVANCED_PARAM_KEYS:
+          value = validate_personality_advanced_value(value)
+        elif key in PERSONALITY_FOLLOW_PARAM_KEYS:
+          value = validate_personality_follow_value(value)
+        settings[key] = value
+      if data.get("personalityProfiles") is not None:
+        raise ValueError("Personality profile documents are not supported by this backup version.")
+      history = {}
+      for key, value in data['history'].items():
+        if key not in galaxy_backup.HISTORY_KEYS:
+          raise ValueError("Unknown history field in backup.")
+        history[key] = _coerce_toggle_restore_value(key, value)
+        if key in ('GalaxyDashboardStats', 'ModelDrivesAndScores', 'StarPilotStats', 'ApiCache_DriveStats') and not isinstance(history[key], dict):
+          raise ValueError('Invalid statistics document.')
+      dashboard = history.get('GalaxyDashboardStats', {})
+      if not isinstance(dashboard, dict) or dashboard.get('version', 1) != 1 or not isinstance(dashboard.get('routes', {}), dict):
+        raise ValueError("Invalid dashboard history.")
+      for name, entry in dashboard.get('routes', {}).items():
+        if not isinstance(name, str) or not isinstance(entry, dict):
+          raise ValueError('Invalid dashboard route.')
+        for field in ('distanceMeters', 'duration', 'engagedSeconds', 'distractedMoments', 'unresponsiveMoments', 'segmentCount'):
+          if field in entry and not galaxy_backup._number(entry[field]):
+            raise ValueError('Invalid dashboard route measurement.')
+      for field in ('attentionRecords', 'personalRecords', 'modelUsage'):
+        if not isinstance(dashboard.get(field, {}), dict):
+          raise ValueError("Invalid dashboard records.")
+      if not isinstance(dashboard.get('ignoredRoutes', []), list):
+        raise ValueError("Invalid ignored-route history.")
+      if 'modelStatistics' not in data:
+        raise ValueError('Model statistics field is missing; use null for settings/history-only backups.')
+      statistics = galaxy_backup.validate_statistics(data['modelStatistics'])
+      with _PERSONALITY_PROFILES_WRITE_LOCK, _STATS_RESPONSE_LOCK:
+        parked()
+        utilities.stop_dashboard_background_analysis()
+        recovery = Path('/data/starpilot/backups') / ('galaxy-restore-' + datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S-%f'))
+        result = galaxy_backup.apply_restore(_params_raw, settings, history, statistics,
+                                            '/data/starpilot/model_stats.sqlite', recovery, parked)
+        utilities._invalidate_dashboard_cache()
+        _STATS_RESPONSE_CACHE.update({'payload': None, 'updated_at': 0.0})
+      update_starpilot_toggles()
+      return jsonify({"success": True, **result, "skippedCount": skipped,
+                      "message": f"Restored settings and history. Added {result['addedDrives']} drives; existing drives were kept."})
+    except (ValueError, TypeError, KeyError, OverflowError) as error:
+      return jsonify({"success": False, "message": str(error)}), 400
+    except galaxy_backup.RestoreError as error:
+      app.logger.exception('Backup restore verification failed')
+      return jsonify({"success": False, "message": str(error)}), 500
+    except Exception:
+      app.logger.exception('Backup restore failed')
+      return jsonify({"success": False, "message": "Restore failed. Check diagnostics; a recovery copy is retained on the device."}), 500
+
+  @app.route("/api/restore", methods=["POST"])
   @app.route("/api/toggles/restore", methods=["POST"])
   def restore_toggle_values():
+    if request.content_length is not None and request.content_length > galaxy_backup.MAX_BYTES:
+      return jsonify({"message": "Backup file is too large."}), 413
     request_data = request.get_json(silent=True)
     if not isinstance(request_data, dict):
       return jsonify({"success": False, "message": "Invalid toggle backup file."}), 400
+
+    if request_data.get("format") == galaxy_backup.FORMAT:
+      return _restore_complete_backup(request_data)
 
     backup_format = request_data.get("format")
     if backup_format not in (None, TOGGLE_BACKUP_FORMAT):
@@ -10056,6 +10176,13 @@ def setup(app):
     if not isinstance(toggle_values, dict):
       return jsonify({"success": False, "message": "Toggle backup does not contain settings."}), 400
 
+    if request.path == "/api/restore":
+      return _restore_complete_backup({
+        "version": galaxy_backup.VERSION,
+        "settings": {key: value for key, value in toggle_values.items() if key not in galaxy_backup.HISTORY_KEYS},
+        "history": {key: value for key, value in toggle_values.items() if key in galaxy_backup.HISTORY_KEYS},
+        "modelStatistics": None,
+      })
     return _restore_toggle_values(toggle_values)
 
   def _restore_toggle_values(toggle_values, *, profile=None):


### PR DESCRIPTION
Instead of just backing up toggles, the backup feature now includes Disengagement/intervention data for each driving model. 

Exports use consistent SQLite reads. Restores validate the schema, values and history relationships, verify applied settings and retain recovery data for rollback. Compatible existing history is preserved, and restore remains restricted to a confirmed parked state throughout the operation.

Per-model statistics export and restore require the persistent model-statistics storage format.

Model-statistics export and restore use the compatible provider in #137. Settings/history-only operation works without it. Personality profile documents and their master switch are explicitly omitted and identified in the backup UI and file; older toggle backups remain supported. Validation: 35 standalone/API tests, 32 recorder-integration tests, seven legacy backup tests and three client tests passed. Browser/device validation remains outstanding.