### PR TITLE
Add per-profile Launch Boost controls to Galaxy

### DIFF
--- a/selfdrive/controls/lib/launch_boost.py
+++ b/selfdrive/controls/lib/launch_boost.py
@@ -1,0 +1,31 @@
+"""Shape only the extra model-trajectory launch request, before safety caps."""
+import math
+
+
+class LaunchBoost:
+  # Fraction of the difference between normal planning and the launch request.
+  FRACTIONS = {"low": 1.0 / 3.0, "medium": 2.0 / 3.0}
+  # Limit increases in the extra contribution, in m/s^3. Reductions are immediate
+  # so smoothing never holds acceleration above a newly reduced request.
+  RISE_RATES = {"low": 0.5, "medium": 1.0}
+
+  def __init__(self):
+    self.extra = 0.0
+
+  def update(self, target, launch_accel, level, allowed, dt):
+    if not allowed or launch_accel is None or level == "off":
+      self.extra = 0.0
+      return target
+    if not math.isfinite(target) or not math.isfinite(launch_accel):
+      self.extra = 0.0
+      return target
+    if level == "high":
+      # Exact legacy behaviour, including the existing vehicle/stop gates.
+      self.extra = 0.0
+      return max(target, launch_accel)
+    if level not in self.FRACTIONS or not math.isfinite(dt) or dt <= 0.0:
+      self.extra = 0.0
+      return target
+    requested_extra = max(0.0, launch_accel - target) * self.FRACTIONS[level]
+    self.extra = min(requested_extra, self.extra + self.RISE_RATES[level] * min(dt, 0.1))
+    return target + self.extra

--- a/selfdrive/controls/lib/longitudinal_planner.py
+++ b/selfdrive/controls/lib/longitudinal_planner.py
@@ -11,6 +11,8 @@ from openpilot.selfdrive.modeld.constants import ModelConstants
 from openpilot.starpilot.common.model_versions import is_tinygrad_model_version
 from openpilot.starpilot.controls.lib.starpilot_vcruise import FT_TO_M, OFFSET_FT_MAX, OFFSET_FT_MIN
 from openpilot.selfdrive.controls.lib.longcontrol import LongCtrlState
+from openpilot.selfdrive.controls.lib.launch_boost import LaunchBoost
+from openpilot.starpilot.common.longitudinal_personality_profiles import resolve_personality_launch_boost
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import LongitudinalMpc, get_safe_obstacle_distance
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import desired_follow_distance
 from openpilot.selfdrive.controls.lib.longitudinal_mpc_lib.long_mpc import should_trigger_planner_fcw
@@ -606,6 +608,7 @@ class LongitudinalPlanner:
     self.tracked_lead_catchup_headway_margins = get_tracked_lead_catchup_headway_margins(CP)
     self.far_follow_output_slew_active = False
     self.model_launch_armed = False
+    self.launch_boost = LaunchBoost()
     self.model_launch_stop_seen = False
     self.confident_lead_depart_elapsed = 0.0
     self.slow_creep_lead_depart_elapsed = 0.0
@@ -2823,8 +2826,18 @@ class LongitudinalPlanner:
         (not lead_present and (self.mode != 'acc' or self.model_launch_stop_seen))
       )
     )
-    if model_launch_allowed:
-      output_a_target = max(output_a_target, model_launch_accel)
+    launch_boost_level = resolve_personality_launch_boost(
+      starpilot_toggles, bool(getattr(sm['starpilotCarState'], 'trafficModeEnabled', False)), personality,
+    )
+    # Preserve High exactly; lower levels must not pre-charge their ramp while
+    # disengaged or while the driver is supplying acceleration.
+    launch_ramp_active = not reset_state and not bool(
+      getattr(sm['carState'], 'gasPressed', False) or getattr(sm['starpilotCarState'], 'accelPressed', False)
+    )
+    output_a_target = self.launch_boost.update(
+      output_a_target, model_launch_accel, launch_boost_level,
+      model_launch_allowed and (launch_boost_level == "high" or launch_ramp_active), self.dt,
+    )
 
     if depart_safety_veto or output_should_stop or bool(getattr(sm['starpilotPlan'], 'forcingStop', False)) or bool(getattr(sm['starpilotPlan'], 'redLight', False)):
       self.lead_depart_accel_hold_until = 0.0

--- a/selfdrive/controls/tests/test_launch_boost.py
+++ b/selfdrive/controls/tests/test_launch_boost.py
@@ -1,0 +1,51 @@
+import math
+import random
+import pytest
+from openpilot.selfdrive.controls.lib.launch_boost import LaunchBoost
+
+def test_off_retains_normal_acceleration_and_clears_previous_extra():
+  boost=LaunchBoost()
+  for _ in range(20):boost.update(0.2,1.5,"medium",True,0.05)
+  assert boost.update(0.2,1.5,"off",True,0.05)==0.2
+  assert boost.extra==0
+  assert boost.update(2.0,1.5,"off",True,0.05)==2.0
+
+def test_high_is_exact_legacy_max_for_varied_planner_targets():
+  rng=random.Random(71);boost=LaunchBoost()
+  for _ in range(1000):
+    target=rng.uniform(-3.5,3.5);launch=rng.uniform(0,1.5)
+    assert boost.update(target,launch,"high",True,0.05)==max(target,launch)
+    assert boost.update(target,launch,"high",False,0.05)==target
+
+@pytest.mark.parametrize("level,fraction,rate",[("low",1/3,0.5),("medium",2/3,1.0)])
+def test_extra_rises_gradually_and_only_scales_difference(level,fraction,rate):
+  boost=LaunchBoost();last=0
+  for _ in range(80):
+    target=boost.update(0.2,1.5,level,True,0.05)
+    assert 0<=boost.extra-last<=rate*0.05+1e-10
+    assert 0.2<=target<=1.5
+    last=boost.extra
+  assert target==pytest.approx(0.2+1.3*fraction)
+  assert boost.update(2.0,1.5,level,True,0.05)==2.0
+
+@pytest.mark.parametrize("level",["low","medium","high"])
+def test_lost_release_or_stop_veto_removes_boost_immediately(level):
+  boost=LaunchBoost()
+  for _ in range(80):boost.update(0.2,1.5,level,True,0.05)
+  assert boost.update(-1.0,1.5,level,False,0.05)==-1.0
+  assert boost.extra==0
+  assert boost.update(-0.5,None,level,True,0.05)==-0.5
+
+@pytest.mark.parametrize("level",["low","medium"])
+def test_reduced_request_and_speed_taper_never_retain_old_boost(level):
+  boost=LaunchBoost()
+  for _ in range(80):boost.update(0.2,1.5,level,True,0.05)
+  assert 0.2<=boost.update(0.2,0.3,level,True,0.05)<=0.3
+  assert boost.update(0.2,0.0,level,True,0.05)==0.2
+  assert boost.extra==0
+
+def test_unknown_level_or_invalid_prediction_never_adds_boost():
+  boost=LaunchBoost()
+  assert boost.update(0.2,1.5,"invalid",True,0.05)==0.2
+  assert boost.update(0.2,math.nan,"medium",True,0.05)==0.2
+  assert boost.update(0.2,1.5,"medium",True,math.inf)==0.2

--- a/selfdrive/controls/tests/test_personality_launch_planner.py
+++ b/selfdrive/controls/tests/test_personality_launch_planner.py
@@ -1,0 +1,96 @@
+import pytest
+from openpilot.selfdrive.controls.tests.test_longitudinal_planner import (
+  LongitudinalPlanner, LongCtrlState, make_sm, make_toggles, make_lead,
+  set_model_launch_trajectory, CarInterface, CAR,
+)
+from opendbc.car.tesla.interface import CarInterface as TeslaInterface
+from opendbc.car.tesla.values import CAR as TESLA
+from openpilot.starpilot.common.longitudinal_personality_profiles import (
+  default_personality_profiles, profile_document, update_personality_launch_boost,
+)
+
+def setup(level,experimental,vehicle="tesla",traffic=False,lead=True):
+  CP=(TeslaInterface.get_non_essential_params(TESLA.TESLA_MODEL_3) if vehicle=="tesla"
+      else CarInterface.get_non_essential_params(CAR.HONDA_CIVIC))
+  planner=LongitudinalPlanner(CP,init_v=0)
+  sm=make_sm(0,desired_accel=0.1,min_accel=-0.5,experimental_mode=experimental,tracking_lead=lead,
+             lead_one=make_lead(status=lead,d_rel=7,v_lead=1.5,a_lead=0.8,radar=False,model_prob=1))
+  sm["carState"].standstill=True
+  sm["controlsState"].longControlState=LongCtrlState.stopping
+  sm["selfdriveState"].personality=1
+  sm["starpilotCarState"].trafficModeEnabled=traffic
+  set_model_launch_trajectory(sm["modelV2"])
+  toggles=make_toggles("v16")
+  toggles.custom_personalities=True
+  profiles=update_personality_launch_boost(default_personality_profiles(False),"traffic" if traffic else "standard",level)
+  toggles.longitudinal_personality_profiles=profile_document(profiles,enabled=True)
+  return planner,sm,toggles
+
+@pytest.mark.parametrize("experimental",[False,True])
+@pytest.mark.parametrize("vehicle",["tesla","honda"])
+@pytest.mark.parametrize("traffic",[False,True])
+def test_personality_launch_levels_reach_real_planner_in_both_modes(experimental,vehicle,traffic):
+  outputs=[]
+  for level in ["off","low","medium","high"]:
+    planner,sm,toggles=setup(level,experimental,vehicle,traffic)
+    # Compare identical initial planner state. Repeated fixed-speed updates
+    # diverge through existing MPC feedback, so are not a level-order oracle.
+    planner.update(sm,toggles)
+    assert not planner.output_should_stop
+    outputs.append(planner.output_a_target)
+  assert outputs==sorted(outputs),outputs
+  assert outputs[0]<outputs[-1]-0.1,outputs
+  assert outputs[-1]>=0.8
+
+@pytest.mark.parametrize("level",["off","low","medium","high"])
+@pytest.mark.parametrize("veto",["brake","redLight","forcingStop","stopped_lead"])
+def test_personality_launch_never_retains_boost_after_stop_veto(level,veto):
+  planner,sm,toggles=setup(level,True)
+  for _ in range(20):planner.update(sm,toggles)
+  if veto=="brake":sm["carState"].brakePressed=True
+  elif veto=="stopped_lead":
+    sm["radarState"].leadOne=make_lead(status=True,d_rel=3.5,v_lead=0,a_lead=-0.8,radar=False,model_prob=1)
+  else:setattr(sm["starpilotPlan"],veto,True)
+  planner.update(sm,toggles)
+  assert planner.launch_boost.extra==0
+  if veto=="stopped_lead":
+    assert planner.output_should_stop
+    assert planner.output_a_target<=0
+
+def test_personality_launch_off_does_not_disable_no_lead_normal_acceleration():
+  planner,sm,toggles=setup("off",True,lead=False)
+  sm["modelV2"].action.desiredAcceleration=0.45
+  planner.update(sm,toggles)
+  assert planner.output_a_target>=0
+  assert planner.launch_boost.extra==0
+
+def test_personality_launch_live_selection_and_master_disable():
+  planner,sm,toggles=setup("medium",True)
+  for _ in range(10):planner.update(sm,toggles)
+  assert planner.launch_boost.extra>0
+  toggles.longitudinal_personality_profiles["profiles"]["standard"]["launchBoost"]="off"
+  planner.update(sm,toggles)
+  off=planner.output_a_target
+  assert planner.launch_boost.extra==0
+  toggles.custom_personalities=False
+  planner.update(sm,toggles)
+  assert planner.output_a_target>off
+
+
+@pytest.mark.parametrize("level",["low","medium"])
+@pytest.mark.parametrize("override",["off","gas","accel_button"])
+def test_personality_launch_ramp_does_not_precharge_during_override(level,override):
+  planner,sm,toggles=setup(level,True)
+  if override=="off":
+    sm["controlsState"].longControlState=LongCtrlState.off
+    sm["selfdriveState"].enabled=False
+  elif override=="gas":sm["carState"].gasPressed=True
+  else:sm["starpilotCarState"].accelPressed=True
+  for _ in range(20):planner.update(sm,toggles)
+  assert planner.launch_boost.extra==0
+  sm["controlsState"].longControlState=LongCtrlState.stopping
+  sm["selfdriveState"].enabled=True
+  sm["carState"].gasPressed=False
+  sm["starpilotCarState"].accelPressed=False
+  planner.update(sm,toggles)
+  assert planner.launch_boost.extra<=planner.launch_boost.RISE_RATES[level]*planner.dt+1e-9

--- a/starpilot/common/longitudinal_personality_profiles.py
+++ b/starpilot/common/longitudinal_personality_profiles.py
@@ -10,6 +10,8 @@ import numbers
 PERSONALITY_PROFILES_PARAM = "LongitudinalPersonalityProfiles"
 PROFILE_SCHEMA_VERSION = 2
 PERSONALITY_IDS = ("traffic", "aggressive", "standard", "relaxed")
+LAUNCH_BOOST_LEVELS = ("off", "low", "medium", "high")
+DEFAULT_LAUNCH_BOOST = "high"
 TRUCK_FINGERPRINT_TOKENS = (
   " RAM 1500 ",
   " RAM HD ",
@@ -301,9 +303,20 @@ def _strict_document(
   profiles = {}
   for personality in PERSONALITY_IDS:
     raw_profile = raw_profiles.get(personality)
-    if not isinstance(raw_profile, dict) or set(raw_profile) != set(_CATEGORY_SPECS):
+    if not isinstance(raw_profile, dict):
+      return None
+    # Optional v2 extension: legacy document normalisation stays unchanged.
+    # Only an explicit launch edit adds this field.
+    has_launch_boost = schema_version == PROFILE_SCHEMA_VERSION and "launchBoost" in raw_profile
+    expected_keys = set(_CATEGORY_SPECS) | ({"launchBoost"} if has_launch_boost else set())
+    if set(raw_profile) != expected_keys:
       return None
     profile = {}
+    if has_launch_boost:
+      level = raw_profile["launchBoost"]
+      if not isinstance(level, str) or level not in LAUNCH_BOOST_LEVELS:
+        return None
+      profile["launchBoost"] = level
     for category in _CATEGORY_SPECS:
       validated = _validated_category_with_length(
         category, raw_profile.get(category), category_lengths[category], curve_bounds, legacy_curve_bounds,
@@ -440,6 +453,35 @@ def update_personality_profile(
     return updated
   updated[personality][category] = validated
   return updated
+
+
+def update_personality_launch_boost(profiles, personality: str, level: str) -> dict[str, dict]:
+  if not isinstance(personality, str) or personality not in PERSONALITY_IDS:
+    raise ValueError("Unknown personality")
+  if not isinstance(level, str) or level not in LAUNCH_BOOST_LEVELS:
+    raise ValueError("Launch Boost must be off, low, medium or high")
+  canonical = strict_profile_document(profile_document(profiles, enabled=True))
+  if canonical is None:
+    raise ValueError("Stored personality profiles must be valid before editing Launch Boost")
+  updated = canonical["profiles"]
+  updated[personality]["launchBoost"] = level
+  return updated
+
+
+def personality_launch_boost_levels(profiles) -> dict[str, str]:
+  return {personality: profiles[personality].get("launchBoost", DEFAULT_LAUNCH_BOOST)
+          for personality in PERSONALITY_IDS}
+
+
+def resolve_personality_launch_boost(toggles, traffic_mode: bool, personality) -> str:
+  personality_id = active_personality_id(traffic_mode, personality)
+  if (personality_id is None or not getattr(toggles, "custom_personalities", False) or
+      not getattr(toggles, f"{personality_id}_personality_profile", True)):
+    return DEFAULT_LAUNCH_BOOST
+  profile = resolve_personality_profile(
+    getattr(toggles, "longitudinal_personality_profiles", {}), traffic_mode, personality,
+  )
+  return profile.get("launchBoost", DEFAULT_LAUNCH_BOOST) if profile is not None else DEFAULT_LAUNCH_BOOST
 
 
 def active_personality_id(traffic_mode: bool, personality) -> str | None:

--- a/starpilot/common/tests/test_personality_launch_boost.py
+++ b/starpilot/common/tests/test_personality_launch_boost.py
@@ -1,0 +1,70 @@
+import json
+from copy import deepcopy
+from types import SimpleNamespace
+import pytest
+from openpilot.starpilot.common.longitudinal_personality_profiles import (
+  LAUNCH_BOOST_LEVELS, PERSONALITY_IDS, default_personality_profiles, profile_document,
+  migrate_profile_document, strict_profile_document, update_personality_launch_boost,
+  update_personality_profile, resolve_personality_launch_boost, synchronise_profile_document_enabled,
+)
+
+def document():
+  return profile_document(default_personality_profiles(False), enabled=True)
+
+@pytest.mark.parametrize("personality", PERSONALITY_IDS)
+@pytest.mark.parametrize("level", LAUNCH_BOOST_LEVELS)
+def test_launch_round_trip_preserves_other_profiles_and_legacy_curves(personality, level):
+  original=document()
+  original["profiles"]["aggressive"]["acceleration"]={"preset":"custom","curve":[4.0]*10,"legacyCurve":[4.1]*7}
+  snapshot=deepcopy(original)
+  saved=deepcopy(original)
+  saved["profiles"]=update_personality_launch_boost(original["profiles"],personality,level)
+  assert original==snapshot
+  assert "launchBoost" not in original["profiles"][personality]
+  loaded=strict_profile_document(json.dumps(saved))
+  assert loaded["profiles"][personality].pop("launchBoost")==level
+  assert loaded==original
+
+def test_legacy_document_and_disabled_profile_keep_original_high():
+  doc=document()
+  assert migrate_profile_document(doc)==doc
+  toggles=SimpleNamespace(custom_personalities=True,longitudinal_personality_profiles=doc)
+  assert resolve_personality_launch_boost(toggles,False,1)=="high"
+  doc["profiles"]=update_personality_launch_boost(doc["profiles"],"standard","off")
+  assert resolve_personality_launch_boost(toggles,False,1)=="off"
+  toggles.standard_personality_profile=False
+  assert resolve_personality_launch_boost(toggles,False,1)=="high"
+  toggles.standard_personality_profile=True; toggles.custom_personalities=False
+  assert resolve_personality_launch_boost(toggles,False,1)=="high"
+  toggles.custom_personalities=True;doc["enabled"]=False
+  assert resolve_personality_launch_boost(toggles,False,1)=="high"
+
+def test_runtime_selects_each_personality_and_traffic_override():
+  doc=document()
+  for personality,level in zip(PERSONALITY_IDS,LAUNCH_BOOST_LEVELS):
+    doc["profiles"]=update_personality_launch_boost(doc["profiles"],personality,level)
+  toggles=SimpleNamespace(custom_personalities=True,longitudinal_personality_profiles=doc)
+  assert [resolve_personality_launch_boost(toggles,False,p) for p in range(3)]==["low","medium","high"]
+  assert resolve_personality_launch_boost(toggles,True,1)=="off"
+  assert resolve_personality_launch_boost(toggles,False,True)=="high"
+
+@pytest.mark.parametrize("level", [None,True,1,{},[],"LOW","sport"])
+def test_invalid_level_is_rejected_without_overwriting_profiles(level):
+  doc=document()
+  with pytest.raises(ValueError):update_personality_launch_boost(doc["profiles"],"standard",level)
+  doc["profiles"]["standard"]["launchBoost"]=level
+  assert strict_profile_document(doc) is None
+
+def test_curve_edit_and_master_switch_preserve_launch_selection():
+  doc=document()
+  doc["profiles"]=update_personality_launch_boost(doc["profiles"],"standard","low")
+  doc["profiles"]=update_personality_profile(doc["profiles"],"standard","braking","eco",[],False)
+  assert synchronise_profile_document_enabled(doc,False,False)["profiles"]["standard"]["launchBoost"]=="low"
+
+
+def test_launch_setting_preserves_dom_defaults():
+  original = document()
+  saved = update_personality_launch_boost(original["profiles"], "standard", "low")
+  for personality in PERSONALITY_IDS:
+    for category in ("acceleration", "braking", "following"):
+      assert saved[personality][category] == {"preset": "dom_default", "curve": []}

--- a/starpilot/system/the_galaxy/assets/mobile/js/api.js
+++ b/starpilot/system/the_galaxy/assets/mobile/js/api.js
@@ -54,6 +54,7 @@ export const api = {
 
   getPersonalityProfiles() { return request("/api/personality_profiles", { cache: "no-store" }) },
   savePersonalityProfile(data) { return request("/api/personality_profiles", { method: "PUT", data }) },
+  savePersonalityLaunchBoost(data) { return request("/api/personality_profiles/launch_boost", { method: "PUT", data }) },
   migratePersonalityProfiles() { return request("/api/personality_profiles/migrate", { method: "POST" }) },
 
   getParams() { return request("/api/params/all") },

--- a/starpilot/system/the_galaxy/assets/mobile/js/components/PersonalityProfiles.js
+++ b/starpilot/system/the_galaxy/assets/mobile/js/components/PersonalityProfiles.js
@@ -74,6 +74,11 @@ export const PersonalityProfiles = {
           throw new Error("Profile data is unavailable or malformed. Retrying automatically…")
         }
       }
+      if (data?.launch_boost_options !== undefined && (
+          !Array.isArray(data.launch_boost_options) || data.launch_boost_options.join(",") !== "off,low,medium,high" ||
+          PROFILES.some(profile => !data.launch_boost_options.includes(data.launch_boost?.[profile])))) {
+        throw new Error("Launch Boost settings are unavailable. Retrying automatically…")
+      }
       return data
     },
     acceptData(data) {
@@ -148,6 +153,11 @@ export const PersonalityProfiles = {
       const value = event.target.checked
       event.target.checked = this.enabled(this.values[key])
       return this.write(() => api.updateParam({ key, value }), () => !this.paramLocked(key))
+    },
+    async launchBoost(profile, level) {
+      const expected = this.data.launch_boost?.[profile]
+      if (expected === level || !this.data.launch_boost_options?.includes(level)) return
+      return this.write(() => api.savePersonalityLaunchBoost({ profile, level, expected }))
     },
     async preset(profile, category, preset) {
       if (this.data.profiles[profile][category].preset === preset) return
@@ -296,6 +306,15 @@ export const PersonalityProfiles = {
               </section>
               <details class="gx-personalities__advanced" :open="advancedOpen[profile]" @toggle="advancedOpen[profile] = $event.target.open">
                 <summary>Advanced</summary>
+                <section v-if="data.launch_boost_options" class="gx-personalities__category">
+                  <h4>Launch Boost</h4>
+                  <div class="gx-personalities__options" role="group" :aria-label="label(profile) + ' Launch Boost'">
+                    <button v-for="level in data.launch_boost_options" :key="level" type="button" class="gx-btn gx-btn--tonal"
+                      :aria-pressed="data.launch_boost[profile] === level" :disabled="editingLocked"
+                      @click="launchBoost(profile, level)">{{ label(level) }}</button>
+                  </div>
+                  <p>Extra acceleration when starting from a stop.</p>
+                </section>
                 <template v-for="(title, category) in CATEGORIES" :key="category">
                 <details v-if="data.profiles[profile][category].preset === 'custom'" open class="gx-personalities__curve">
                   <summary>Custom {{ title.toLowerCase() }} graph</summary>

--- a/starpilot/system/the_galaxy/tests/test_launch_boost_api.py
+++ b/starpilot/system/the_galaxy/tests/test_launch_boost_api.py
@@ -1,0 +1,83 @@
+import json
+from copy import deepcopy
+import pytest
+from test_personality_profiles_api import _client, the_galaxy
+from openpilot.starpilot.common.longitudinal_personality_profiles import (
+  PERSONALITY_IDS, LAUNCH_BOOST_LEVELS, PERSONALITY_PROFILES_PARAM,
+  default_personality_profiles, profile_document, strict_profile_document,
+)
+URL="/api/personality_profiles/launch_boost"
+
+@pytest.mark.parametrize("profile", PERSONALITY_IDS)
+@pytest.mark.parametrize("level", LAUNCH_BOOST_LEVELS)
+def test_save_readback_and_reload_each_personality_level(monkeypatch,profile,level):
+  client,params=_client(monkeypatch,{"CustomPersonalities":True})
+  before=client.get("/api/personality_profiles").get_json()
+  assert before["launch_boost"]==dict.fromkeys(PERSONALITY_IDS,"high")
+  response=client.put(URL,json={"profile":profile,"level":level,"expected":"high"})
+  assert response.status_code==200,response.get_json()
+  saved=client.get("/api/personality_profiles").get_json()
+  assert saved["launch_boost"][profile]==level
+  profiles=deepcopy(saved["profiles"]);assert profiles[profile].pop("launchBoost")==level
+  assert profiles==before["profiles"]
+  assert strict_profile_document(params.values[PERSONALITY_PROFILES_PARAM])["profiles"]==saved["profiles"]
+
+def test_stale_launch_edit_rejected_but_unrelated_curve_edit_is_preserved(monkeypatch):
+  client,params=_client(monkeypatch,{"CustomPersonalities":True})
+  assert client.put(URL,json={"profile":"standard","level":"low","expected":"high"}).status_code==200
+  assert client.put(URL,json={"profile":"standard","level":"off","expected":"high"}).status_code==409
+  current=client.get("/api/personality_profiles").get_json()
+  assert client.put("/api/personality_profiles",json={"profile":"standard","category":"braking","preset":"eco","curve":[],"expected":current["profiles"]["standard"]["braking"]}).status_code==200
+  assert client.put(URL,json={"profile":"standard","level":"medium","expected":"low"}).status_code==200
+  saved=client.get("/api/personality_profiles").get_json()
+  assert saved["profiles"]["standard"]["braking"]["preset"]=="eco"
+  assert saved["launch_boost"]["standard"]=="medium"
+  assert client.put("/api/personality_profiles",json={"profile":"standard","category":"launchBoost","preset":"off","curve":[]}).status_code==400
+
+@pytest.mark.parametrize("state",[{"IsOffroad":None},{"IsOnroad":True,"IsOffroad":True},{"IsOnroad":False,"IsOffroad":False}])
+def test_unknown_or_onroad_state_rejects_without_writes(monkeypatch,state):
+  client,params=_client(monkeypatch,state)
+  assert client.put(URL,json={"profile":"standard","level":"off","expected":"high"}).status_code==403
+  assert params.writes==[]
+
+@pytest.mark.parametrize("payload",[{},None,{"profile":[],"level":"off","expected":"high"},{"profile":"standard","level":False,"expected":"high"},{"profile":"standard","level":"off","expected":True},{"profile":"standard","level":"off","expected":"high","extra":1}])
+def test_malformed_payload_rejected(monkeypatch,payload):
+  client,params=_client(monkeypatch)
+  assert client.put(URL,json=payload).status_code==400
+  assert params.writes==[]
+
+def test_onroad_edit_uses_existing_personality_authoring_policy(monkeypatch):
+  client,params=_client(monkeypatch,{"IsOnroad":True})
+  assert client.put(URL,json={"profile":"traffic","level":"low","expected":"high"}).status_code==403
+  assert params.writes == []
+
+def test_failed_persistence_is_not_reported_as_saved(monkeypatch):
+  client,params=_client(monkeypatch)
+  monkeypatch.setattr(params,"put",lambda *args:None)
+  assert client.put(URL,json={"profile":"standard","level":"off","expected":"high"}).status_code==500
+
+def test_corrupt_document_not_overwritten(monkeypatch):
+  client,params=_client(monkeypatch,{PERSONALITY_PROFILES_PARAM:'{"schemaVersion":99}'})
+  assert client.put(URL,json={"profile":"standard","level":"off","expected":"high"}).status_code==409
+  assert params.writes==[]
+
+def test_road_state_rechecked_after_writer_lock(monkeypatch):
+  client,params=_client(monkeypatch)
+  class ChangeState:
+    def __enter__(self):params.values["IsOnroad"]=True
+    def __exit__(self,*args):pass
+  monkeypatch.setattr(the_galaxy,"_PERSONALITY_PROFILES_WRITE_LOCK",ChangeState())
+  assert client.put(URL,json={"profile":"standard","level":"off","expected":"high"}).status_code==403
+  assert params.writes==[]
+
+
+@pytest.mark.parametrize("extra", [{"preset": "custom"}, {"preset": "off", "expected": "low"}])
+def test_launch_field_cannot_be_edited_as_a_curve_category(monkeypatch, extra):
+  client, params = _client(monkeypatch)
+  assert client.put(URL, json={"profile": "standard", "level": "low", "expected": "high"}).status_code == 200
+  before = deepcopy(params.values)
+  response = client.put("/api/personality_profiles", json={
+    "profile": "standard", "category": "launchBoost", "curve": [], **extra,
+  })
+  assert response.status_code == 400
+  assert params.values == before

--- a/starpilot/system/the_galaxy/the_galaxy.py
+++ b/starpilot/system/the_galaxy/the_galaxy.py
@@ -138,6 +138,8 @@ from openpilot.starpilot.common.longitudinal_personality_profiles import (
   CURVE_BOUNDS,
   FOLLOWING_PRESETS,
   FOLLOWING_SPEEDS_MPH,
+  LAUNCH_BOOST_LEVELS,
+  PERSONALITY_IDS,
   PERSONALITY_PROFILES_PARAM,
   PERSONALITY_ADVANCED_PARAM_KEYS,
   PERSONALITY_FOLLOW_PARAM_KEYS,
@@ -150,10 +152,12 @@ from openpilot.starpilot.common.longitudinal_personality_profiles import (
   is_truck_fingerprint,
   migrate_profile_document,
   personality_reference_curves,
+  personality_launch_boost_levels,
   profile_document,
   strict_profile_document,
   synchronise_profile_document_enabled,
   update_personality_profile,
+  update_personality_launch_boost,
   validate_personality_advanced_value,
   validate_personality_follow_value,
 )
@@ -5875,6 +5879,36 @@ def setup(app):
       "schema_version": PROFILE_SCHEMA_VERSION,
     }), 200
 
+  @app.route("/api/personality_profiles/launch_boost", methods=["PUT"])
+  @_serialize_personality_profile_writes
+  def personality_launch_boost():
+    if _personality_settings_write_locked():
+      return jsonify({"error": "Longitudinal personality profiles can only be changed while off-road."}), 403
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict) or set(data) != {"profile", "level", "expected"}:
+      return jsonify({"error": "Expected profile, level and expected Launch Boost setting."}), 400
+    if (not isinstance(data["profile"], str) or data["profile"] not in PERSONALITY_IDS or
+        not isinstance(data["level"], str) or data["level"] not in LAUNCH_BOOST_LEVELS or
+        not isinstance(data["expected"], str) or data["expected"] not in LAUNCH_BOOST_LEVELS):
+      return jsonify({"error": "Invalid personality or Launch Boost setting."}), 400
+    raw = _safe_params_get_live_raw(PERSONALITY_PROFILES_PARAM)
+    document = strict_profile_document(raw)
+    if document is None and not is_unconfigured_profile_document(raw):
+      return jsonify({"error": "Stored profiles need migration or repair before editing Launch Boost."}), 409
+    profiles = document["profiles"] if document is not None else default_personality_profiles(False)
+    current = personality_launch_boost_levels(profiles)[data["profile"]]
+    if data["expected"] != current:
+      return jsonify({"error": "Saved Launch Boost changed. Reload and review it before editing again."}), 409
+    profiles = update_personality_launch_boost(profiles, data["profile"], data["level"])
+    candidate = profile_document(profiles, enabled=params.get_bool("CustomPersonalities"))
+    if _personality_settings_write_locked():
+      return jsonify({"error": "Personality editing became unavailable. Refresh before retrying."}), 403
+    params.put(PERSONALITY_PROFILES_PARAM, candidate)
+    update_starpilot_toggles()
+    if strict_profile_document(_safe_params_get_live_raw(PERSONALITY_PROFILES_PARAM)) != candidate:
+      return jsonify({"error": "Launch Boost save could not be verified. Refresh before retrying."}), 500
+    return jsonify({"launch_boost": personality_launch_boost_levels(profiles)}), 200
+
   @app.route("/api/personality_profiles", methods=["GET", "PUT"])
   @_serialize_personality_profile_writes
   def personality_profiles():
@@ -5901,6 +5935,8 @@ def setup(app):
         return jsonify({"error": "Expected profile, category, preset, curve, and optional expected category."}), 400
 
       try:
+        if data["category"] not in ("acceleration", "braking", "following"):
+          raise ValueError("Unknown profile category")
         current_config = profiles[data["profile"]][data["category"]]
         if "expected" in data and (data["expected"] != current_config or any(
           isinstance(value, bool) for key in ("curve", "legacyCurve") for value in data["expected"].get(key, [])
@@ -5958,6 +5994,8 @@ def setup(app):
         "following": list(FOLLOWING_PRESETS),
       },
       "profiles": profiles,
+      "launch_boost": personality_launch_boost_levels(profiles),
+      "launch_boost_options": list(LAUNCH_BOOST_LEVELS),
       "reference_curves": personality_reference_curves(ev_tuning, truck_tuning),
       "schema_version": PROFILE_SCHEMA_VERSION,
       "speed_breakpoints_mph": {


### PR DESCRIPTION
I find that the launch boost is no longer needed with eGPU models as they react so quickly and it causes an uncomfortable jolt when starting from a stop, it also causes acceleration thats too aggressive when in stop start traffic.

- Add Off/Low/Medium/High under Advanced for Traffic, Aggressive, Standard and Relaxed profiles.
- Keep High/default equivalent to Dom. Low and Medium scale and ramp only the extra model-launch request; Off disables that contribution.
- Retain Dom's launch eligibility and downstream controls, with no additional lead eligibility gate.
